### PR TITLE
fix: move LIVE button __init__ args to properties + update test

### DIFF
--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -50,7 +50,7 @@ class LiveButton(QPushButton):
         super().__init__(parent)
 
         self._mmc = mmcore or CMMCorePlus.instance()
-        
+
         self._camera = self._mmc.getCameraDevice()
 
         self._button_text_on: str = "Live"

--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -23,21 +23,6 @@ class LiveButton(QPushButton):
     When pressed, a 'ContinuousSequenceAcquisition' is started or stopped
     and a pymmcore-plus signal 'startContinuousSequenceAcquisition' or
     'stopSequenceAcquisition' is emitted.
-
-    Properties
-    ----------
-    button_text_on : str
-        Text of the QPushButton in the on state.
-        Default = "Live".
-    button_text_off : str
-        Text of the QPushButton in the off state.
-        Default = "Stop".
-    icon_color_on : COLOR_TYPE
-       Color of the QPushButton icon in the on state.
-       Default = (0. 255, 0).
-    icon_color_off : COLOR_TYPE
-       Color of the QPushButton icon in the off state.
-       Default = "magenta".
     """
 
     def __init__(
@@ -76,7 +61,11 @@ class LiveButton(QPushButton):
 
     @property
     def button_text_on(self) -> str:
-        """Set the live button text for when live mode is on."""
+        """
+        Set the live button text for when live mode is on.
+
+        Default = "Live."
+        """
         return self._button_text_on
 
     @button_text_on.setter
@@ -87,7 +76,11 @@ class LiveButton(QPushButton):
 
     @property
     def button_text_off(self) -> str:
-        """Set the live button text for when live mode is off."""
+        """
+        Set the live button text for when live mode is off.
+
+        Default = "Stop."
+        """
         return self._button_text_off
 
     @button_text_off.setter
@@ -98,7 +91,11 @@ class LiveButton(QPushButton):
 
     @property
     def icon_color_on(self) -> COLOR_TYPE:
-        """Set the live button color for when live mode is on."""
+        """
+        Set the live button color for when live mode is on.
+
+        Default = (0. 255, 0).
+        """
         return self._icon_color_on
 
     @icon_color_on.setter
@@ -109,7 +106,11 @@ class LiveButton(QPushButton):
 
     @property
     def icon_color_off(self) -> COLOR_TYPE:
-        """Set the live button color for when live mode is off."""
+        """
+        Set the live button color for when live mode is off.
+
+        Default = "magenta".
+        """
         return self._icon_color_off
 
     @icon_color_off.setter

--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -35,9 +35,6 @@ class LiveButton(QPushButton):
         super().__init__(parent)
 
         self._mmc = mmcore or CMMCorePlus.instance()
-
-        self._camera = self._mmc.getCameraDevice()
-
         self._button_text_on: str = "Live"
         self._button_text_off: str = "Stop"
         self._icon_color_on: COLOR_TYPE = (0, 255, 0)
@@ -70,7 +67,7 @@ class LiveButton(QPushButton):
 
     @button_text_on.setter
     def button_text_on(self, text: str) -> None:
-        if not self._mmc.isSequenceRunning(self._camera):
+        if not self._mmc.isSequenceRunning():
             self.setText(text)
         self._button_text_on = text
 
@@ -85,7 +82,7 @@ class LiveButton(QPushButton):
 
     @button_text_off.setter
     def button_text_off(self, text: str) -> None:
-        if self._mmc.isSequenceRunning(self._camera):
+        if self._mmc.isSequenceRunning():
             self.setText(text)
         self._button_text_off = text
 
@@ -100,7 +97,7 @@ class LiveButton(QPushButton):
 
     @icon_color_on.setter
     def icon_color_on(self, color: COLOR_TYPE) -> None:
-        if not self._mmc.isSequenceRunning(self._camera):
+        if not self._mmc.isSequenceRunning():
             self.setIcon(icon(MDI6.video_outline, color=color))
         self._icon_color_on = color
 
@@ -115,7 +112,7 @@ class LiveButton(QPushButton):
 
     @icon_color_off.setter
     def icon_color_off(self, color: COLOR_TYPE) -> None:
-        if self._mmc.isSequenceRunning(self._camera):
+        if self._mmc.isSequenceRunning():
             self.setIcon(icon(MDI6.video_off_outline, color=color))
         self._icon_color_off = color
 

--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -26,7 +26,7 @@ class LiveButton(QPushButton):
     and a pymmcore-plus signal 'startContinuousSequenceAcquisition' or
     'stopSequenceAcquisition' is emitted.
 
-    Parameters
+    Properties
     ----------
     button_text_on : str
         Text of the QPushButton in the on state.
@@ -40,8 +40,6 @@ class LiveButton(QPushButton):
     icon_color_off : COLOR_TYPE
        Color of the QPushButton icon in the off state.
        Default = "magenta".
-    icon_size : Optional[int]
-        Size of the QPushButton icon.
     """
 
     def __init__(
@@ -58,7 +56,6 @@ class LiveButton(QPushButton):
 
         self._button_text_on: str = "Live"
         self._button_text_off: str = "Stop"
-        self._icon_size: int = 30
         self._icon_color_on: COLOR_TYPE = (0, 255, 0)
         self._icon_color_off: COLOR_TYPE = "magenta"
 
@@ -122,21 +119,11 @@ class LiveButton(QPushButton):
             self.setIcon(icon(MDI6.video_off_outline, color=color))
         self._icon_color_off = color
 
-    @property
-    def icon_size(self) -> int:
-        """Set the snap button icon size."""
-        return self._icon_size
-
-    @icon_size.setter
-    def icon_size(self, size: int) -> None:
-        self.setIconSize(QSize(size, size))
-        self._icon_size = size
-
     def _create_button(self) -> None:
         if self._button_text_on:
             self.setText(self._button_text_on)
         self._set_icon_state(False)
-        self.setIconSize(QSize(self._icon_size, self._icon_size))
+        self.setIconSize(QSize(30, 30))
         self.clicked.connect(self._toggle_live_mode)
 
     def _on_system_cfg_loaded(self) -> None:

--- a/tests/test_live_button.py
+++ b/tests/test_live_button.py
@@ -11,17 +11,13 @@ if TYPE_CHECKING:
 
 def test_live_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
-    live_btn = LiveButton(
-        button_text_on_off=("Live", "Stop"),
-        icon_size=40,
-        icon_color_on_off=("green", "magenta"),
-    )
+    live_btn = LiveButton()
 
     qtbot.addWidget(live_btn)
 
     assert live_btn.text() == "Live"
-    assert live_btn.icon_size == 40
-    assert live_btn.icon_color_on == "green"
+    assert live_btn.icon_size == 30
+    assert live_btn.icon_color_on == (0, 255, 0)
     assert live_btn.icon_color_off == "magenta"
 
     # test from direct mmcore signals
@@ -44,3 +40,17 @@ def test_live_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
         live_btn.click()
     assert not global_mmcore.isSequenceRunning()
     assert live_btn.text() == "Live"
+
+    live_btn.icon_size = 50
+    assert live_btn._icon_size == 50
+    live_btn.icon_color_on = "Red"
+    assert live_btn._icon_color_on == "Red"
+    live_btn.icon_color_off = "Green"
+    assert live_btn._icon_color_off == "Green"
+    live_btn.button_text_on = "LIVE"
+    assert live_btn.text() == "LIVE"
+    live_btn.button_text_off = "STOP"
+    global_mmcore.startContinuousSequenceAcquisition(0)
+    assert live_btn.text() == "STOP"
+    global_mmcore.stopSequenceAcquisition()
+    assert live_btn.text() == "LIVE"

--- a/tests/test_live_button.py
+++ b/tests/test_live_button.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qtpy.QtCore import QSize
+
 from pymmcore_widgets._live_button_widget import LiveButton
 
 if TYPE_CHECKING:
@@ -16,7 +18,7 @@ def test_live_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     qtbot.addWidget(live_btn)
 
     assert live_btn.text() == "Live"
-    assert live_btn.icon_size == 30
+    assert live_btn.iconSize() == QSize(30, 30)
     assert live_btn.icon_color_on == (0, 255, 0)
     assert live_btn.icon_color_off == "magenta"
 
@@ -41,8 +43,6 @@ def test_live_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert not global_mmcore.isSequenceRunning()
     assert live_btn.text() == "Live"
 
-    live_btn.icon_size = 50
-    assert live_btn._icon_size == 50
     live_btn.icon_color_on = "Red"
     assert live_btn._icon_color_on == "Red"
     live_btn.icon_color_off = "Green"


### PR DESCRIPTION
This PR removes style `args` in the `__init__` method for the `live button` and sets them as `properties` + tests update.