### PR TITLE
Fix: Remove 'get_core_singleton()' and replace with CMMCorePlus.instance()

### DIFF
--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -3,7 +3,6 @@ from typing import Optional, Union
 from pymmcore_plus import CMMCorePlus, DeviceType
 from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
 
-from ._core import get_core_singleton
 from ._presets_widget import PresetsWidget
 from ._util import ComboMessageBox
 
@@ -30,7 +29,7 @@ class ChannelWidget(QWidget):
     ) -> None:
 
         super().__init__(parent)
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
 
         self._channel_group = channel_group or self._get_channel_group()
 

--- a/src/pymmcore_widgets/_core.py
+++ b/src/pymmcore_widgets/_core.py
@@ -8,24 +8,6 @@ from pymmcore_plus import CMMCorePlus
 
 MAG_PATTERN = re.compile(r"(\d{1,3})[xX]")
 RESOLUTION_ID_PREFIX = "px_size_"
-_SESSION_CORE: Optional[CMMCorePlus] = None
-
-
-def get_core_singleton(remote: bool = False) -> CMMCorePlus:
-    """Retrieve the MMCore singleton for this session.
-
-    The first call to this function determines whether we're running remote or not.
-    perhaps a temporary function for now...
-    """
-    global _SESSION_CORE
-    if _SESSION_CORE is None:
-        if remote:
-            from pymmcore_plus import RemoteMMCore
-
-            _SESSION_CORE = RemoteMMCore()
-        else:
-            _SESSION_CORE = CMMCorePlus.instance()
-    return _SESSION_CORE
 
 
 def load_system_config(config: str = "", mmcore: Optional[CMMCorePlus] = None) -> None:
@@ -37,14 +19,14 @@ def load_system_config(config: str = "", mmcore: Optional[CMMCorePlus] = None) -
     `CMMCorePlus.instance().loadSystemConfiguration(...)` (instead of this function)
     and we need to handle that as well.  So this function shouldn't get too complex.
     """
-    mmc = mmcore or get_core_singleton()
+    mmc = mmcore or CMMCorePlus.instance()
     mmc.unloadAllDevices()
     mmc.loadSystemConfiguration(config or "MMConfig_demo.cfg")
 
 
 def iter_dev_props(mmc: Optional[CMMCorePlus] = None) -> Iterator[Tuple[str, str]]:
     """Yield all pairs of currently loaded (device_label, property_name)."""
-    mmc = mmc or get_core_singleton()
+    mmc = mmc or CMMCorePlus.instance()
     for dev in mmc.getLoadedDevices():
         for prop in mmc.getDevicePropertyNames(dev):
             yield dev, prop

--- a/src/pymmcore_widgets/_device_widget.py
+++ b/src/pymmcore_widgets/_device_widget.py
@@ -6,8 +6,6 @@ from pymmcore_plus import CMMCorePlus, DeviceType
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QWidget
 from superqt.utils import signals_blocked
 
-from ._core import get_core_singleton
-
 LABEL = pymmcore.g_Keyword_Label
 
 
@@ -34,7 +32,7 @@ class DeviceWidget(QWidget):
     ) -> None:
         super().__init__(parent)
         self._device_label = device_label
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self.destroyed.connect(self._disconnect)
 
         # TODO:
@@ -87,7 +85,7 @@ class DeviceWidget(QWidget):
         DeviceWidget
             Appropriate DeviceWidget subclass instance.
         """
-        dev_type = get_core_singleton().getDeviceType(device_label)
+        dev_type = CMMCorePlus.instance().getDeviceType(device_label)
         _map = {DeviceType.StateDevice: StateDeviceWidget}
         if dev_type not in _map:
             raise NotImplementedError(

--- a/src/pymmcore_widgets/_exposure_widget.py
+++ b/src/pymmcore_widgets/_exposure_widget.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
 
 from pymmcore import g_Keyword_CoreCamera, g_Keyword_CoreDevice
 
-from ._core import get_core_singleton
-
 
 class ExposureWidget(QtW.QWidget):
     """Generic widget to get/set exposure time on a camera."""
@@ -25,7 +23,7 @@ class ExposureWidget(QtW.QWidget):
         core: Optional[CMMCorePlus] = None,
     ):
         super().__init__()
-        self._mmc = core or get_core_singleton()
+        self._mmc = core or CMMCorePlus.instance()
         self._camera = camera or self._mmc.getCameraDevice()
 
         self.label = QtW.QLabel()

--- a/src/pymmcore_widgets/_exposure_widget.py
+++ b/src/pymmcore_widgets/_exposure_widget.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
+from pymmcore import g_Keyword_CoreCamera, g_Keyword_CoreDevice
+from pymmcore_plus import CMMCorePlus
 from qtpy import QtWidgets as QtW
 from qtpy.QtCore import Qt
 from superqt.utils import signals_blocked
-
-if TYPE_CHECKING:
-    from pymmcore_plus import CMMCorePlus
-
-from pymmcore import g_Keyword_CoreCamera, g_Keyword_CoreDevice
 
 
 class ExposureWidget(QtW.QWidget):

--- a/src/pymmcore_widgets/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_table_widget.py
@@ -1,10 +1,10 @@
 from typing import Tuple, Union
 
+from pymmcore_plus import CMMCorePlus
 from qtpy import QtWidgets as QtW
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout
 
-from ._core import get_core_singleton
 from ._presets_widget import PresetsWidget
 from ._property_widget import PropertyWidget
 
@@ -32,7 +32,7 @@ class GroupPresetTableWidget(QtW.QWidget):
     def __init__(self) -> None:
         super().__init__()
 
-        self._mmc = get_core_singleton()
+        self._mmc = CMMCorePlus.instance()
         self._mmc.events.systemConfigurationLoaded.connect(self._populate_table)
         self.table_wdg = _MainTable()
         self.table_wdg.show()

--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -7,8 +7,6 @@ from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QPushButton
 from superqt.fonticon import icon
 
-from ._core import get_core_singleton
-
 COLOR_TYPE = Union[
     QColor,
     int,
@@ -47,7 +45,7 @@ class LiveButton(QPushButton):
 
         super().__init__()
 
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._camera = self._mmc.getCameraDevice()
         self.button_text_on = button_text_on_off[0]
         self.button_text_off = button_text_on_off[1]

--- a/src/pymmcore_widgets/_load_system_cfg_widget.py
+++ b/src/pymmcore_widgets/_load_system_cfg_widget.py
@@ -3,7 +3,7 @@ from typing import Optional
 from pymmcore_plus import CMMCorePlus
 from qtpy import QtWidgets as QtW
 
-from ._core import get_core_singleton, load_system_config
+from ._core import load_system_config
 
 
 class ConfigurationWidget(QtW.QGroupBox):
@@ -17,7 +17,7 @@ class ConfigurationWidget(QtW.QGroupBox):
     ) -> None:
         super().__init__(parent)
 
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
 
         self.setTitle("Micro-Manager Configuration")
 

--- a/src/pymmcore_widgets/_objective_widget.py
+++ b/src/pymmcore_widgets/_objective_widget.py
@@ -3,7 +3,6 @@ from typing import Optional, Union
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QSizePolicy, QWidget
 
-from ._core import get_core_singleton
 from ._device_widget import StateDeviceWidget
 from ._util import ComboMessageBox
 
@@ -29,7 +28,7 @@ class ObjectivesWidget(QWidget):
         mmcore: Optional[CMMCorePlus] = None
     ):
         super().__init__(parent)
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._objective_device = objective_device or self._guess_objective_device()
         self._combo = self._create_objective_combo(objective_device)
 

--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -1,11 +1,9 @@
 import warnings
 from typing import List, Optional, Tuple
 
-from pymmcore_plus import DeviceType
+from pymmcore_plus import CMMCorePlus, DeviceType
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QListView, QWidget
 from superqt.utils import signals_blocked
-
-from ._core import get_core_singleton
 
 
 class PresetsWidget(QWidget):
@@ -19,7 +17,7 @@ class PresetsWidget(QWidget):
 
         super().__init__(parent)
 
-        self._mmc = get_core_singleton()
+        self._mmc = CMMCorePlus.instance()
 
         self._group = group
 

--- a/src/pymmcore_widgets/_property_browser.py
+++ b/src/pymmcore_widgets/_property_browser.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ._core import get_core_singleton, iter_dev_props
+from ._core import iter_dev_props
 from ._property_widget import PropertyWidget
 
 
@@ -27,7 +27,7 @@ class _PropertyTable(QTableWidget):
         self, mmcore: Optional[CMMCorePlus] = None, parent: Optional[QWidget] = None
     ):
         super().__init__(0, 2, parent=parent)
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._mmc.events.systemConfigurationLoaded.connect(self._rebuild_table)
         self.destroyed.connect(self._disconnect)
 
@@ -81,7 +81,7 @@ class PropertyBrowser(QDialog):
         self, mmcore: Optional[CMMCorePlus] = None, parent: Optional[QWidget] = None
     ):
         super().__init__(parent)
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
 
         self._prop_table = _PropertyTable(mmcore)
         self._show_read_only: bool = True

--- a/src/pymmcore_widgets/_property_widget.py
+++ b/src/pymmcore_widgets/_property_widget.py
@@ -16,8 +16,6 @@ from qtpy.QtWidgets import (
 )
 from superqt import QLabeledDoubleSlider, QLabeledSlider, utils
 
-from ._core import get_core_singleton
-
 STATE = pymmcore.g_Keyword_State
 LABEL = pymmcore.g_Keyword_Label
 
@@ -243,7 +241,7 @@ def make_property_value_widget(
     PPropValueWidget
         A widget with a normalized PropValueWidget protocol.
     """
-    core = core or get_core_singleton()
+    core = core or CMMCorePlus.instance()
 
     # Create the widget based on property type and allowed choices
     wdg = _creat_prop_widget(core, dev, prop)
@@ -340,7 +338,7 @@ class PropertyWidget(QWidget):
         core: Optional[CMMCorePlus] = None,
     ) -> None:
         super().__init__(parent)
-        self._mmc = core or get_core_singleton()
+        self._mmc = core or CMMCorePlus.instance()
 
         if device_label not in self._mmc.getLoadedDevices():
             raise ValueError(f"Device not loaded: {device_label!r}")

--- a/src/pymmcore_widgets/_slider_dialog_widget.py
+++ b/src/pymmcore_widgets/_slider_dialog_widget.py
@@ -5,7 +5,7 @@ from pymmcore_plus import CMMCorePlus, PropertyType
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialog, QGridLayout, QLabel, QWidget
 
-from ._core import get_core_singleton, iter_dev_props
+from ._core import iter_dev_props
 from ._property_widget import PropertyWidget
 
 
@@ -38,7 +38,7 @@ class SliderDialog(QDialog):
         ptrn = re.compile(property_regex, re.IGNORECASE)
 
         _grid = QGridLayout()
-        core: CMMCorePlus = mmcore or get_core_singleton()
+        core: CMMCorePlus = mmcore or CMMCorePlus.instance()
         lights = [
             dp
             for dp in iter_dev_props(core)

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -8,8 +8,6 @@ from qtpy.QtWidgets import QPushButton, QSizePolicy, QWidget
 from superqt.fonticon import icon
 from superqt.utils import create_worker
 
-from ._core import get_core_singleton
-
 COLOR_TYPES = Union[
     QColor,
     int,
@@ -38,7 +36,7 @@ class SnapButton(QPushButton):
 
         self.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
 
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._camera = self._mmc.getCameraDevice()
 
         self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)

--- a/src/pymmcore_widgets/_stage_widget.py
+++ b/src/pymmcore_widgets/_stage_widget.py
@@ -19,8 +19,6 @@ from qtpy.QtWidgets import (
 from superqt.fonticon import setTextIcon
 from superqt.utils import signals_blocked
 
-from ._core import get_core_singleton
-
 AlignCenter = Qt.AlignmentFlag.AlignCenter
 PREFIX = MDI6.__name__.lower()
 STAGE_DEVICES = {DeviceType.Stage, DeviceType.XYStage}
@@ -98,7 +96,7 @@ class StageWidget(QWidget):
 
         self.setStyleSheet(STYLE)
 
-        self._mmc = mmcore or get_core_singleton()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._levels = levels
         self._device = device
         self._dtype = self._mmc.getDeviceType(self._device)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,18 @@ from pathlib import Path
 import pytest
 from pymmcore_plus import CMMCorePlus
 
-from pymmcore_widgets import _core
+
+# to create a new CMMCorePlus() for every test
+@pytest.fixture
+def core(monkeypatch):
+    new_core = CMMCorePlus()
+    monkeypatch.setattr("pymmcore_plus.core._mmcore_plus._instance", new_core)
+    return new_core
 
 
-@pytest.fixture(params=["local"])
-def global_mmcore(request):
-    _core._SESSION_CORE = CMMCorePlus()  # refresh singleton
-    if request.param == "remote":
-        from pymmcore_plus import server
-
-        server.try_kill_server()
-
-    mmc = _core.get_core_singleton(remote=request.param == "remote")
-    if len(mmc.getLoadedDevices()) < 2:
-        mmc.loadSystemConfiguration(str(Path(__file__).parent / "test_config.cfg"))
+@pytest.fixture()
+def global_mmcore(core):
+    mmc = CMMCorePlus.instance()
+    assert mmc == core
+    mmc.loadSystemConfiguration(str(Path(__file__).parent / "test_config.cfg"))
     return mmc

--- a/tests/test_combo_message_box_widget.py
+++ b/tests/test_combo_message_box_widget.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pymmcore_plus import CMMCorePlus
-
 from pymmcore_widgets._util import ComboMessageBox
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
 
-def test_combo_message_box_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
+def test_combo_message_box_widget(qtbot: QtBot):
 
     items = ["item_1", "item_2", "item_3"]
 

--- a/tests/test_device_widget.py
+++ b/tests/test_device_widget.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pymmcore_plus import CMMCorePlus, DeviceType
 
 from pymmcore_widgets import DeviceWidget, StateDeviceWidget
 
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
 
-def test_state_device_widget(qtbot, global_mmcore: CMMCorePlus):
+
+def test_state_device_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     for label in global_mmcore.getLoadedDevicesOfType(DeviceType.StateDevice):
         wdg: StateDeviceWidget = DeviceWidget.for_device(label)
         qtbot.addWidget(wdg)

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pymmcore_widgets._presets_widget import PresetsWidget
 
+if TYPE_CHECKING:
+    from pymmcore_plus import CMMCorePlus
+    from pytestqt.qtbot import QtBot
 
-def test_preset_widget(qtbot, global_mmcore):
+
+def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     for group in global_mmcore.getAvailableConfigGroups():
         wdg = PresetsWidget(group)
         qtbot.addWidget(wdg)

--- a/tests/test_property_browser.py
+++ b/tests/test_property_browser.py
@@ -1,15 +1,21 @@
-from pymmcore_plus import CMMCorePlus
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from pymmcore_widgets import PropertyBrowser
 
+if TYPE_CHECKING:
+    from pymmcore_plus import CMMCorePlus
+    from pytestqt.qtbot import QtBot
 
-def test_prop_browser(global_mmcore, qtbot):
+
+def test_prop_browser(global_mmcore: CMMCorePlus, qtbot: QtBot):
     pb = PropertyBrowser(mmcore=global_mmcore)
     qtbot.addWidget(pb)
     pb.show()
 
 
-def test_prop_browser_core_reset(global_mmcore: CMMCorePlus, qtbot):
+def test_prop_browser_core_reset(global_mmcore: CMMCorePlus, qtbot: QtBot):
     """test that loading and resetting doesn't cause errors."""
     global_mmcore.unloadAllDevices()
     pb = PropertyBrowser(mmcore=global_mmcore)


### PR DESCRIPTION
This PR removes the `get_core_singleton()` method from all the widgets and replaces it with `CMMCorePlus.instance()` method.