### PR TITLE
fix: fix _set_combo_view method

### DIFF
--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -62,7 +62,7 @@ class PresetsWidget(QWidget):
         view_height = sum(
             self._combo.view().sizeHintForRow(i) for i in range(self._combo.count())
         )
-        view.setFixedSize(self._combo.sizeHint().width(), view_height)
+        view.setFixedHeight(view_height)
         self._combo.setView(view)
 
     def _check_if_presets_have_same_props(self) -> None:


### PR DESCRIPTION
Fix poor width rendering of preset widgets as shown in https://github.com/pymmcore-plus/napari-micromanager/issues/184.

![Screen Shot 2022-07-25 at 10 49 30 AM](https://user-images.githubusercontent.com/70725613/180806702-d843a17a-acea-4b86-9305-a3c0dacfcd55.png)

![Screen Shot 2022-07-25 at 10 48 54 AM](https://user-images.githubusercontent.com/70725613/180806713-16ca5882-635b-445f-ba9a-a2a0410246b0.png)

fixes https://github.com/pymmcore-plus/napari-micromanager/issues/184.