### PR TITLE
fix: always track the current camera for live and snap buttons

### DIFF
--- a/src/pymmcore_widgets/live_button_widget.py
+++ b/src/pymmcore_widgets/live_button_widget.py
@@ -28,8 +28,6 @@ class LiveButton(QPushButton):
 
     Parameters
     ----------
-    camera:
-        Camera device. If 'None' -> getCameraDevice()
     button_text_on_off : Optional[tuple[str, str]]
         Text of the QPushButton in the on and off state.
     icon_size : Optional[int]
@@ -40,7 +38,6 @@ class LiveButton(QPushButton):
 
     def __init__(
         self,
-        camera: Optional[str] = None,
         button_text_on_off: Tuple[str, str] = ("", ""),
         icon_size: int = 30,
         icon_color_on_off: Tuple[COLOR_TYPE, COLOR_TYPE] = ("", ""),
@@ -51,7 +48,7 @@ class LiveButton(QPushButton):
         super().__init__()
 
         self._mmc = mmcore or get_core_singleton()
-        self._camera = camera or self._mmc.getCameraDevice()
+        self._camera = self._mmc.getCameraDevice()
         self.button_text_on = button_text_on_off[0]
         self.button_text_off = button_text_on_off[1]
         self.icon_size = icon_size
@@ -82,8 +79,7 @@ class LiveButton(QPushButton):
         self.clicked.connect(self._toggle_live_mode)
 
     def _on_system_cfg_loaded(self) -> None:
-        if not self._camera:
-            self._camera = self._mmc.getCameraDevice()
+        self._camera = self._mmc.getCameraDevice()
         self.setEnabled(bool(self._camera))
 
     def _toggle_live_mode(self) -> None:

--- a/src/pymmcore_widgets/snap_button_widget.py
+++ b/src/pymmcore_widgets/snap_button_widget.py
@@ -28,8 +28,6 @@ class SnapButton(QPushButton):
 
     Parameters
     ----------
-    camera:
-        Camera device. If 'None' -> getCameraDevice()
     button_text : Optional[str]
         Text of the QPushButton.
     icon_size : Optional[int]
@@ -40,7 +38,6 @@ class SnapButton(QPushButton):
 
     def __init__(
         self,
-        camera: Optional[str] = None,
         button_text: Optional[str] = None,
         icon_size: Optional[int] = 30,
         icon_color: Optional[COLOR_TYPES] = "",
@@ -53,7 +50,7 @@ class SnapButton(QPushButton):
         self.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
 
         self._mmc = mmcore or get_core_singleton()
-        self._camera = camera or self._mmc.getCameraDevice()
+        self._camera = self._mmc.getCameraDevice()
         self.button_text = button_text
         self.icon_size = icon_size
         self.icon_color = icon_color
@@ -85,8 +82,7 @@ class SnapButton(QPushButton):
         create_worker(self._mmc.snap, _start_thread=True)
 
     def _on_system_cfg_loaded(self) -> None:
-        if not self._camera:
-            self._camera = self._mmc.getCameraDevice()
+        self._camera = self._mmc.getCameraDevice()
         self.setEnabled(bool(self._camera))
 
     def _disconnect(self) -> None:


### PR DESCRIPTION
Previously if you accidentally loaded the demo config before loading a real one then the `snap` button would fail because `self._camera` was not being updated. This does remove the ability to pass in a user chosen camera, but I don't think that that's very useful because both `snap` and `startContinuousSequenceAcquisition` don't actually take camera arguments.