### PR TITLE
feat/test: move SNAP button style __init__ args to properties + fix test

### DIFF
--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -4,7 +4,7 @@ from fonticon_mdi6 import MDI6
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QPushButton, QSizePolicy
+from qtpy.QtWidgets import QPushButton, QSizePolicy, QWidget
 from superqt.fonticon import icon
 from superqt.utils import create_worker
 
@@ -26,34 +26,35 @@ class SnapButton(QPushButton):
     Once the button is clicked, an image is acquired and the pymmcore-plus
     'imageSnapped(image: nparray)' signal is emitted.
 
-    Parameters
+    Properties
     ----------
-    button_text : Optional[str]
+    button_text: str
         Text of the QPushButton.
-    icon_size : Optional[int]
+        Default = "Snap".
+    icon_size: int
         Size of the QPushButton icon.
-    icon_color : Optional[COLOR_TYPE]
+        Default = 30.
+    icon_color: COLOR_TYPE
        Color of the QPushButton icon in the on and off state.
+       Default = (0, 255, 0)
     """
 
     def __init__(
         self,
-        button_text: Optional[str] = None,
-        icon_size: Optional[int] = 30,
-        icon_color: Optional[COLOR_TYPES] = "",
         *,
+        parent: Optional[QWidget] = None,
         mmcore: Optional[CMMCorePlus] = None,
     ) -> None:
 
-        super().__init__()
+        super().__init__(parent)
 
         self.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
 
         self._mmc = mmcore or get_core_singleton()
         self._camera = self._mmc.getCameraDevice()
-        self.button_text = button_text
-        self.icon_size = icon_size
-        self.icon_color = icon_color
+        self._button_text: str = "Snap"
+        self._icon_size: int = 30
+        self._icon_color: COLOR_TYPES = (0, 255, 0)
 
         self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)
         self._on_system_cfg_loaded()
@@ -65,11 +66,40 @@ class SnapButton(QPushButton):
         if len(self._mmc.getLoadedDevices()) > 1:
             self.setEnabled(True)
 
+    @property
+    def button_text(self) -> str:
+        """Set the text of the snap button."""
+        return self._button_text
+
+    @button_text.setter
+    def button_text(self, text: str) -> None:
+        self.setText(text)
+        self._button_text = text
+
+    @property
+    def icon_size(self) -> int:
+        """Set the snap button icon size."""
+        return self._icon_size
+
+    @icon_size.setter
+    def icon_size(self, size: int) -> None:
+        self.setIconSize(QSize(size, size))
+        self._icon_size = size
+
+    @property
+    def icon_color(self) -> COLOR_TYPES:
+        """Set the snap button icon color."""
+        return self._icon_color
+
+    @icon_color.setter
+    def icon_color(self, color: COLOR_TYPES) -> None:
+        self.setIcon(icon(MDI6.camera_outline, color=color))
+        self._icon_color = color
+
     def _create_button(self) -> None:
-        if self.button_text:
-            self.setText(self.button_text)
-        self.setIcon(icon(MDI6.camera_outline, color=self.icon_color))
-        self.setIconSize(QSize(self.icon_size, self.icon_size))
+        self.setText(self._button_text)
+        self.setIcon(icon(MDI6.camera_outline, color=self._icon_color))
+        self.setIconSize(QSize(self._icon_size, self._icon_size))
         self.clicked.connect(self._snap)
 
     def _snap(self) -> None:

--- a/tests/test_snap_button_widget.py
+++ b/tests/test_snap_button_widget.py
@@ -29,3 +29,10 @@ def test_snap_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     ):
         snap_btn.click()
         assert not global_mmcore.isSequenceRunning()
+
+    snap_btn.icon_size = 50
+    assert snap_btn._icon_size == 50
+    snap_btn.icon_color = "Red"
+    assert snap_btn._icon_color == "Red"
+    snap_btn.button_text = "SNAP"
+    assert snap_btn.text() == "SNAP"

--- a/tests/test_snap_button_widget.py
+++ b/tests/test_snap_button_widget.py
@@ -11,17 +11,13 @@ if TYPE_CHECKING:
 
 def test_snap_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
-    snap_btn = SnapButton(
-        button_text="Snap",
-        icon_size=40,
-        icon_color="green",
-    )
+    snap_btn = SnapButton()
 
     qtbot.addWidget(snap_btn)
 
     assert snap_btn.text() == "Snap"
-    assert snap_btn.icon_size == 40
-    assert snap_btn.icon_color == "green"
+    assert snap_btn.icon_size == 30
+    assert snap_btn.icon_color == (0, 255, 0)
 
     global_mmcore.startContinuousSequenceAcquisition(0)
 


### PR DESCRIPTION
This PR removes style `args` in the `__init__` method  for the `snap button` and sets them as properties + tests update.