### PR TITLE
feat: update GroupPresetTableWidget + PresetsWidget + tests

### DIFF
--- a/examples/group_preset_widget.py
+++ b/examples/group_preset_widget.py
@@ -1,16 +1,12 @@
-from pathlib import Path
-
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QApplication
 
 from pymmcore_widgets import GroupPresetTableWidget
 
-CFG = Path(__file__).parent.parent / "tests" / "test_config.cfg"
-
 app = QApplication([])
 
 mmc = CMMCorePlus().instance()
-mmc.loadSystemConfiguration(CFG)
+mmc.loadSystemConfiguration()
 
 group_preset_wdg = GroupPresetTableWidget()
 group_preset_wdg.show()

--- a/examples/group_preset_widget.py
+++ b/examples/group_preset_widget.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QApplication
+
+from pymmcore_widgets import GroupPresetTableWidget
+
+CFG = Path(__file__).parent.parent / "tests" / "test_config.cfg"
+
+app = QApplication([])
+
+mmc = CMMCorePlus().instance()
+mmc.loadSystemConfiguration(CFG)
+
+group_preset_wdg = GroupPresetTableWidget()
+group_preset_wdg.show()
+
+app.exec_()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    'pymmcore-plus @ git+https://github.com/fdrgsp/pymmcore-plus.git@manage_groups_presets',
+    'pymmcore-plus @ git+https://github.com/fdrgsp/pymmcore-plus.git@new_group_preset_signals',
     'useq-schema >=0.1.0',
     'superqt >=0.3.1',
     'fonticon-materialdesignicons6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    'pymmcore-plus>=0.4.4',
+    'pymmcore-plus @ git+https://github.com/fdrgsp/pymmcore-plus.git@manage_groups_presets',
     'useq-schema >=0.1.0',
     'superqt >=0.3.1',
     'fonticon-materialdesignicons6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    'pymmcore-plus @ git+https://github.com/fdrgsp/pymmcore-plus.git@new_group_preset_signals',
+    'pymmcore-plus>=0.4.4',
     'useq-schema >=0.1.0',
     'superqt >=0.3.1',
     'fonticon-materialdesignicons6',

--- a/src/pymmcore_widgets/__init__.py
+++ b/src/pymmcore_widgets/__init__.py
@@ -9,7 +9,7 @@ except PackageNotFoundError:
 from ._channel_widget import ChannelWidget
 from ._device_widget import DeviceWidget, StateDeviceWidget
 from ._exposure_widget import DefaultCameraExposureWidget, ExposureWidget
-from ._group_preset_table_widget import GroupPresetTableWidget
+from ._group_preset_widget._group_preset_table_widget import GroupPresetTableWidget
 from ._live_button_widget import LiveButton
 from ._load_system_cfg_widget import ConfigurationWidget
 from ._objective_widget import ObjectivesWidget

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -44,10 +44,9 @@ class ChannelWidget(QWidget):
         self._mmc.events.channelGroupChanged.connect(self._on_channel_group_changed)
         self._mmc.events.configSet.connect(self._on_channel_set)
 
-        # connections to the new pymmcore-plus groupDeleted and newGroupPreset signals
         # presetDeleted signal is handled by the PresetsWidget
-        self._mmc.events.newGroupPreset.connect(self._on_new_group_preset)
-        self._mmc.events.groupDeleted.connect(self._on_group_deleted)
+        self._mmc.events.configDefined.connect(self._on_new_group_preset)
+        self._mmc.events.configGroupDeleted.connect(self._on_group_deleted)
 
         self.destroyed.connect(self._disconnect_from_core)
         self._on_sys_cfg_loaded()
@@ -121,5 +120,5 @@ class ChannelWidget(QWidget):
         self._mmc.events.systemConfigurationLoaded.disconnect(self._on_sys_cfg_loaded)
         self._mmc.events.channelGroupChanged.disconnect(self._on_channel_group_changed)
         self._mmc.events.configSet.disconnect(self._on_channel_set)
-        self._mmc.events.newGroupPreset.disconnect(self._on_new_group_preset)
-        self._mmc.events.groupDeleted.connect(self._on_group_deleted)
+        self._mmc.events.configDefined.disconnect(self._on_new_group_preset)
+        self._mmc.events.configGroupDeleted.connect(self._on_group_deleted)

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -44,6 +44,7 @@ class ChannelWidget(QWidget):
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_cfg_loaded)
         self._mmc.events.channelGroupChanged.connect(self._on_channel_group_changed)
         self._mmc.events.configSet.connect(self._on_channel_set)
+        self._mmc.events.newGroupPreset.connect(self._on_new_group_preset)
 
         # connections to the new pymmcore-plus groupDeleted and presetDeleted signals
         self._mmc.events.groupDeleted.connect(self._on_group_or_preset_deleted)
@@ -102,6 +103,10 @@ class ChannelWidget(QWidget):
         self.channel_wdg.deleteLater()
         self._update_widget(new_channel_group)
 
+    def _on_new_group_preset(self, group: str) -> None:
+        if group == self._channel_group:
+            self._on_channel_group_changed(group)
+
     def _on_group_or_preset_deleted(self, group: str) -> None:
         if group == self._channel_group:
             self._on_channel_group_changed("")
@@ -114,3 +119,4 @@ class ChannelWidget(QWidget):
         self._mmc.events.systemConfigurationLoaded.disconnect(self._on_sys_cfg_loaded)
         self._mmc.events.channelGroupChanged.disconnect(self._on_channel_group_changed)
         self._mmc.events.configSet.disconnect(self._on_channel_set)
+        self._mmc.events.newGroupPreset.disconnect(self._on_new_group_preset)

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -45,6 +45,10 @@ class ChannelWidget(QWidget):
         self._mmc.events.channelGroupChanged.connect(self._on_channel_group_changed)
         self._mmc.events.configSet.connect(self._on_channel_set)
 
+        # connections to the new pymmcore-plus groupDeleted and presetDeleted signals
+        self._mmc.events.groupDeleted.connect(self._on_group_or_preset_deleted)
+        self._mmc.events.presetDeleted.connect(self._on_group_or_preset_deleted)
+
         self.destroyed.connect(self._disconnect_from_core)
         self._on_sys_cfg_loaded()
 
@@ -63,6 +67,9 @@ class ChannelWidget(QWidget):
     ) -> Union[PresetsWidget, QComboBox]:
         if channel_group:
             channel_wdg = PresetsWidget(channel_group)
+        # if not channel_group, first try to guess it.
+        elif new_channel_group := self._get_channel_group():
+            channel_wdg = PresetsWidget(new_channel_group)
         else:
             channel_wdg = QComboBox()
             channel_wdg.setEnabled(False)
@@ -94,6 +101,10 @@ class ChannelWidget(QWidget):
         self.channel_wdg.setParent(_wdg)
         self.channel_wdg.deleteLater()
         self._update_widget(new_channel_group)
+
+    def _on_group_or_preset_deleted(self, group: str) -> None:
+        if group == self._channel_group:
+            self._on_channel_group_changed("")
 
     def _update_widget(self, channel_group: str) -> None:
         self.channel_wdg = self._create_channel_widget(channel_group)

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -68,17 +68,7 @@ class ChannelWidget(QWidget):
     ) -> Union[PresetsWidget, QComboBox]:
         if channel_group:
             channel_wdg = PresetsWidget(channel_group)
-            print(channel_wdg.allowedValues())
-
-            # self._mmc.setChannelGroup(channel_group)
-
-            # TODO: adding new groups does not extend the list of available
-            # "core", "ChannelGroup" options.
-            # self._mmc.setChannelGroup(channel_group) will give an ValueError because
-            # channel_group will not be in the ("core", "ChannelGroup") available options.  # noqa: E501
-            # see "updateAllowedChannelGroups" line 7584 of micromanager:
-            # https://github.com/micro-manager/mmCoreAndDevices/blob/9fb489f6935d0b17edc4fae939ee1aa191d6ab34/MMCore/MMCore.cpp  # noqa: E501
-
+            self._mmc.setChannelGroup(channel_group)
         else:
             channel_wdg = QComboBox()
             channel_wdg.setEnabled(False)

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -106,6 +106,8 @@ class ChannelWidget(QWidget):
     def _on_new_group_preset(self, group: str) -> None:
         if group == self._channel_group:
             self._on_channel_group_changed(group)
+        elif not self._mmc.getChannelGroup():
+            self._on_channel_group_changed("")
 
     def _on_group_or_preset_deleted(self, group: str) -> None:
         if group == self._channel_group:

--- a/src/pymmcore_widgets/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_table_widget.py
@@ -4,9 +4,12 @@ from qtpy import QtWidgets as QtW
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout
 
-from ._core import get_core_singleton
-from ._presets_widget import PresetsWidget
-from ._property_widget import PropertyWidget
+# from ._core import get_core_singleton
+# from ._presets_widget import PresetsWidget
+# from ._property_widget import PropertyWidget
+from pymmcore_widgets._core import get_core_singleton
+from pymmcore_widgets._presets_widget import PresetsWidget
+from pymmcore_widgets._property_widget import PropertyWidget
 
 
 class _MainTable(QtW.QTableWidget):
@@ -34,13 +37,92 @@ class GroupPresetTableWidget(QtW.QWidget):
 
         self._mmc = get_core_singleton()
         self._mmc.events.systemConfigurationLoaded.connect(self._populate_table)
-        self.table_wdg = _MainTable()
-        self.table_wdg.show()
-        self.setLayout(QVBoxLayout())
-        self.setContentsMargins(0, 0, 0, 0)
-        self.layout().addWidget(self.table_wdg)
+
+        self._create_gui()
 
         self._populate_table()
+
+    def _create_gui(self) -> None:
+
+        self.setLayout(QVBoxLayout())
+        self.layout().setSpacing(5)
+        self.setContentsMargins(0, 0, 0, 0)
+
+        save_btn = self._add_save_button()
+        self.layout().addWidget(save_btn)
+
+        self.table_wdg = _MainTable()
+        self.layout().addWidget(self.table_wdg)
+
+        btns = self._add_groups_presets_buttons()
+        self.layout().addWidget(btns)
+
+    def _add_groups_presets_buttons(self) -> QtW.QWidget:
+
+        main_wdg = QtW.QWidget()
+        main_wdg_layout = QtW.QHBoxLayout()
+        main_wdg_layout.setSpacing(10)
+        main_wdg_layout.setContentsMargins(0, 0, 0, 0)
+        main_wdg.setLayout(main_wdg_layout)
+
+        lbl_sizepolicy = QtW.QSizePolicy(QtW.QSizePolicy.Fixed, QtW.QSizePolicy.Fixed)
+
+        # groups
+        groups_btn_wdg = QtW.QWidget()
+        groups_layout = QtW.QHBoxLayout()
+        groups_layout.setSpacing(5)
+        groups_layout.setContentsMargins(0, 0, 0, 0)
+        groups_btn_wdg.setLayout(groups_layout)
+
+        groups_lbl = QtW.QLabel(text="Group:")
+        groups_lbl.setSizePolicy(lbl_sizepolicy)
+        self.groups_add_btn = QtW.QPushButton(text="+")
+        self.groups_remove_btn = QtW.QPushButton(text="-")
+        self.groups_edit_btn = QtW.QPushButton(text="Edit")
+        groups_layout.addWidget(groups_lbl)
+        groups_layout.addWidget(self.groups_add_btn)
+        groups_layout.addWidget(self.groups_remove_btn)
+        groups_layout.addWidget(self.groups_edit_btn)
+
+        main_wdg_layout.addWidget(groups_btn_wdg)
+
+        # presets
+        presets_btn_wdg = QtW.QWidget()
+        presets_layout = QtW.QHBoxLayout()
+        presets_layout.setSpacing(5)
+        presets_layout.setContentsMargins(0, 0, 0, 0)
+        presets_btn_wdg.setLayout(presets_layout)
+
+        presets_lbl = QtW.QLabel(text="Preset:")
+        presets_lbl.setSizePolicy(lbl_sizepolicy)
+        self.presets_add_btn = QtW.QPushButton(text="+")
+        self.presets_remove_btn = QtW.QPushButton(text="-")
+        self.presets_edit_btn = QtW.QPushButton(text="Edit")
+        presets_layout.addWidget(presets_lbl)
+        presets_layout.addWidget(self.presets_add_btn)
+        presets_layout.addWidget(self.presets_remove_btn)
+        presets_layout.addWidget(self.presets_edit_btn)
+
+        main_wdg_layout.addWidget(presets_btn_wdg)
+
+        return main_wdg
+
+    def _add_save_button(self) -> QtW.QWidget:
+
+        save_btn_wdg = QtW.QWidget()
+        save_btn_layout = QtW.QHBoxLayout()
+        save_btn_layout.setSpacing(0)
+        save_btn_layout.setContentsMargins(0, 0, 0, 0)
+        save_btn_wdg.setLayout(save_btn_layout)
+
+        spacer = QtW.QSpacerItem(
+            10, 10, QtW.QSizePolicy.Expanding, QtW.QSizePolicy.Fixed
+        )
+        save_btn_layout.addItem(spacer)
+        self.save_btn = QtW.QPushButton(text="Save")
+        save_btn_layout.addWidget(self.save_btn)
+
+        return save_btn_wdg
 
     def _on_system_cfg_loaded(self) -> None:
         self._populate_table()
@@ -94,3 +176,14 @@ class GroupPresetTableWidget(QtW.QWidget):
             return PresetsWidget(group)
         else:
             return PropertyWidget(device, property)
+
+
+if __name__ == "__main__":
+    from qtpy.QtWidgets import QApplication
+
+    mmc = get_core_singleton()
+    mmc.loadSystemConfiguration()
+    app = QApplication([])
+    table = GroupPresetTableWidget()
+    table.show()
+    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -16,9 +16,6 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-# from ._core import get_core_singleton
-# from ._property_widget import PropertyWidget
-# from ._add_first_preset_widget import AddFirstPresetWidget
 from pymmcore_widgets._core import get_core_singleton
 from pymmcore_widgets._property_widget import PropertyWidget
 
@@ -46,6 +43,8 @@ class AddFirstPresetWidget(QDialog):
         self._populate_table()
 
     def _create_gui(self) -> None:
+
+        self.setWindowTitle(f"Add the first Preset to the new '{self._group}' Group")
 
         main_layout = QVBoxLayout()
         main_layout.setSpacing(0)

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -125,6 +125,7 @@ class AddFirstPresetWidget(QDialog):
         for idx, (dev, prop, _) in enumerate(self._dev_prop_val_list):
             item = QTableWidgetItem(f"{dev}-{prop}")
             wdg = PropertyWidget(dev, prop, core=self._mmc)
+            wdg._value_widget.valueChanged.disconnect()
             self.table.setItem(idx, 0, item)
             self.table.setCellWidget(idx, 1, wdg)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -148,7 +148,7 @@ class AddFirstPresetWidget(QDialog):
             for d, p, v in dev_prop_val:
                 self._mmc.defineConfig(self._group, self._preset, d, p, v)
 
-        self._mmc.events.newGroupPreset.emit(self._group, self._preset, d, p, v)
+        self._mmc.events.configDefined.emit(self._group, self._preset, d, p, v)
 
         self.close()
         self.parent().close()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -126,7 +126,7 @@ class AddFirstPresetWidget(QDialog):
         for idx, (dev, prop, _) in enumerate(self._dev_prop_val_list):
             item = QTableWidgetItem(f"{dev}-{prop}")
             wdg = PropertyWidget(dev, prop, core=self._mmc)
-            wdg._value_widget.valueChanged.disconnect()
+            wdg._value_widget.valueChanged.disconnect()  # type: ignore
             self.table.setItem(idx, 0, item)
             self.table.setCellWidget(idx, 1, wdg)
 
@@ -142,7 +142,7 @@ class AddFirstPresetWidget(QDialog):
 
         self._preset = self.preset_name_lineedit.text()
 
-        self._mmc.defineConfigFromDevicePropertyValueList(
+        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
             self._group, self._preset, dev_prop_val
         )
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -105,14 +105,15 @@ class AddFirstPresetWidget(QDialog):
         wdg_layout.setContentsMargins(0, 0, 0, 0)
         wdg.setLayout(wdg_layout)
 
-        self.info_lbl = QLabel()
         self.apply_button = QPushButton(text="Create Preset")
         self.apply_button.setSizePolicy(
             QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         )
         self.apply_button.clicked.connect(self._create_first_preset)
 
-        wdg_layout.addWidget(self.info_lbl)
+        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        wdg_layout.addItem(spacer)
         wdg_layout.addWidget(self.apply_button)
 
         return wdg
@@ -143,10 +144,6 @@ class AddFirstPresetWidget(QDialog):
 
         self._mmc.defineConfigFromDevicePropertyValueList(
             self._group, self._preset, dev_prop_val
-        )
-
-        self.info_lbl.setText(
-            f"{self._preset} of {self._group} group has been created!"
         )
 
         self.close()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -19,6 +19,8 @@ from qtpy.QtWidgets import (
 
 from pymmcore_widgets._property_widget import PropertyWidget
 
+from .._util import block_core
+
 
 class AddFirstPresetWidget(QDialog):
     """A widget to create the first specified group's preset."""
@@ -142,9 +144,11 @@ class AddFirstPresetWidget(QDialog):
 
         self._preset = self.preset_name_lineedit.text()
 
-        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
-            self._group, self._preset, dev_prop_val
-        )
+        with block_core(self._mmc.events):
+            for d, p, v in dev_prop_val:
+                self._mmc.defineConfig(self._group, self._preset, d, p, v)
+
+        self._mmc.events.newGroupPreset.emit(self._group, self._preset, d, p, v)
 
         self.close()
         self.parent().close()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -268,7 +268,7 @@ class AddGroupWidget(QDialog):
         if group in self._mmc.getAvailableConfigGroups():
             warnings.warn(f"There is already a preset called {group}.")
             self.info_lbl.setStyleSheet("color: magenta;")
-            self.info_lbl.setText(f"{group} already exist!")
+            self.info_lbl.setText(f"'{group}' already exist!")
             return
 
         dev_prop_val_list = []

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -298,7 +298,7 @@ class AddGroupWidget(QDialog):
         if hasattr(self, "_first_preset_wdg"):
             self._first_preset_wdg.close()  # type: ignore
         self._first_preset_wdg = AddFirstPresetWidget(
-            group, "NewPreset", dev_prop_val_list, parent=self
+            group, dev_prop_val_list, parent=self
         )
         self._first_preset_wdg.show()
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -268,7 +268,7 @@ class AddGroupWidget(QDialog):
         if group in self._mmc.getAvailableConfigGroups():
             warnings.warn(f"There is already a preset called {group}.")
             self.info_lbl.setStyleSheet("color: magenta;")
-            self.info_lbl.setText(f"{group} already exist!!")
+            self.info_lbl.setText(f"{group} already exist!")
             return
 
         dev_prop_val_list = []

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -257,6 +257,18 @@ class AddGroupWidget(QDialog):
 
     def _add_group(self) -> None:
 
+        cbox = [
+            self._prop_table.cellWidget(r, 0)
+            for r in range(self._prop_table.rowCount())
+            if self._prop_table.cellWidget(r, 0).isChecked()
+        ]
+
+        if not cbox:
+            warnings.warn("Select at lest one property!")
+            self.info_lbl.setStyleSheet("color: magenta;")
+            self.info_lbl.setText("Select at lest one property!")
+            return
+
         group = self.group_lineedit.text()
 
         if not group:

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -2,9 +2,9 @@ import warnings
 from functools import partial
 from typing import Dict, Optional, Set, Tuple, cast
 
-from pymmcore_plus import CMMCorePlus, DeviceType
+from pymmcore_plus import DeviceType
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QCloseEvent, QColor
 from qtpy.QtWidgets import (
     QAbstractScrollArea,
     QCheckBox,
@@ -23,14 +23,9 @@ from qtpy.QtWidgets import (
 )
 
 from pymmcore_widgets._core import get_core_singleton, iter_dev_props
-from pymmcore_widgets._group_preset_widget._add_first_preset_widget import (
-    AddFirstPresetWidget,
-)
 from pymmcore_widgets._property_widget import PropertyWidget
 
-# from ._core import get_core_singleton, iter_dev_props
-# from ._property_widget import PropertyWidget
-# from ._add_first_preset_widget import AddFirstPresetWidget
+from ._add_first_preset_widget import AddFirstPresetWidget
 
 
 class _PropertyTable(QTableWidget):
@@ -99,7 +94,15 @@ class AddGroupWidget(QDialog):
 
         self.destroyed.connect(self._disconnect)
 
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """Close also 'AddFirstPresetWidget' if is open."""
+        if hasattr(self, "_first_preset_wdg"):
+            self._first_preset_wdg.close()  # type: ignore
+        event.accept()
+
     def _create_gui(self) -> None:
+
+        self.setWindowTitle("Create a new Group")
 
         main_layout = QVBoxLayout()
         main_layout.setSpacing(10)
@@ -288,15 +291,4 @@ class AddGroupWidget(QDialog):
         self._first_preset_wdg.show()
 
         self.info_lbl.setStyleSheet("")
-        self.info_lbl.setText(f"{group} group created!")
-
-
-if __name__ == "__main__":
-    from qtpy.QtWidgets import QApplication
-
-    CMMCorePlus.instance().loadSystemConfiguration()
-    app = QApplication([])
-    table = AddGroupWidget()
-    table.show()
-
-    app.exec_()
+        self.info_lbl.setText("")

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -1,0 +1,300 @@
+import warnings
+from functools import partial
+from typing import Dict, Optional, Set, Tuple, cast
+
+from pymmcore_plus import CMMCorePlus, DeviceType
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import (
+    QAbstractScrollArea,
+    QCheckBox,
+    QDialog,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pymmcore_widgets._core import get_core_singleton, iter_dev_props
+from pymmcore_widgets._group_preset_widget._add_first_preset_widget import (
+    AddFirstPresetWidget,
+)
+from pymmcore_widgets._property_widget import PropertyWidget
+
+# from ._core import get_core_singleton, iter_dev_props
+# from ._property_widget import PropertyWidget
+# from ._add_first_preset_widget import AddFirstPresetWidget
+
+
+class _PropertyTable(QTableWidget):
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(0, 3, parent=parent)
+        self._mmc = get_core_singleton()
+        self._mmc.events.systemConfigurationLoaded.connect(self._rebuild_table)
+        self.destroyed.connect(self._disconnect)
+
+        self.setHorizontalHeaderLabels([" ", "Property", "Value"])
+        self.setColumnWidth(0, 250)
+        self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
+        vh = self.verticalHeader()
+        vh.setSectionResizeMode(vh.ResizeMode.Fixed)
+        vh.setDefaultSectionSize(24)
+        vh.setVisible(False)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.setSelectionMode(self.SelectionMode.NoSelection)
+        self._rebuild_table()
+
+    def _disconnect(self) -> None:
+        self._mmc.events.systemConfigurationLoaded.disconnect(self._rebuild_table)
+
+    def _rebuild_table(self) -> None:
+        self.clearContents()
+        props = list(iter_dev_props(self._mmc))
+        self.setRowCount(len(props))
+        for i, (dev, prop) in enumerate(props):
+            _checkbox = QCheckBox()
+            _checkbox.setProperty("row", i)
+            self.setCellWidget(i, 0, _checkbox)
+            item = QTableWidgetItem(f"{dev}-{prop}")
+            wdg = PropertyWidget(dev, prop, core=self._mmc)
+            wdg.setEnabled(False)
+            self.setItem(i, 1, item)
+            self.setCellWidget(i, 2, wdg)
+            if wdg.isReadOnly():
+                # TODO: make this more theme aware
+                item.setBackground(QColor("#AAA"))
+                wdg.setStyleSheet("QLabel { background-color : #AAA }")
+
+        self.resizeColumnsToContents()
+
+        # TODO: install eventFilter to prevent mouse wheel from scrolling sliders
+
+
+DevTypeLabels: Dict[str, Tuple[DeviceType, ...]] = {
+    "cameras": (DeviceType.CameraDevice,),
+    "shutters": (DeviceType.ShutterDevice,),
+    "stages": (DeviceType.StageDevice,),
+    "wheels, turrets, etc.": (DeviceType.StateDevice,),
+}
+_d: Set[DeviceType] = set.union(*(set(i) for i in DevTypeLabels.values()))
+DevTypeLabels["other devices"] = tuple(set(DeviceType) - _d)
+
+
+class AddGroupWidget(QDialog):
+    """Widget to create a new group."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._mmc = get_core_singleton()
+        self._mmc.events.systemConfigurationLoaded.connect(self._update_filter)
+
+        self._create_gui()
+
+        self.destroyed.connect(self._disconnect)
+
+    def _create_gui(self) -> None:
+
+        main_layout = QVBoxLayout()
+        main_layout.setSpacing(10)
+        main_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(main_layout)
+
+        group_lineedit = self._create_group_lineedit_wdg()
+        main_layout.addWidget(group_lineedit)
+
+        table = self._create_table_wdg()
+        main_layout.addWidget(table)
+
+        btn = self._create_button_wdg()
+        main_layout.addWidget(btn)
+
+    def _create_group_lineedit_wdg(self) -> QGroupBox:
+
+        wdg = QGroupBox()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(10)
+        wdg.setLayout(layout)
+
+        group_lbl = QLabel(text="Group name:")
+        group_lbl.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
+
+        self.group_lineedit = QLineEdit()
+
+        layout.addWidget(group_lbl)
+        layout.addWidget(self.group_lineedit)
+
+        return wdg
+
+    def _create_table_wdg(self) -> QGroupBox:
+
+        wdg = QGroupBox()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(0)
+        wdg.setLayout(layout)
+
+        self._prop_table = _PropertyTable()
+        self._show_read_only: bool = True
+
+        self._filters: Set[DeviceType] = set()
+        self._filter_text = QLineEdit()
+        self._filter_text.setClearButtonEnabled(True)
+        self._filter_text.setPlaceholderText("Filter by device or property name...")
+        self._filter_text.textChanged.connect(self._update_filter)
+
+        right = QWidget()
+        right.setLayout(QVBoxLayout())
+        right.layout().addWidget(self._filter_text)
+        right.layout().addWidget(self._prop_table)
+
+        left = QWidget()
+        left.setLayout(QVBoxLayout())
+        left.layout().addWidget(self._make_checkboxes())
+
+        self.layout().addWidget(left)
+        self.layout().addWidget(right)
+        layout.addWidget(left)
+        layout.addWidget(right)
+
+        return wdg
+
+    def _create_button_wdg(self) -> QWidget:
+
+        wdg = QWidget()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        wdg.setLayout(layout)
+
+        self.info_lbl = QLabel()
+
+        self.new_group_btn = QPushButton(text="Create New Group")
+        self.new_group_btn.setSizePolicy(
+            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        )
+        self.new_group_btn.clicked.connect(self._add_group)
+
+        layout.addWidget(self.info_lbl)
+        layout.addWidget(self.new_group_btn)
+
+        return wdg
+
+    def _disconnect(self) -> None:
+        self._mmc.events.systemConfigurationLoaded.disconnect(self._update_filter)
+
+    def _update_filter(self) -> None:
+        filt = self._filter_text.text().lower()
+        for r in range(self._prop_table.rowCount()):
+            wdg = cast(PropertyWidget, self._prop_table.cellWidget(r, 2))
+            if wdg.isReadOnly() and not self._show_read_only:  # sourcery skip
+                self._prop_table.hideRow(r)
+            elif wdg.deviceType() in self._filters:
+                self._prop_table.hideRow(r)
+            elif filt and filt not in self._prop_table.item(r, 1).text().lower():
+                self._prop_table.hideRow(r)
+            else:
+                self._prop_table.showRow(r)
+
+    def _toggle_filter(self, label: str) -> None:
+        self._filters.symmetric_difference_update(DevTypeLabels[label])
+        self._update_filter()
+
+    def _make_checkboxes(self) -> QWidget:
+        dev_gb = QGroupBox("Device Type")
+        dev_gb.setLayout(QGridLayout())
+        dev_gb.layout().setSpacing(6)
+        all_btn = QPushButton("All")
+        dev_gb.layout().addWidget(all_btn, 0, 0, 1, 1)
+        none_btn = QPushButton("None")
+        dev_gb.layout().addWidget(none_btn, 0, 1, 1, 1)
+        for i, (label, devtypes) in enumerate(DevTypeLabels.items()):
+            cb = QCheckBox(label)
+            cb.setChecked(devtypes[0] not in self._filters)
+            cb.toggled.connect(partial(self._toggle_filter, label))
+            dev_gb.layout().addWidget(cb, i + 1, 0, 1, 2)
+
+        @all_btn.clicked.connect  # type: ignore
+        def _check_all() -> None:
+            for cxbx in dev_gb.findChildren(QCheckBox):
+                cxbx.setChecked(True)
+
+        @none_btn.clicked.connect  # type: ignore
+        def _check_none() -> None:
+            for cxbx in dev_gb.findChildren(QCheckBox):
+                cxbx.setChecked(False)
+
+        for i in dev_gb.findChildren(QWidget):
+            i.setFocusPolicy(Qt.FocusPolicy.NoFocus)  # type: ignore
+
+        ro = QCheckBox("Show read-only")
+        ro.setChecked(self._show_read_only)
+        ro.toggled.connect(self._set_show_read_only)
+        ro.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
+        c = QWidget()
+        c.setLayout(QVBoxLayout())
+        c.layout().addWidget(dev_gb)
+        c.layout().addWidget(ro)
+        c.layout().addStretch()
+        return c
+
+    def _set_show_read_only(self, state: bool) -> None:
+        self._show_read_only = state
+        self._update_filter()
+
+    def _add_group(self) -> None:
+
+        group = self.group_lineedit.text()
+
+        if not group:
+            warnings.warn("Give a name to the group!")
+            self.info_lbl.setStyleSheet("color: magenta;")
+            self.info_lbl.setText("Give a name to the group!")
+            return
+
+        if group in self._mmc.getAvailableConfigGroups():
+            warnings.warn(f"There is already a preset called {group}.")
+            self.info_lbl.setStyleSheet("color: magenta;")
+            self.info_lbl.setText(f"{group} already exist!!")
+            return
+
+        dev_prop_val_list = []
+        for r in range(self._prop_table.rowCount()):
+            checkbox = cast(QCheckBox, self._prop_table.cellWidget(r, 0))
+            if checkbox.isChecked():
+                row = checkbox.property("row")
+                dev_prop = self._prop_table.item(row, 1).text()
+                dev = dev_prop.split("-")[0]
+                prop = dev_prop.split("-")[1]
+                value = self._prop_table.cellWidget(row, 2).value()
+
+                dev_prop_val_list.append((dev, prop, str(value)))
+
+        if hasattr(self, "_first_preset_wdg"):
+            self._first_preset_wdg.close()  # type: ignore
+        self._first_preset_wdg = AddFirstPresetWidget(
+            group, "NewPreset", dev_prop_val_list, parent=self
+        )
+        self._first_preset_wdg.show()
+
+        self.info_lbl.setStyleSheet("")
+        self.info_lbl.setText(f"{group} group created!")
+
+
+if __name__ == "__main__":
+    from qtpy.QtWidgets import QApplication
+
+    CMMCorePlus.instance().loadSystemConfiguration()
+    app = QApplication([])
+    table = AddGroupWidget()
+    table.show()
+
+    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -115,6 +115,8 @@ class AddGroupWidget(QDialog):
         btn = self._create_button_wdg()
         main_layout.addWidget(btn)
 
+        self._set_show_read_only(False)
+
     def _create_group_lineedit_wdg(self) -> QGroupBox:
 
         wdg = QGroupBox()
@@ -142,7 +144,7 @@ class AddGroupWidget(QDialog):
         wdg.setLayout(layout)
 
         self._prop_table = _PropertyTable()
-        self._show_read_only: bool = True
+        self._show_read_only: bool = False
 
         self._filters: Set[DeviceType] = set()
         self._filter_text = QLineEdit()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -1,0 +1,181 @@
+# Simple table with the properties options
+import warnings
+from typing import Optional
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSizePolicy,
+    QSpacerItem,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pymmcore_widgets._core import get_core_singleton
+from pymmcore_widgets._property_widget import PropertyWidget
+
+
+class AddPresetWidget(QDialog):
+    """A widget to add presets to a specified group."""
+
+    def __init__(self, group: str, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        self._mmc = get_core_singleton()
+        self._group = group
+
+        self._create_gui()
+
+        self._populate_table()
+
+    def _create_gui(self) -> None:
+
+        main_layout = QVBoxLayout()
+        main_layout.setSpacing(0)
+        main_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(main_layout)
+
+        wdg = QWidget()
+        wdg_layout = QVBoxLayout()
+        wdg_layout.setSpacing(10)
+        wdg_layout.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(wdg_layout)
+
+        top_wdg = self._create_top_wdg()
+        wdg_layout.addWidget(top_wdg)
+
+        self.table = _Table()
+        wdg_layout.addWidget(self.table)
+
+        bottom_wdg = self._create_bottom_wdg()
+        wdg_layout.addWidget(bottom_wdg)
+
+        main_layout.addWidget(wdg)
+
+    def _create_top_wdg(self) -> QGroupBox:
+        wdg = QGroupBox()
+        wdg_layout = QHBoxLayout()
+        wdg_layout.setSpacing(5)
+        wdg_layout.setContentsMargins(5, 5, 5, 5)
+        wdg.setLayout(wdg_layout)
+
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        gp_lbl = QLabel(text="Group:")
+        gp_lbl.setSizePolicy(lbl_sizepolicy)
+        group_name_lbl = QLabel(text=f"{self._group}")
+        group_name_lbl.setSizePolicy(lbl_sizepolicy)
+
+        ps_lbl = QLabel(text="Preset:")
+        ps_lbl.setSizePolicy(lbl_sizepolicy)
+        self.preset_name_lineedit = QLineEdit()
+
+        spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        wdg_layout.addWidget(gp_lbl)
+        wdg_layout.addWidget(group_name_lbl)
+        wdg_layout.addItem(spacer)
+        wdg_layout.addWidget(ps_lbl)
+        wdg_layout.addWidget(self.preset_name_lineedit)
+
+        return wdg
+
+    def _create_bottom_wdg(self) -> QWidget:
+
+        wdg = QWidget()
+        wdg_layout = QHBoxLayout()
+        wdg_layout.setSpacing(5)
+        wdg_layout.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(wdg_layout)
+
+        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.add_preset_button = QPushButton(text="Add Preset")
+        self.add_preset_button.clicked.connect(self._add_preset)
+
+        wdg_layout.addItem(spacer)
+        wdg_layout.addWidget(self.add_preset_button)
+
+        return wdg
+
+    def _populate_table(self) -> None:
+
+        self.table.clearContents()
+
+        dev_prop = []
+        for preset in self._mmc.getAvailableConfigs(self._group):
+            dev_prop.extend(
+                [
+                    (k[0], k[1])
+                    for k in self._mmc.getConfigData(self._group, preset)
+                    if (k[0], k[1]) not in dev_prop
+                ]
+            )
+
+        self.table.setRowCount(len(dev_prop))
+        for idx, (dev, prop) in enumerate(dev_prop):
+            item = QTableWidgetItem(f"{dev}-{prop}")
+            wdg = PropertyWidget(dev, prop, core=self._mmc)
+            self.table.setItem(idx, 0, item)
+            self.table.setCellWidget(idx, 1, wdg)
+
+    def _add_preset(self) -> None:
+
+        preset_name = self.preset_name_lineedit.text()
+
+        if preset_name in self._mmc.getAvailableConfigs(self._group):
+            warnings.warn(f"There is already a preset called {preset_name}.")
+            return
+
+        if not preset_name:
+            idx = sum(
+                "NewPreset" in p for p in self._mmc.getAvailableConfigs(self._group)
+            )
+            preset_name = f"NewPreset_{idx}" if idx > 0 else "NewPreset"
+
+        dev_prop_val = []
+        for row in range(self.table.rowCount()):
+            device_property = self.table.item(row, 0).text()
+            dev = device_property.split("-")[0]
+            prop = device_property.split("-")[1]
+            value = self.table.cellWidget(row, 1).value()
+            dev_prop_val.append((dev, prop, value))
+
+        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
+            self._group, preset_name, dev_prop_val
+        )
+
+
+class _Table(QTableWidget):
+    """Set table properties for EditPresetWidget."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        hdr = self.horizontalHeader()
+        hdr.setSectionResizeMode(hdr.Stretch)
+        hdr.setDefaultAlignment(Qt.AlignHCenter)
+        vh = self.verticalHeader()
+        vh.setVisible(False)
+        vh.setSectionResizeMode(vh.Fixed)
+        vh.setDefaultSectionSize(24)
+        self.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.setColumnCount(2)
+        self.setHorizontalHeaderLabels(["Device-Property", "Value"])
+
+
+if __name__ == "__main__":
+    from qtpy.QtWidgets import QApplication
+
+    cfg = "/Users/FG/Dropbox/git/pymmcore-widgets/tests/test_config.cfg"
+    mmc = get_core_singleton()
+    mmc.loadSystemConfiguration(cfg)
+    app = QApplication([])
+    table = AddPresetWidget("Channel")
+    table.show()
+    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -127,6 +127,7 @@ class AddPresetWidget(QDialog):
         for idx, (dev, prop) in enumerate(dev_prop):
             item = QTableWidgetItem(f"{dev}-{prop}")
             wdg = PropertyWidget(dev, prop, core=self._mmc)
+            wdg._value_widget.valueChanged.disconnect()
             self.table.setItem(idx, 0, item)
             self.table.setCellWidget(idx, 1, wdg)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -36,6 +36,8 @@ class AddPresetWidget(QDialog):
 
     def _create_gui(self) -> None:
 
+        self.setWindowTitle(f"Add a new Preset to the '{self._group}' Group")
+
         main_layout = QVBoxLayout()
         main_layout.setSpacing(0)
         main_layout.setContentsMargins(10, 10, 10, 10)
@@ -59,6 +61,7 @@ class AddPresetWidget(QDialog):
         main_layout.addWidget(wdg)
 
     def _create_top_wdg(self) -> QGroupBox:
+
         wdg = QGroupBox()
         wdg_layout = QHBoxLayout()
         wdg_layout.setSpacing(5)
@@ -168,7 +171,7 @@ class AddPresetWidget(QDialog):
             self._group, preset_name, dev_prop_val
         )
         self.info_lbl.setStyleSheet("")
-        self.info_lbl.setText(f"{preset_name} has been defined!")
+        self.info_lbl.setText(f"{preset_name} has been added!")
 
 
 class _Table(QTableWidget):
@@ -186,15 +189,3 @@ class _Table(QTableWidget):
         self.setEditTriggers(QTableWidget.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Device-Property", "Value"])
-
-
-if __name__ == "__main__":
-    from qtpy.QtWidgets import QApplication
-
-    cfg = "/Users/FG/Dropbox/git/pymmcore-widgets/tests/test_config.cfg"
-    mmc = get_core_singleton()
-    mmc.loadSystemConfiguration(cfg)
-    app = QApplication([])
-    table = AddPresetWidget("Channel")
-    table.show()
-    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -80,7 +80,7 @@ class AddPresetWidget(QDialog):
         ps_lbl = QLabel(text="Preset:")
         ps_lbl.setSizePolicy(lbl_sizepolicy)
         self.preset_name_lineedit = QLineEdit()
-        self.preset_name_lineedit.setPlaceholderText("NewPreset")
+        self.preset_name_lineedit.setPlaceholderText(self._get_placeholder_name())
 
         spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
 
@@ -91,6 +91,10 @@ class AddPresetWidget(QDialog):
         wdg_layout.addWidget(self.preset_name_lineedit)
 
         return wdg
+
+    def _get_placeholder_name(self) -> str:
+        idx = sum("NewPreset" in p for p in self._mmc.getAvailableConfigs(self._group))
+        return f"NewPreset_{idx}" if idx > 0 else "NewPreset"
 
     def _create_bottom_wdg(self) -> QWidget:
 
@@ -145,10 +149,7 @@ class AddPresetWidget(QDialog):
             return
 
         if not preset_name:
-            idx = sum(
-                "NewPreset" in p for p in self._mmc.getAvailableConfigs(self._group)
-            )
-            preset_name = f"NewPreset_{idx}" if idx > 0 else "NewPreset"
+            preset_name = self.preset_name_lineedit.placeholderText()
 
         dev_prop_val = []
         for row in range(self.table.rowCount()):
@@ -179,6 +180,7 @@ class AddPresetWidget(QDialog):
 
         self.info_lbl.setStyleSheet("")
         self.info_lbl.setText(f"'{preset_name}' has been added!")
+        self.preset_name_lineedit.setPlaceholderText(self._get_placeholder_name())
 
 
 class _Table(QTableWidget):

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -80,6 +80,7 @@ class AddPresetWidget(QDialog):
         ps_lbl = QLabel(text="Preset:")
         ps_lbl.setSizePolicy(lbl_sizepolicy)
         self.preset_name_lineedit = QLineEdit()
+        self.preset_name_lineedit.setPlaceholderText("NewPreset")
 
         spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -138,7 +138,7 @@ class AddPresetWidget(QDialog):
         if preset_name in self._mmc.getAvailableConfigs(self._group):
             warnings.warn(f"There is already a preset called {preset_name}.")
             self.info_lbl.setStyleSheet("color: magenta;")
-            self.info_lbl.setText(f"{preset_name} already exist!")
+            self.info_lbl.setText(f"'{preset_name}' already exist!")
             return
 
         if not preset_name:
@@ -165,14 +165,14 @@ class AddPresetWidget(QDialog):
                     f"devices, properties and values: {p}."
                 )
                 self.info_lbl.setStyleSheet("color: magenta;")
-                self.info_lbl.setText(f"{p} already has the same properties!")
+                self.info_lbl.setText(f"'{p}' already has the same properties!")
                 return
 
         self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
             self._group, preset_name, dev_prop_val
         )
         self.info_lbl.setStyleSheet("")
-        self.info_lbl.setText(f"{preset_name} has been added!")
+        self.info_lbl.setText(f"'{preset_name}' has been added!")
 
 
 class _Table(QTableWidget):

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -174,7 +174,7 @@ class AddPresetWidget(QDialog):
             for d, p, v in dev_prop_val:
                 self._mmc.defineConfig(self._group, preset_name, d, p, v)
 
-        self._mmc.events.newGroupPreset.emit(self._group, preset_name, d, p, v)
+        self._mmc.events.configDefined.emit(self._group, preset_name, d, p, v)
 
         self.info_lbl.setStyleSheet("")
         self.info_lbl.setText(f"'{preset_name}' has been added!")

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -127,7 +127,7 @@ class AddPresetWidget(QDialog):
         for idx, (dev, prop) in enumerate(dev_prop):
             item = QTableWidgetItem(f"{dev}-{prop}")
             wdg = PropertyWidget(dev, prop, core=self._mmc)
-            wdg._value_widget.valueChanged.disconnect()
+            wdg._value_widget.valueChanged.disconnect()  # type: ignore
             self.table.setItem(idx, 0, item)
             self.table.setCellWidget(idx, 1, wdg)
 
@@ -168,7 +168,7 @@ class AddPresetWidget(QDialog):
                 self.info_lbl.setText(f"{p} already has the same properties!")
                 return
 
-        self._mmc.defineConfigFromDevicePropertyValueList(
+        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
             self._group, preset_name, dev_prop_val
         )
         self.info_lbl.setStyleSheet("")

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -322,4 +322,4 @@ class EditGroupWidget(QDialog):
                 self._group, preset, preset_dpv
             )
 
-        self.info_lbl.setText(f"{self._group} Group Modified.")
+        self.info_lbl.setText(f"'{self._group}' Group Modified.")

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -318,7 +318,7 @@ class EditGroupWidget(QDialog):
             if _to_add:
                 preset_dpv.extend(_to_add)
 
-            self._mmc.defineConfigFromDevicePropertyValueList(
+            self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
                 self._group, preset, preset_dpv
             )
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -24,6 +24,8 @@ from qtpy.QtWidgets import (
 from pymmcore_widgets._core import iter_dev_props
 from pymmcore_widgets._property_widget import PropertyWidget
 
+from .._util import block_core
+
 
 class _PropertyTable(QTableWidget):
     def __init__(
@@ -318,8 +320,10 @@ class EditGroupWidget(QDialog):
             if _to_add:
                 preset_dpv.extend(_to_add)
 
-            self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
-                self._group, preset, preset_dpv
-            )
+            with block_core(self._mmc.events):
+                for d, p, v in preset_dpv:
+                    self._mmc.defineConfig(self._group, preset, d, p, v)
+
+            self._mmc.events.newGroupPreset.emit(self._group, preset, d, p, v)
 
         self.info_lbl.setText(f"'{self._group}' Group Modified.")

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -324,6 +324,6 @@ class EditGroupWidget(QDialog):
                 for d, p, v in preset_dpv:
                     self._mmc.defineConfig(self._group, preset, d, p, v)
 
-            self._mmc.events.newGroupPreset.emit(self._group, preset, d, p, v)
+            self._mmc.events.configDefined.emit(self._group, preset, d, p, v)
 
         self.info_lbl.setText(f"'{self._group}' Group Modified.")

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -1,0 +1,315 @@
+from functools import partial
+from typing import Dict, List, Optional, Set, Tuple, cast
+
+from pymmcore_plus import DeviceType
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import (
+    QAbstractScrollArea,
+    QCheckBox,
+    QDialog,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pymmcore_widgets._core import get_core_singleton, iter_dev_props
+from pymmcore_widgets._property_widget import PropertyWidget
+
+
+class _PropertyTable(QTableWidget):
+    def __init__(
+        self, group: str = None, *, parent: Optional[QWidget] = None  # type: ignore
+    ) -> None:
+        super().__init__(0, 3, parent=parent)
+
+        self._mmc = get_core_singleton()
+        self._mmc.events.systemConfigurationLoaded.connect(self._rebuild_table)
+        self.destroyed.connect(self._disconnect)
+
+        self.setHorizontalHeaderLabels([" ", "Property", "Value"])
+        self.setColumnWidth(0, 250)
+        self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
+        vh = self.verticalHeader()
+        vh.setSectionResizeMode(vh.ResizeMode.Fixed)
+        vh.setDefaultSectionSize(24)
+        vh.setVisible(False)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.setSelectionMode(self.SelectionMode.NoSelection)
+
+        self._rebuild_table(group)
+
+    def _disconnect(self) -> None:
+        self._mmc.events.systemConfigurationLoaded.disconnect(self._rebuild_table)
+
+    def _get_group_dev_prop(self, group: str) -> List[Tuple[str, str]]:
+        presets = self._mmc.getAvailableConfigs(group)
+        return [(k[0], k[1]) for k in self._mmc.getConfigData(group, presets[0])]
+
+    def _rebuild_table(self, group: str = None) -> None:  # type: ignore
+
+        self.clearContents()
+
+        if group:
+            dev_prop = self._get_group_dev_prop(group)
+
+        props = list(iter_dev_props(self._mmc))
+        self.setRowCount(len(props))
+        for i, (dev, prop) in enumerate(props):
+            item = QTableWidgetItem(f"{dev}-{prop}")
+            _checkbox = QCheckBox()
+            _checkbox.setProperty("row", i)
+            if group and (dev, prop) in dev_prop:
+                _checkbox.setChecked(True)
+            self.setCellWidget(i, 0, _checkbox)
+            wdg = PropertyWidget(dev, prop, core=self._mmc)
+            wdg.setEnabled(False)
+            self.setItem(i, 1, item)
+            self.setCellWidget(i, 2, wdg)
+            if wdg.isReadOnly():
+                # TODO: make this more theme aware
+                item.setBackground(QColor("#AAA"))
+                wdg.setStyleSheet("QLabel { background-color : #AAA }")
+
+        self.resizeColumnsToContents()
+
+        # TODO: install eventFilter to prevent mouse wheel from scrolling sliders
+
+
+DevTypeLabels: Dict[str, Tuple[DeviceType, ...]] = {
+    "cameras": (DeviceType.CameraDevice,),
+    "shutters": (DeviceType.ShutterDevice,),
+    "stages": (DeviceType.StageDevice,),
+    "wheels, turrets, etc.": (DeviceType.StateDevice,),
+}
+_d: Set[DeviceType] = set.union(*(set(i) for i in DevTypeLabels.values()))
+DevTypeLabels["other devices"] = tuple(set(DeviceType) - _d)
+
+
+class EditGroupWidget(QDialog):
+    """Widget to edit the specified group."""
+
+    def __init__(self, group: str, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._mmc = get_core_singleton()
+
+        self._group = group
+
+        if self._group not in self._mmc.getAvailableConfigGroups():
+            return
+
+        self._mmc.events.systemConfigurationLoaded.connect(self._update_filter)
+
+        self._create_gui()
+
+        self.group_lineedit.setText(self._group)
+        self.group_lineedit.setEnabled(False)
+
+        self.destroyed.connect(self._disconnect)
+
+    # def closeEvent(self, event: QCloseEvent) -> None:
+    #     """Close also 'AddFirstPresetWidget' if is open."""
+    #     if hasattr(self, "_first_preset_wdg"):
+    #         self._first_preset_wdg.close()  # type: ignore
+    #     event.accept()
+
+    def _create_gui(self) -> None:
+
+        self.setWindowTitle("Create a new Group")
+
+        main_layout = QVBoxLayout()
+        main_layout.setSpacing(10)
+        main_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(main_layout)
+
+        group_lineedit = self._create_group_lineedit_wdg()
+        main_layout.addWidget(group_lineedit)
+
+        table = self._create_table_wdg()
+        main_layout.addWidget(table)
+
+        btn = self._create_button_wdg()
+        main_layout.addWidget(btn)
+
+        self._set_show_read_only(False)
+
+    def _create_group_lineedit_wdg(self) -> QGroupBox:
+
+        wdg = QGroupBox()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(10)
+        wdg.setLayout(layout)
+
+        group_lbl = QLabel(text="Group name:")
+        group_lbl.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
+
+        self.group_lineedit = QLineEdit()
+
+        layout.addWidget(group_lbl)
+        layout.addWidget(self.group_lineedit)
+
+        return wdg
+
+    def _create_table_wdg(self) -> QGroupBox:
+
+        wdg = QGroupBox()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(0)
+        wdg.setLayout(layout)
+
+        self._prop_table = _PropertyTable(self._group)
+        self._show_read_only: bool = False
+
+        self._filters: Set[DeviceType] = set()
+        self._filter_text = QLineEdit()
+        self._filter_text.setClearButtonEnabled(True)
+        self._filter_text.setPlaceholderText("Filter by device or property name...")
+        self._filter_text.textChanged.connect(self._update_filter)
+
+        right = QWidget()
+        right.setLayout(QVBoxLayout())
+        right.layout().addWidget(self._filter_text)
+        right.layout().addWidget(self._prop_table)
+
+        left = QWidget()
+        left.setLayout(QVBoxLayout())
+        left.layout().addWidget(self._make_checkboxes())
+
+        self.layout().addWidget(left)
+        self.layout().addWidget(right)
+        layout.addWidget(left)
+        layout.addWidget(right)
+
+        return wdg
+
+    def _create_button_wdg(self) -> QWidget:
+
+        wdg = QWidget()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        wdg.setLayout(layout)
+
+        self.info_lbl = QLabel()
+
+        self.new_group_btn = QPushButton(text="Create New Group")
+        self.new_group_btn.setSizePolicy(
+            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        )
+        self.new_group_btn.clicked.connect(self._add_group)
+
+        layout.addWidget(self.info_lbl)
+        layout.addWidget(self.new_group_btn)
+
+        return wdg
+
+    def _disconnect(self) -> None:
+        self._mmc.events.systemConfigurationLoaded.disconnect(self._update_filter)
+
+    def _update_filter(self) -> None:
+        filt = self._filter_text.text().lower()
+        for r in range(self._prop_table.rowCount()):
+            wdg = cast(PropertyWidget, self._prop_table.cellWidget(r, 2))
+            if wdg.isReadOnly() and not self._show_read_only:  # sourcery skip
+                self._prop_table.hideRow(r)
+            elif wdg.deviceType() in self._filters:
+                self._prop_table.hideRow(r)
+            elif filt and filt not in self._prop_table.item(r, 1).text().lower():
+                self._prop_table.hideRow(r)
+            else:
+                self._prop_table.showRow(r)
+
+    def _toggle_filter(self, label: str) -> None:
+        self._filters.symmetric_difference_update(DevTypeLabels[label])
+        self._update_filter()
+
+    def _make_checkboxes(self) -> QWidget:
+        dev_gb = QGroupBox("Device Type")
+        dev_gb.setLayout(QGridLayout())
+        dev_gb.layout().setSpacing(6)
+        all_btn = QPushButton("All")
+        dev_gb.layout().addWidget(all_btn, 0, 0, 1, 1)
+        none_btn = QPushButton("None")
+        dev_gb.layout().addWidget(none_btn, 0, 1, 1, 1)
+        for i, (label, devtypes) in enumerate(DevTypeLabels.items()):
+            cb = QCheckBox(label)
+            cb.setChecked(devtypes[0] not in self._filters)
+            cb.toggled.connect(partial(self._toggle_filter, label))
+            dev_gb.layout().addWidget(cb, i + 1, 0, 1, 2)
+
+        @all_btn.clicked.connect  # type: ignore
+        def _check_all() -> None:
+            for cxbx in dev_gb.findChildren(QCheckBox):
+                cxbx.setChecked(True)
+
+        @none_btn.clicked.connect  # type: ignore
+        def _check_none() -> None:
+            for cxbx in dev_gb.findChildren(QCheckBox):
+                cxbx.setChecked(False)
+
+        for i in dev_gb.findChildren(QWidget):
+            i.setFocusPolicy(Qt.FocusPolicy.NoFocus)  # type: ignore
+
+        ro = QCheckBox("Show read-only")
+        ro.setChecked(self._show_read_only)
+        ro.toggled.connect(self._set_show_read_only)
+        ro.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
+        c = QWidget()
+        c.setLayout(QVBoxLayout())
+        c.layout().addWidget(dev_gb)
+        c.layout().addWidget(ro)
+        c.layout().addStretch()
+        return c
+
+    def _set_show_read_only(self, state: bool) -> None:
+        self._show_read_only = state
+        self._update_filter()
+
+    def _add_group(self) -> None:
+        pass
+        # group = self.group_lineedit.text()
+
+        # if not group:
+        #     warnings.warn("Give a name to the group!")
+        #     self.info_lbl.setStyleSheet("color: magenta;")
+        #     self.info_lbl.setText("Give a name to the group!")
+        #     return
+
+        # if group in self._mmc.getAvailableConfigGroups():
+        #     warnings.warn(f"There is already a preset called {group}.")
+        #     self.info_lbl.setStyleSheet("color: magenta;")
+        #     self.info_lbl.setText(f"{group} already exist!!")
+        #     return
+
+        # dev_prop_val_list = []
+        # for r in range(self._prop_table.rowCount()):
+        #     checkbox = cast(QCheckBox, self._prop_table.cellWidget(r, 0))
+        #     if checkbox.isChecked():
+        #         row = checkbox.property("row")
+        #         dev_prop = self._prop_table.item(row, 1).text()
+        #         dev = dev_prop.split("-")[0]
+        #         prop = dev_prop.split("-")[1]
+        #         value = self._prop_table.cellWidget(row, 2).value()
+
+        #         dev_prop_val_list.append((dev, prop, str(value)))
+
+        # if hasattr(self, "_first_preset_wdg"):
+        #     self._first_preset_wdg.close()  # type: ignore
+        # self._first_preset_wdg = AddFirstPresetWidget(
+        #     group, "NewPreset", dev_prop_val_list, parent=self
+        # )
+        # self._first_preset_wdg.show()
+
+        # self.info_lbl.setStyleSheet("")
+        # self.info_lbl.setText("")

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -1,0 +1,169 @@
+# Simple table with the properties options
+from typing import Optional
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSizePolicy,
+    QSpacerItem,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pymmcore_widgets._core import get_core_singleton
+from pymmcore_widgets._property_widget import PropertyWidget
+
+
+class EditPresetWidget(QDialog):
+    """A widget to edit a specified group's presets."""
+
+    def __init__(
+        self, group: str, preset: str, *, parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+
+        self._mmc = get_core_singleton()
+        self._group = group
+        self._preset = preset
+
+        self._create_gui()
+
+        self._populate_table()
+
+    def _create_gui(self) -> None:
+
+        main_layout = QVBoxLayout()
+        main_layout.setSpacing(0)
+        main_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(main_layout)
+
+        wdg = QWidget()
+        wdg_layout = QVBoxLayout()
+        wdg_layout.setSpacing(10)
+        wdg_layout.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(wdg_layout)
+
+        top_wdg = self._create_top_wdg()
+        wdg_layout.addWidget(top_wdg)
+
+        self.table = _Table()
+        wdg_layout.addWidget(self.table)
+
+        bottom_wdg = self._create_bottom_wdg()
+        wdg_layout.addWidget(bottom_wdg)
+
+        main_layout.addWidget(wdg)
+
+    def _create_top_wdg(self) -> QGroupBox:
+        wdg = QGroupBox()
+        wdg_layout = QHBoxLayout()
+        wdg_layout.setSpacing(5)
+        wdg_layout.setContentsMargins(5, 5, 5, 5)
+        wdg.setLayout(wdg_layout)
+
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        gp_lbl = QLabel(text="Group:")
+        gp_lbl.setSizePolicy(lbl_sizepolicy)
+        group_name_lbl = QLabel(text=f"{self._group}")
+        group_name_lbl.setSizePolicy(lbl_sizepolicy)
+
+        ps_lbl = QLabel(text="Preset:")
+        ps_lbl.setSizePolicy(lbl_sizepolicy)
+        self.preset_name_lineedit = QLineEdit()
+        self.preset_name_lineedit.setText(f"{self._preset}")
+
+        spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        wdg_layout.addWidget(gp_lbl)
+        wdg_layout.addWidget(group_name_lbl)
+        wdg_layout.addItem(spacer)
+        wdg_layout.addWidget(ps_lbl)
+        wdg_layout.addWidget(self.preset_name_lineedit)
+
+        return wdg
+
+    def _create_bottom_wdg(self) -> QWidget:
+
+        wdg = QWidget()
+        wdg_layout = QHBoxLayout()
+        wdg_layout.setSpacing(5)
+        wdg_layout.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(wdg_layout)
+
+        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.apply_button = QPushButton(text="Apply Changes")
+        self.apply_button.clicked.connect(self._apply_changes)
+
+        wdg_layout.addItem(spacer)
+        wdg_layout.addWidget(self.apply_button)
+
+        return wdg
+
+    def _populate_table(self) -> None:
+
+        self.table.clearContents()
+
+        dev_prop = [
+            (k[0], k[1]) for k in self._mmc.getConfigData(self._group, self._preset)
+        ]
+        self.table.setRowCount(len(dev_prop))
+        for idx, (dev, prop) in enumerate(dev_prop):
+            item = QTableWidgetItem(f"{dev}-{prop}")
+            wdg = PropertyWidget(dev, prop, core=self._mmc)
+            self.table.setItem(idx, 0, item)
+            self.table.setCellWidget(idx, 1, wdg)
+
+    def _apply_changes(self) -> None:
+
+        dev_prop_val = []
+        for row in range(self.table.rowCount()):
+            device_property = self.table.item(row, 0).text()
+            dev = device_property.split("-")[0]
+            prop = device_property.split("-")[1]
+            value = self.table.cellWidget(row, 1).value()
+            dev_prop_val.append((dev, prop, value))
+
+        self._mmc.deleteConfig(self._group, self._preset)
+
+        self._preset = self.preset_name_lineedit.text()
+
+        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
+            self._group, self._preset, dev_prop_val
+        )
+
+
+class _Table(QTableWidget):
+    """Set table properties for EditPresetWidget."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        hdr = self.horizontalHeader()
+        hdr.setSectionResizeMode(hdr.Stretch)
+        hdr.setDefaultAlignment(Qt.AlignHCenter)
+        vh = self.verticalHeader()
+        vh.setVisible(False)
+        vh.setSectionResizeMode(vh.Fixed)
+        vh.setDefaultSectionSize(24)
+        self.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.setColumnCount(2)
+        self.setHorizontalHeaderLabels(["Device-Property", "Value"])
+
+
+if __name__ == "__main__":
+    from qtpy.QtWidgets import QApplication
+
+    cfg = "/Users/FG/Dropbox/git/pymmcore-widgets/tests/test_config.cfg"
+    mmc = get_core_singleton()
+    mmc.loadSystemConfiguration(cfg)
+    app = QApplication([])
+    table = EditPresetWidget("Channel", "FITC")
+    table.show()
+    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -1,4 +1,4 @@
-# Simple table with the properties options
+import warnings
 from typing import Optional
 
 from qtpy.QtCore import Qt
@@ -139,6 +139,19 @@ class EditPresetWidget(QDialog):
             value = str(self.table.cellWidget(row, 1).value())
             dev_prop_val.append((dev, prop, value))
 
+        for p in self._mmc.getAvailableConfigs(self._group):
+            dpv_preset = [
+                (k[0], k[1], k[2]) for k in self._mmc.getConfigData(self._group, p)
+            ]
+            if dpv_preset == dev_prop_val:
+                warnings.warn(
+                    "Threre is already a preset with the same "
+                    f"devices, properties and values: {p}."
+                )
+                self.info_lbl.setStyleSheet("color: magenta;")
+                self.info_lbl.setText(f"{p} already has the same properties!")
+                return
+
         self._mmc.deleteConfig(self._group, self._preset)
 
         self._preset = self.preset_name_lineedit.text()
@@ -147,6 +160,7 @@ class EditPresetWidget(QDialog):
             self._group, self._preset, dev_prop_val
         )
 
+        self.info_lbl.setStyleSheet("")
         self.info_lbl.setText(f"{self._preset} has been modified!")
 
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -98,11 +98,14 @@ class EditPresetWidget(QDialog):
         wdg_layout.setContentsMargins(0, 0, 0, 0)
         wdg.setLayout(wdg_layout)
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.info_lbl = QLabel()
         self.apply_button = QPushButton(text="Apply Changes")
+        self.apply_button.setSizePolicy(
+            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        )
         self.apply_button.clicked.connect(self._apply_changes)
 
-        wdg_layout.addItem(spacer)
+        wdg_layout.addWidget(self.info_lbl)
         wdg_layout.addWidget(self.apply_button)
 
         return wdg
@@ -135,9 +138,11 @@ class EditPresetWidget(QDialog):
 
         self._preset = self.preset_name_lineedit.text()
 
-        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
+        self._mmc.defineConfigFromDevicePropertyValueList(
             self._group, self._preset, dev_prop_val
         )
+
+        self.info_lbl.setText(f"{self._preset} has been modified!")
 
 
 class _Table(QTableWidget):

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -125,7 +125,7 @@ class EditPresetWidget(QDialog):
         for idx, (dev, prop) in enumerate(dev_prop):
             item = QTableWidgetItem(f"{dev}-{prop}")
             wdg = PropertyWidget(dev, prop, core=self._mmc)
-            wdg._value_widget.valueChanged.disconnect()
+            wdg._value_widget.valueChanged.disconnect()  # type: ignore
             self.table.setItem(idx, 0, item)
             self.table.setCellWidget(idx, 1, wdg)
 
@@ -143,7 +143,7 @@ class EditPresetWidget(QDialog):
 
         self._preset = self.preset_name_lineedit.text()
 
-        self._mmc.defineConfigFromDevicePropertyValueList(
+        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
             self._group, self._preset, dev_prop_val
         )
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -22,6 +22,8 @@ from superqt.utils import signals_blocked
 
 from pymmcore_widgets._property_widget import PropertyWidget
 
+from .._util import block_core
+
 
 class EditPresetWidget(QDialog):
     """A widget to edit a specified group's presets."""
@@ -207,9 +209,11 @@ class EditPresetWidget(QDialog):
 
         self._preset = self.preset_name_lineedit.text()
 
-        self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
-            self._group, self._preset, dev_prop_val
-        )
+        with block_core(self._mmc.events):
+            for d, p, v in dev_prop_val:
+                self._mmc.defineConfig(self._group, self._preset, d, p, v)
+
+        self._mmc.events.newGroupPreset.emit(self._group, self._preset, d, p, v)
 
         self._update_combo()
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -71,7 +71,8 @@ class EditPresetWidget(QDialog):
 
     def _resize(self) -> None:
         self.resize(
-            self.sizeHint().width() + self._presets_combo.sizeHint().width(),
+            self.minimumSizeHint().width()
+            + self._presets_combo.minimumSizeHint().width(),
             self.sizeHint().height(),
         )
 
@@ -96,6 +97,9 @@ class EditPresetWidget(QDialog):
         ps_lbl = QLabel(text="Preset:")
         ps_lbl.setSizePolicy(lbl_sizepolicy)
         self.preset_name_lineedit = QLineEdit()
+        self.preset_name_lineedit.setSizePolicy(
+            QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        )
         self.preset_name_lineedit.setText(f"{self._preset}")
 
         spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -125,6 +125,7 @@ class EditPresetWidget(QDialog):
         for idx, (dev, prop) in enumerate(dev_prop):
             item = QTableWidgetItem(f"{dev}-{prop}")
             wdg = PropertyWidget(dev, prop, core=self._mmc)
+            wdg._value_widget.valueChanged.disconnect()
             self.table.setItem(idx, 0, item)
             self.table.setCellWidget(idx, 1, wdg)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -39,7 +39,7 @@ class EditPresetWidget(QDialog):
 
         self._populate_table_and_combo()
 
-    def _create_gui(self) -> None:
+    def _create_gui(self) -> None:  # sourcery skip: class-extract-method
 
         self.setWindowTitle(
             f"Edit the '{self._preset}' Preset from the '{self._group}' Group"
@@ -70,7 +70,6 @@ class EditPresetWidget(QDialog):
         self._resize()
 
     def _resize(self) -> None:
-
         self.resize(
             self.sizeHint().width() + self._presets_combo.sizeHint().width(),
             self.sizeHint().height(),
@@ -138,7 +137,13 @@ class EditPresetWidget(QDialog):
             self._presets_combo.addItems(presets)
             self._presets_combo.setCurrentText(self._preset)
             self.preset_name_lineedit.setText(f"{self._preset}")
+            self._resize_combo_height(len(presets))
         self._resize()
+
+    def _resize_combo_height(self, max_items: int) -> None:
+        self._presets_combo.setEditable(True)
+        self._presets_combo.setMaxVisibleItems(max_items)
+        self._presets_combo.setEditable(False)
 
     def _populate_table_and_combo(self) -> None:
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -39,6 +39,10 @@ class EditPresetWidget(QDialog):
 
     def _create_gui(self) -> None:
 
+        self.setWindowTitle(
+            f"Edit the '{self._preset}' Preset from the '{self._group}' Group"
+        )
+
         main_layout = QVBoxLayout()
         main_layout.setSpacing(0)
         main_layout.setContentsMargins(10, 10, 10, 10)
@@ -160,15 +164,3 @@ class _Table(QTableWidget):
         self.setEditTriggers(QTableWidget.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Device-Property", "Value"])
-
-
-if __name__ == "__main__":
-    from qtpy.QtWidgets import QApplication
-
-    cfg = "/Users/FG/Dropbox/git/pymmcore-widgets/tests/test_config.cfg"
-    mmc = get_core_singleton()
-    mmc.loadSystemConfiguration(cfg)
-    app = QApplication([])
-    table = EditPresetWidget("Channel", "FITC")
-    table.show()
-    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -149,7 +149,7 @@ class EditPresetWidget(QDialog):
                     f"devices, properties and values: {p}."
                 )
                 self.info_lbl.setStyleSheet("color: magenta;")
-                self.info_lbl.setText(f"{p} already has the same properties!")
+                self.info_lbl.setText(f"'{p}' already has the same properties!")
                 return
 
         self._mmc.deleteConfig(self._group, self._preset)
@@ -161,7 +161,7 @@ class EditPresetWidget(QDialog):
         )
 
         self.info_lbl.setStyleSheet("")
-        self.info_lbl.setText(f"{self._preset} has been modified!")
+        self.info_lbl.setText(f"'{self._preset}' has been modified!")
 
 
 class _Table(QTableWidget):

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -131,7 +131,7 @@ class EditPresetWidget(QDialog):
             device_property = self.table.item(row, 0).text()
             dev = device_property.split("-")[0]
             prop = device_property.split("-")[1]
-            value = self.table.cellWidget(row, 1).value()
+            value = str(self.table.cellWidget(row, 1).value())
             dev_prop_val.append((dev, prop, value))
 
         self._mmc.deleteConfig(self._group, self._preset)

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -213,7 +213,7 @@ class EditPresetWidget(QDialog):
             for d, p, v in dev_prop_val:
                 self._mmc.defineConfig(self._group, self._preset, d, p, v)
 
-        self._mmc.events.newGroupPreset.emit(self._group, self._preset, d, p, v)
+        self._mmc.events.configDefined.emit(self._group, self._preset, d, p, v)
 
         self._update_combo()
 

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -164,7 +164,7 @@ class GroupPresetTableWidget(QtW.QWidget):
             if isinstance(wdg, PresetsWidget):
                 wdg._disconnect()
             elif isinstance(wdg, PropertyWidget):
-                wdg._value_widget.destroy()  # type: ignore
+                wdg._value_widget.destroy()
 
     def _populate_table(self) -> None:
         self._reset_table()
@@ -177,7 +177,7 @@ class GroupPresetTableWidget(QtW.QWidget):
                 if isinstance(wdg, PresetsWidget):
                     wdg = wdg._combo
                 elif isinstance(wdg, PropertyWidget):
-                    wdg = wdg._value_widget  # type: ignore
+                    wdg = wdg._value_widget
 
     def _get_cfg_data(self, group: str, preset: str) -> Tuple[str, str, str, int]:
         # Return last device-property-value for the preset and the
@@ -288,7 +288,8 @@ class GroupPresetTableWidget(QtW.QWidget):
         (filename, _) = QtW.QFileDialog.getSaveFileName(
             self, "Save Micro-Manager Configuration."
         )
-        self._mmc.saveSystemConfiguration(filename)
+        if filename:
+            self._mmc.saveSystemConfiguration(filename)
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._populate_table)

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -44,8 +44,8 @@ class GroupPresetTableWidget(QtW.QGroupBox):
         self._mmc = CMMCorePlus.instance()
         self._mmc.events.systemConfigurationLoaded.connect(self._populate_table)
 
-        self._mmc.events.groupDeleted.connect(self._on_group_deleted)
-        self._mmc.events.newGroupPreset.connect(self._on_new_group_preset)
+        self._mmc.events.configGroupDeleted.connect(self._on_group_deleted)
+        self._mmc.events.configDefined.connect(self._on_new_group_preset)
 
         self._create_gui()
 
@@ -334,5 +334,5 @@ class GroupPresetTableWidget(QtW.QGroupBox):
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._populate_table)
-        self._mmc.events.groupDeleted.disconnect(self._on_group_deleted)
-        self._mmc.events.newGroupPreset.disconnect(self._on_new_group_preset)
+        self._mmc.events.configGroupDeleted.disconnect(self._on_group_deleted)
+        self._mmc.events.configDefined.disconnect(self._on_new_group_preset)

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -241,9 +241,11 @@ class GroupPresetTableWidget(QtW.QWidget):
         if isinstance(wdg, PropertyWidget):
             return
 
-        if not hasattr(self, "add_preset"):
-            add_preset = AddPresetWidget(group, parent=self)
-        add_preset.show()
+        if not hasattr(self, "_add_preset_wdg"):
+            self._add_preset_wdg = AddPresetWidget(group, parent=self)
+        if hasattr(self, "_edit_table_wgd"):
+            self._edit_table_wgd.close()
+        self._add_preset_wdg.show()
 
     def _delete_preset(self) -> None:
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
@@ -280,9 +282,11 @@ class GroupPresetTableWidget(QtW.QWidget):
             return
         if isinstance(wdg, PresetsWidget):
             preset = wdg._combo.currentText()
-        if not hasattr(self, "edit_table"):
-            edit_table = EditPresetWidget(group, preset, parent=self)
-        edit_table.show()
+        if not hasattr(self, "_edit_table_wgd"):
+            self._edit_table_wgd = EditPresetWidget(group, preset, parent=self)
+        if hasattr(self, "_add_preset_wdg"):
+            self._add_preset_wdg.close()
+        self._edit_table_wgd.show()
 
     def _save_cfg(self) -> None:
         (filename, _) = QtW.QFileDialog.getSaveFileName(

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -270,7 +270,7 @@ class GroupPresetTableWidget(QtW.QWidget):
         row = list(selected_rows)[0]
         group = self.table_wdg.item(row, 0).text()
         self._close_if_hasattr()
-        self._edit_group_wdg = EditGroupWidget(group)
+        self._edit_group_wdg = EditGroupWidget(group, parent=self)
         self._edit_group_wdg.show()
 
     def _add_preset(self) -> None:

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -5,11 +5,6 @@ from qtpy import QtWidgets as QtW
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout
 
-# from ._core import get_core_singleton
-# from ._presets_widget import PresetsWidget
-# from ._property_widget import PropertyWidget
-# from ._edit_preset_widget import EditPresetWidget
-# from ._add_preset_widget import AddPresetWidget
 from pymmcore_widgets._core import get_core_singleton
 from pymmcore_widgets._group_preset_widget._add_group_widget import AddGroupWidget
 from pymmcore_widgets._group_preset_widget._add_preset_widget import AddPresetWidget
@@ -17,6 +12,11 @@ from pymmcore_widgets._group_preset_widget._edit_group_widget import EditGroupWi
 from pymmcore_widgets._group_preset_widget._edit_preset_widget import EditPresetWidget
 from pymmcore_widgets._presets_widget import PresetsWidget
 from pymmcore_widgets._property_widget import PropertyWidget
+
+# from ._add_group_widget import AddGroupWidget
+# from ._add_preset_widget import AddPresetWidget
+# from ._edit_group_widget import EditGroupWidget
+# from ._edit_preset_widget import EditPresetWidget
 
 
 class _MainTable(QtW.QTableWidget):
@@ -34,6 +34,7 @@ class _MainTable(QtW.QTableWidget):
         self.setEditTriggers(QtW.QTableWidget.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Group", "Preset"])
+        self.setMinimumHeight(200)
 
 
 class GroupPresetTableWidget(QtW.QWidget):
@@ -230,15 +231,20 @@ class GroupPresetTableWidget(QtW.QWidget):
         else:
             return PropertyWidget(device, property)
 
-    def _add_group(self) -> None:
+    def _close_if_hasattr(self) -> None:
+        attr_list = [
+            "_add_group_wdg",
+            "_edit_preset_wgd",
+            "_add_preset_wdg",
+            "_edit_group_wdg",
+        ]
+        for i in attr_list:
+            if hasattr(self, i):
+                getattr(self, i).close()
 
-        if hasattr(self, "_add_group_wdg"):
-            self._add_group_wdg.close()  # type: ignore
+    def _add_group(self) -> None:
+        self._close_if_hasattr()
         self._add_group_wdg = AddGroupWidget(parent=self)
-        if hasattr(self, "_edit_table_wgd"):
-            self._edit_table_wgd.close()  # type: ignore
-        if hasattr(self, "_add_preset_wdg"):
-            self._add_preset_wdg.close()  # type: ignore
         self._add_group_wdg.show()
 
     def _delete_group(self) -> None:
@@ -263,9 +269,7 @@ class GroupPresetTableWidget(QtW.QWidget):
 
         row = list(selected_rows)[0]
         group = self.table_wdg.item(row, 0).text()
-
-        if hasattr(self, "_edit_group_wdg"):
-            self._edit_group_wdg.close()  # type: ignore
+        self._close_if_hasattr()
         self._edit_group_wdg = EditGroupWidget(group)
         self._edit_group_wdg.show()
 
@@ -281,12 +285,8 @@ class GroupPresetTableWidget(QtW.QWidget):
         if isinstance(wdg, PropertyWidget):
             return
 
-        if hasattr(self, "_add_preset_wdg"):
-            self._add_preset_wdg.close()  # type: ignore
+        self._close_if_hasattr()
         self._add_preset_wdg = AddPresetWidget(group, parent=self)
-
-        if hasattr(self, "_edit_table_wgd"):
-            self._edit_table_wgd.close()  # type: ignore
         self._add_preset_wdg.show()
 
     def _delete_preset(self) -> None:
@@ -324,12 +324,9 @@ class GroupPresetTableWidget(QtW.QWidget):
             return
         if isinstance(wdg, PresetsWidget):
             preset = wdg._combo.currentText()
-        if hasattr(self, "_edit_table_wgd"):
-            self._edit_table_wgd.close()  # type: ignore
-        self._edit_table_wgd = EditPresetWidget(group, preset, parent=self)
-        if hasattr(self, "_add_preset_wdg"):
-            self._add_preset_wdg.close()
-        self._edit_table_wgd.show()
+        self._close_if_hasattr()
+        self._edit_preset_wgd = EditPresetWidget(group, preset, parent=self)
+        self._edit_preset_wgd.show()
 
     def _save_cfg(self) -> None:
         (filename, _) = QtW.QFileDialog.getSaveFileName(

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -209,12 +209,13 @@ class GroupPresetTableWidget(QtW.QWidget):
 
     def _add_group(self) -> None:
 
-        if not hasattr(self, "_add_group_wdg"):
-            self._add_group_wdg = AddGroupWidget(parent=self)
+        if hasattr(self, "_add_group_wdg"):
+            self._add_group_wdg.close()  # type: ignore
+        self._add_group_wdg = AddGroupWidget(parent=self)
         if hasattr(self, "_edit_table_wgd"):
-            self._edit_table_wgd.close()
+            self._edit_table_wgd.close()  # type: ignore
         if hasattr(self, "_add_preset_wdg"):
-            self._add_preset_wdg.close()
+            self._add_preset_wdg.close()  # type: ignore
         self._add_group_wdg.show()
 
     def _delete_group(self) -> None:
@@ -249,10 +250,12 @@ class GroupPresetTableWidget(QtW.QWidget):
         if isinstance(wdg, PropertyWidget):
             return
 
-        if not hasattr(self, "_add_preset_wdg"):
-            self._add_preset_wdg = AddPresetWidget(group, parent=self)
+        if hasattr(self, "_add_preset_wdg"):
+            self._add_preset_wdg.close()  # type: ignore
+        self._add_preset_wdg = AddPresetWidget(group, parent=self)
+
         if hasattr(self, "_edit_table_wgd"):
-            self._edit_table_wgd.close()
+            self._edit_table_wgd.close()  # type: ignore
         self._add_preset_wdg.show()
 
     def _delete_preset(self) -> None:
@@ -290,8 +293,9 @@ class GroupPresetTableWidget(QtW.QWidget):
             return
         if isinstance(wdg, PresetsWidget):
             preset = wdg._combo.currentText()
-        if not hasattr(self, "_edit_table_wgd"):
-            self._edit_table_wgd = EditPresetWidget(group, preset, parent=self)
+        if hasattr(self, "_edit_table_wgd"):
+            self._edit_table_wgd.close()  # type: ignore
+        self._edit_table_wgd = EditPresetWidget(group, preset, parent=self)
         if hasattr(self, "_add_preset_wdg"):
             self._add_preset_wdg.close()
         self._edit_table_wgd.show()

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -41,6 +41,7 @@ class _MainTable(QTableWidget):
         vh.setSectionResizeMode(vh.Fixed)
         vh.setDefaultSectionSize(24)
         self.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.setSelectionBehavior(QTableWidget.SelectRows)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Group", "Preset"])
         self.setMinimumHeight(200)
@@ -87,10 +88,13 @@ class GroupPresetTableWidget(QGroupBox):
         self.layout().addWidget(save_btn)
 
         self.table_wdg = _MainTable()
+        self.table_wdg.itemSelectionChanged.connect(self._on_table_selection_changed)
         self.layout().addWidget(self.table_wdg)
 
         btns = self._add_groups_presets_buttons()
         self.layout().addWidget(btns)
+
+        self._enable_buttons(False)
 
     def _add_groups_presets_buttons(self) -> QWidget:
 
@@ -163,6 +167,20 @@ class GroupPresetTableWidget(QGroupBox):
         save_btn_layout.addWidget(self.save_btn)
 
         return save_btn_wdg
+
+    def _on_table_selection_changed(self) -> None:
+        selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
+        if not selected_rows or len(selected_rows) > 1:
+            self._enable_buttons(False)
+        else:
+            self._enable_buttons(True)
+
+    def _enable_buttons(self, enabled: bool) -> None:
+        self.groups_remove_btn.setEnabled(enabled)
+        self.groups_edit_btn.setEnabled(enabled)
+        self.presets_add_btn.setEnabled(enabled)
+        self.presets_remove_btn.setEnabled(enabled)
+        self.presets_edit_btn.setEnabled(enabled)
 
     def _on_system_cfg_loaded(self) -> None:
         self._populate_table()

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import QVBoxLayout
 from pymmcore_widgets._core import get_core_singleton
 from pymmcore_widgets._group_preset_widget._add_group_widget import AddGroupWidget
 from pymmcore_widgets._group_preset_widget._add_preset_widget import AddPresetWidget
+from pymmcore_widgets._group_preset_widget._edit_group_widget import EditGroupWidget
 from pymmcore_widgets._group_preset_widget._edit_preset_widget import EditPresetWidget
 from pymmcore_widgets._presets_widget import PresetsWidget
 from pymmcore_widgets._property_widget import PropertyWidget
@@ -167,7 +168,7 @@ class GroupPresetTableWidget(QtW.QWidget):
                             f"{dev_prop_1} are not included in the group "
                             "and will not be added!"
                         )
-                        self._mmc.deletePresetDeviceProperties(  # type: ignore
+                        self._mmc.deletePresetDeviceProperties(
                             group, preset, dev_prop_1, emit=False
                         )
                     else:
@@ -200,7 +201,7 @@ class GroupPresetTableWidget(QtW.QWidget):
                 if isinstance(wdg, PresetsWidget):
                     wdg = wdg._combo
                 elif isinstance(wdg, PropertyWidget):
-                    wdg = wdg._value_widget  # type: ignore
+                    wdg = wdg._value_widget
 
     def _get_cfg_data(self, group: str, preset: str) -> Tuple[str, str, str, int]:
         # Return last device-property-value for the preset and the
@@ -259,6 +260,14 @@ class GroupPresetTableWidget(QtW.QWidget):
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
         if not selected_rows or len(selected_rows) > 1:
             return
+
+        row = list(selected_rows)[0]
+        group = self.table_wdg.item(row, 0).text()
+
+        if hasattr(self, "_edit_group_wdg"):
+            self._edit_group_wdg.close()  # type: ignore
+        self._edit_group_wdg = EditGroupWidget(group)
+        self._edit_group_wdg.show()
 
     def _add_preset(self) -> None:
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -169,7 +169,7 @@ class GroupPresetTableWidget(QtW.QWidget):
                             f"{dev_prop_1} are not included in the group "
                             "and will not be added!"
                         )
-                        self._mmc.deletePresetDeviceProperties(
+                        self._mmc.deletePresetDeviceProperties(  # type: ignore
                             group, preset, dev_prop_1, emit=False
                         )
                     else:
@@ -202,7 +202,7 @@ class GroupPresetTableWidget(QtW.QWidget):
                 if isinstance(wdg, PresetsWidget):
                     wdg = wdg._combo
                 elif isinstance(wdg, PropertyWidget):
-                    wdg = wdg._value_widget
+                    wdg = wdg._value_widget  # type: ignore
 
     def _get_cfg_data(self, group: str, preset: str) -> Tuple[str, str, str, int]:
         # Return last device-property-value for the preset and the

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -10,6 +10,7 @@ from qtpy.QtWidgets import QVBoxLayout
 # from ._edit_preset_widget import EditPresetWidget
 # from ._add_preset_widget import AddPresetWidget
 from pymmcore_widgets._core import get_core_singleton
+from pymmcore_widgets._group_preset_widget._add_group_widget import AddGroupWidget
 from pymmcore_widgets._group_preset_widget._add_preset_widget import AddPresetWidget
 from pymmcore_widgets._group_preset_widget._edit_preset_widget import EditPresetWidget
 from pymmcore_widgets._presets_widget import PresetsWidget
@@ -207,7 +208,14 @@ class GroupPresetTableWidget(QtW.QWidget):
             return PropertyWidget(device, property)
 
     def _add_group(self) -> None:
-        pass
+
+        if not hasattr(self, "_add_group_wdg"):
+            self._add_group_wdg = AddGroupWidget(parent=self)
+        if hasattr(self, "_edit_table_wgd"):
+            self._edit_table_wgd.close()
+        if hasattr(self, "_add_preset_wdg"):
+            self._add_preset_wdg.close()
+        self._add_group_wdg.show()
 
     def _delete_group(self) -> None:
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -163,9 +163,11 @@ class GroupPresetTableWidget(QtW.QGroupBox):
                             f"{dev_prop_1} are not included in the group "
                             "and will not be added!"
                         )
-                        self._mmc.deletePresetDeviceProperties(  # type: ignore
-                            group, preset, dev_prop_1, emit=False
-                        )
+
+                        with self._mmc.events.newGroupPreset.blocked():
+                            self._mmc.deletePresetDeviceProperties(  # type: ignore
+                                group, preset, dev_prop_1
+                            )
                     else:
                         self._mmc.deleteConfig(group, preset)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import List, Tuple, Union
 
 from pymmcore_plus import CMMCorePlus
@@ -151,30 +150,18 @@ class GroupPresetTableWidget(QtW.QGroupBox):
             row = matching_item[0].row()
 
             if isinstance(self.table_wdg.cellWidget(row, 1), PropertyWidget):
-                _presets = self._mmc.getAvailableConfigs(group)
-                if len(_presets) > 1:
-                    dev_prop_0 = [
-                        (k[0], k[1])
-                        for k in self._mmc.getConfigData(group, _presets[0])
-                    ]
-                    dev_prop_1 = [(k[0], k[1]) for k in dev_prop_val_list]
-                    if dev_prop_1 != dev_prop_0:
-                        warnings.warn(
-                            f"{dev_prop_1} are not included in the group "
-                            "and will not be added!"
-                        )
 
-                        with self._mmc.events.newGroupPreset.blocked():
-                            self._mmc.deletePresetDeviceProperties(  # type: ignore
-                                group, preset, dev_prop_1
-                            )
-                    else:
-                        self._mmc.deleteConfig(group, preset)
+                dev_prop_val = [
+                    (k[0], k[1], k[2]) for k in self._mmc.getConfigData(group, preset)
+                ]
 
-                self._populate_table()
+                self._mmc.deleteConfigGroup(group)
 
-        else:
-            self._populate_table()
+                self._mmc.defineConfigFromDevicePropertyValueList(  # type: ignore
+                    group, preset, dev_prop_val + dev_prop_val_list
+                )
+
+        self._populate_table()
 
     def _reset_table(self) -> None:
         self._disconnect_wdgs()

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -7,7 +7,11 @@ from qtpy.QtWidgets import QVBoxLayout
 # from ._core import get_core_singleton
 # from ._presets_widget import PresetsWidget
 # from ._property_widget import PropertyWidget
+# from ._edit_preset_widget import EditPresetWidget
+# from ._add_preset_widget import AddPresetWidget
 from pymmcore_widgets._core import get_core_singleton
+from pymmcore_widgets._group_preset_widget._add_preset_widget import AddPresetWidget
+from pymmcore_widgets._group_preset_widget._edit_preset_widget import EditPresetWidget
 from pymmcore_widgets._presets_widget import PresetsWidget
 from pymmcore_widgets._property_widget import PropertyWidget
 
@@ -226,7 +230,20 @@ class GroupPresetTableWidget(QtW.QWidget):
             return
 
     def _add_preset(self) -> None:
-        pass
+        selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
+        if not selected_rows or len(selected_rows) > 1:
+            return
+
+        row = list(selected_rows)[0]
+        group = self.table_wdg.item(row, 0).text()
+        wdg = self.table_wdg.cellWidget(row, 1)
+
+        if isinstance(wdg, PropertyWidget):
+            return
+
+        if not hasattr(self, "add_preset"):
+            add_preset = AddPresetWidget(group, parent=self)
+        add_preset.show()
 
     def _delete_preset(self) -> None:
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
@@ -255,6 +272,17 @@ class GroupPresetTableWidget(QtW.QWidget):
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
         if not selected_rows or len(selected_rows) > 1:
             return
+
+        row = list(selected_rows)[0]
+        group = self.table_wdg.item(row, 0).text()
+        wdg = self.table_wdg.cellWidget(row, 1)
+        if isinstance(wdg, PropertyWidget):
+            return
+        if isinstance(wdg, PresetsWidget):
+            preset = wdg._combo.currentText()
+        if not hasattr(self, "edit_table"):
+            edit_table = EditPresetWidget(group, preset, parent=self)
+        edit_table.show()
 
     def _save_cfg(self) -> None:
         (filename, _) = QtW.QFileDialog.getSaveFileName(

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -6,17 +6,13 @@ from qtpy import QtWidgets as QtW
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout
 
-from pymmcore_widgets._group_preset_widget._add_group_widget import AddGroupWidget
-from pymmcore_widgets._group_preset_widget._add_preset_widget import AddPresetWidget
-from pymmcore_widgets._group_preset_widget._edit_group_widget import EditGroupWidget
-from pymmcore_widgets._group_preset_widget._edit_preset_widget import EditPresetWidget
 from pymmcore_widgets._presets_widget import PresetsWidget
 from pymmcore_widgets._property_widget import PropertyWidget
 
-# from ._add_group_widget import AddGroupWidget
-# from ._add_preset_widget import AddPresetWidget
-# from ._edit_group_widget import EditGroupWidget
-# from ._edit_preset_widget import EditPresetWidget
+from ._add_group_widget import AddGroupWidget
+from ._add_preset_widget import AddPresetWidget
+from ._edit_group_widget import EditGroupWidget
+from ._edit_preset_widget import EditPresetWidget
 
 
 class _MainTable(QtW.QTableWidget):
@@ -46,9 +42,7 @@ class GroupPresetTableWidget(QtW.QGroupBox):
         self._mmc = CMMCorePlus.instance()
         self._mmc.events.systemConfigurationLoaded.connect(self._populate_table)
 
-        # connections to the new pymmcore-plus groupDeleted signal
         self._mmc.events.groupDeleted.connect(self._on_group_deleted)
-        # presetDeleted signal is handled by the "PresetsWidget"/"PropertyWidget"
         self._mmc.events.newGroupPreset.connect(self._on_new_group_preset)
 
         self._create_gui()
@@ -256,7 +250,7 @@ class GroupPresetTableWidget(QtW.QGroupBox):
         for row_idx in sorted(selected_rows, reverse=True):
             group = self.table_wdg.item(row_idx, 0).text()
             self.table_wdg.removeRow(row_idx)
-            self._mmc.deleteConfigGroup(group)  # emitted delete group
+            self._mmc.deleteConfigGroup(group)
 
     def _on_group_deleted(self, group: str) -> None:
         if matching_item := self.table_wdg.findItems(group, Qt.MatchExactly):
@@ -303,14 +297,14 @@ class GroupPresetTableWidget(QtW.QGroupBox):
                 preset = wdg._combo.currentText()
 
                 if len(wdg.allowedValues()) > 1:
-                    self._mmc.deleteConfig(group, preset)  # emitted delete preset
+                    self._mmc.deleteConfig(group, preset)
                 else:
                     self.table_wdg.removeRow(row_idx)
-                    self._mmc.deleteConfigGroup(group)  # emitted delete group
+                    self._mmc.deleteConfigGroup(group)
 
             elif isinstance(wdg, PropertyWidget):
                 self.table_wdg.removeRow(row_idx)
-                self._mmc.deleteConfigGroup(group)  # emitted delete group
+                self._mmc.deleteConfigGroup(group)
 
     def _edit_preset(self) -> None:
         selected_rows = {r.row() for r in self.table_wdg.selectedIndexes()}
@@ -339,15 +333,3 @@ class GroupPresetTableWidget(QtW.QGroupBox):
         self._mmc.events.systemConfigurationLoaded.disconnect(self._populate_table)
         self._mmc.events.groupDeleted.disconnect(self._on_group_deleted)
         self._mmc.events.newGroupPreset.disconnect(self._on_new_group_preset)
-
-
-if __name__ == "__main__":
-    from qtpy.QtWidgets import QApplication
-
-    cfg = "/Users/FG/Dropbox/git/pymmcore-widgets/tests/test_config.cfg"
-    mmc = CMMCorePlus.instance()
-    mmc.loadSystemConfiguration(cfg)
-    app = QApplication([])
-    table = GroupPresetTableWidget()
-    table.show()
-    app.exec_()

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -189,8 +189,6 @@ class GroupPresetTableWidget(QGroupBox):
         self, group: str, preset: str, device: str, property: str, value: str
     ) -> None:
 
-        print(group, preset, device, property, value)
-
         if not device or not property or not value:
             return
 

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -310,7 +310,7 @@ class GroupPresetTableWidget(QGroupBox):
                 self._mmc.deleteConfigGroup(group)
 
     def _msg_box(self, msg: str) -> Any:
-        msgBox = QMessageBox()
+        msgBox = QMessageBox(parent=self)
         msgBox.setIcon(QMessageBox.Warning)
         msgBox.setWindowTitle("Delete")
         msgBox.setText(msg)

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -37,7 +37,7 @@ class _MainTable(QtW.QTableWidget):
         self.setMinimumHeight(200)
 
 
-class GroupPresetTableWidget(QtW.QWidget):
+class GroupPresetTableWidget(QtW.QGroupBox):
     """Widget to get/set group presets."""
 
     def __init__(self) -> None:

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import (
 from pymmcore_widgets._presets_widget import PresetsWidget
 from pymmcore_widgets._property_widget import PropertyWidget
 
+from .._core import load_system_config
 from .._util import block_core
 from ._add_group_widget import AddGroupWidget
 from ._add_preset_widget import AddPresetWidget
@@ -156,7 +157,7 @@ class GroupPresetTableWidget(QGroupBox):
 
         save_btn_wdg = QWidget()
         save_btn_layout = QHBoxLayout()
-        save_btn_layout.setSpacing(0)
+        save_btn_layout.setSpacing(5)
         save_btn_layout.setContentsMargins(0, 0, 0, 0)
         save_btn_wdg.setLayout(save_btn_layout)
 
@@ -165,6 +166,9 @@ class GroupPresetTableWidget(QGroupBox):
         self.save_btn = QPushButton(text="Save cfg")
         self.save_btn.clicked.connect(self._save_cfg)
         save_btn_layout.addWidget(self.save_btn)
+        self.load_btn = QPushButton(text="Load cfg")
+        self.load_btn.clicked.connect(self._load_cfg)
+        save_btn_layout.addWidget(self.load_btn)
 
         return save_btn_wdg
 
@@ -369,6 +373,14 @@ class GroupPresetTableWidget(QGroupBox):
         )
         if filename:
             self._mmc.saveSystemConfiguration(filename)
+
+    def _load_cfg(self) -> None:
+        """Open file dialog to select a config file."""
+        (filename, _) = QFileDialog.getOpenFileName(
+            self, "Select a Micro-Manager configuration file", "", "cfg(*.cfg)"
+        )
+        if filename:
+            load_system_config(filename, mmcore=self._mmc)
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._populate_table)

--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -33,7 +33,9 @@ class PresetsWidget(QWidget):
         if not self._presets:
             raise ValueError(f"{self._group} group does not have presets.")
 
-        self.dev_prop = self._get_group_dev_prop(self._group, self._presets[0])
+        self._update_presets()
+
+        self.dev_prop = self._get_group_dev_prop(self._group)
 
         self._check_if_presets_have_same_props()
 
@@ -117,7 +119,7 @@ class PresetsWidget(QWidget):
                 self._combo.setCurrentText(preset)
                 self._combo.setStyleSheet("")
         else:
-            dev_prop_list = self._get_group_dev_prop(group, preset)
+            dev_prop_list = self._get_group_dev_prop(group)
             if any(dev_prop for dev_prop in dev_prop_list if dev_prop in self.dev_prop):
                 self._set_if_props_match_preset()
 
@@ -135,7 +137,7 @@ class PresetsWidget(QWidget):
         """Return a list with (device, property) for the selected group preset."""
         return [(k[0], k[1]) for k in self._mmc.getConfigData(group, preset)]
 
-    def _get_group_dev_prop(self, group: str, preset: str) -> List[Tuple[str, str]]:
+    def _get_group_dev_prop(self, group: str) -> List[Tuple[str, str]]:
         """Return list of all (device, prop) used in the config group's presets."""
         dev_props = []
         for preset in self._mmc.getAvailableConfigs(group):
@@ -157,7 +159,7 @@ class PresetsWidget(QWidget):
     def _update_combo(self) -> None:
         self._presets = list(self._mmc.getAvailableConfigs(self._group))
         if self._presets:
-            self.dev_prop = self._get_group_dev_prop(self._group, self._presets[0])
+            self.dev_prop = self._get_group_dev_prop(self._group)
         self._combo.addItems(self._presets)
         self._combo.setEnabled(True)
         self._combo.setCurrentText(self._mmc.getCurrentConfig(self._group))

--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -57,10 +57,9 @@ class PresetsWidget(QWidget):
         self._mmc.events.systemConfigurationLoaded.connect(self._refresh)
         self._mmc.events.propertyChanged.connect(self._on_property_changed)
 
-        # connections to the new pymmcore-plus presetDeleted and newGroupPreset
-        self._mmc.events.presetDeleted.connect(self._on_preset_deleted)
-        self._mmc.events.groupDeleted.connect(self._on_group_deleted)
-        self._mmc.events.newGroupPreset.connect(self._on_new_group_preset)
+        self._mmc.events.configDeleted.connect(self._on_preset_deleted)
+        self._mmc.events.configGroupDeleted.connect(self._on_group_deleted)
+        self._mmc.events.configDefined.connect(self._on_new_group_preset)
 
         self.destroyed.connect(self._disconnect)
 
@@ -276,6 +275,6 @@ class PresetsWidget(QWidget):
         self._mmc.events.configSet.disconnect(self._on_cfg_set)
         self._mmc.events.systemConfigurationLoaded.disconnect(self._refresh)
         self._mmc.events.propertyChanged.disconnect(self._on_property_changed)
-        self._mmc.events.presetDeleted.disconnect(self._on_preset_deleted)
-        self._mmc.events.groupDeleted.disconnect(self._on_group_deleted)
-        self._mmc.events.newGroupPreset.disconnect(self._on_new_group_preset)
+        self._mmc.events.configDeleted.disconnect(self._on_preset_deleted)
+        self._mmc.events.configGroupDeleted.disconnect(self._on_group_deleted)
+        self._mmc.events.configDefined.disconnect(self._on_new_group_preset)

--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -76,6 +76,7 @@ class PresetsWidget(QWidget):
         """Prevent the group to have presets containing different properties."""
         group_dev_prop = self._get_preset_dev_prop(self._group, self._presets[0])
 
+        _to_delete = []
         for preset in self._presets:
             if preset == self._presets[0]:
                 continue
@@ -83,13 +84,15 @@ class PresetsWidget(QWidget):
             device_property = self._get_preset_dev_prop(self._group, preset)
 
             if len(device_property) != len(group_dev_prop):
+                _to_delete.append(preset)
                 self._mmc.deleteConfig(self._group, preset)
-                warnings.warn(
-                    f"{preset} preset don't have all the {self._group} group "
-                    "properties and will be deleted!"
-                )
 
-        self._presets = list(self._mmc.getAvailableConfigs(self._group))
+        if _to_delete:
+            warnings.warn(
+                f"{_to_delete} presets don't have all the {self._group} group "
+                "properties and will be deleted!"
+            )
+            self._presets = list(self._mmc.getAvailableConfigs(self._group))
 
     def _on_text_activate(self, text: str) -> None:
         # used if there is only 1 preset and you want to set it

--- a/src/pymmcore_widgets/_property_browser.py
+++ b/src/pymmcore_widgets/_property_browser.py
@@ -29,6 +29,9 @@ class _PropertyTable(QTableWidget):
         super().__init__(0, 2, parent=parent)
         self._mmc = mmcore or CMMCorePlus.instance()
         self._mmc.events.systemConfigurationLoaded.connect(self._rebuild_table)
+        self._mmc.events.configGroupDeleted.connect(self._rebuild_table)
+        self._mmc.events.configDeleted.connect(self._rebuild_table)
+        self._mmc.events.configDefined.connect(self._rebuild_table)
         self.destroyed.connect(self._disconnect)
 
         self.setMinimumWidth(500)
@@ -46,6 +49,9 @@ class _PropertyTable(QTableWidget):
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._rebuild_table)
+        self._mmc.events.configGroupDeleted.disconnect(self._rebuild_table)
+        self._mmc.events.configDeleted.disconnect(self._rebuild_table)
+        self._mmc.events.configDefined.disconnect(self._rebuild_table)
 
     def _rebuild_table(self) -> None:
         self.clearContents()

--- a/src/pymmcore_widgets/_util.py
+++ b/src/pymmcore_widgets/_util.py
@@ -1,5 +1,6 @@
-from typing import Optional, Sequence
+from typing import ContextManager, Optional, Sequence, Union
 
+from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler
 from qtpy.QtWidgets import (
     QComboBox,
     QDialog,
@@ -8,6 +9,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt.utils import signals_blocked
 
 
 class ComboMessageBox(QDialog):
@@ -40,3 +42,11 @@ class ComboMessageBox(QDialog):
     def currentText(self) -> str:
         """Returns the current QComboBox text."""
         return self._combo.currentText()  # type: ignore [no-any-return]
+
+
+def block_core(mmcore_events: Union[CMMCoreSignaler, PCoreSignaler]) -> ContextManager:
+    """Block core signals."""
+    if isinstance(mmcore_events, CMMCoreSignaler):
+        return mmcore_events.blocked()  # type: ignore
+    elif isinstance(mmcore_events, PCoreSignaler):
+        return signals_blocked(mmcore_events)  # type: ignore

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -69,3 +69,4 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
     assert isinstance(wdg.channel_wdg, PresetsWidget)
     assert len(wdg.channel_wdg.allowedValues()) == 1
+    assert global_mmcore.getChannelGroup() == "Channels"

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import QComboBox
 
 from pymmcore_widgets._channel_widget import ChannelWidget
 from pymmcore_widgets._presets_widget import PresetsWidget
+from pymmcore_widgets._util import block_core
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -63,9 +64,11 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
             ("Excitation", "Label", "Chroma-HQ570"),
         ]
 
-        global_mmcore.defineConfigFromDevicePropertyValueList(
-            "Channels", "DAPI", dev_prop_val
-        )
+        with block_core(global_mmcore.events):
+            for d, p, v in dev_prop_val:
+                global_mmcore.defineConfig("Channels", "DAPI", d, p, v)
+
+        global_mmcore.events.newGroupPreset.emit("Channels", "DAPI", d, p, v)
 
     assert isinstance(wdg.channel_wdg, PresetsWidget)
     assert len(wdg.channel_wdg.allowedValues()) == 1

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -44,19 +44,19 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert isinstance(wdg.channel_wdg, PresetsWidget)
     assert len(wdg.channel_wdg.allowedValues()) == 4
 
-    with qtbot.waitSignal(global_mmcore.events.presetDeleted):
+    with qtbot.waitSignal(global_mmcore.events.configDeleted):
         global_mmcore.deleteConfig("Channel", "DAPI")
 
     assert "DAPI" not in global_mmcore.getAvailableConfigs("Channel")
     assert "DAPI" not in wdg.channel_wdg.allowedValues()
 
-    with qtbot.waitSignal(global_mmcore.events.groupDeleted):
+    with qtbot.waitSignal(global_mmcore.events.configGroupDeleted):
         global_mmcore.deleteConfigGroup("Channel")
     assert isinstance(wdg.channel_wdg, QComboBox)
     assert wdg.channel_wdg.count() == 0
     assert global_mmcore.getChannelGroup() == ""
 
-    with qtbot.waitSignal(global_mmcore.events.newGroupPreset):
+    with qtbot.waitSignal(global_mmcore.events.configDefined):
 
         dev_prop_val = [
             ("Dichroic", "Label", "400DCLP"),
@@ -68,7 +68,7 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
             for d, p, v in dev_prop_val:
                 global_mmcore.defineConfig("Channels", "DAPI", d, p, v)
 
-        global_mmcore.events.newGroupPreset.emit("Channels", "DAPI", d, p, v)
+        global_mmcore.events.configDefined.emit("Channels", "DAPI", d, p, v)
 
     assert isinstance(wdg.channel_wdg, PresetsWidget)
     assert len(wdg.channel_wdg.allowedValues()) == 1

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -152,8 +152,8 @@ def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     assert isinstance(bit_cbox, QCheckBox)
     assert bin_cbox.isChecked()
     assert bit_cbox.isChecked()
-    assert table.item(1, 1).text() == "Camera-Binning"
-    assert table.item(2, 1).text() == "Camera-BitDepth"
+    assert table.item(bin_row, 1).text() == "Camera-Binning"
+    assert table.item(bit_row, 1).text() == "Camera-BitDepth"
 
     edit_gp.new_group_btn.click()
     assert edit_gp.info_lbl.text() == ""

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -108,7 +108,7 @@ def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     assert hasattr(add_gp_wdg, "_first_preset_wdg")
 
     wdg = add_gp_wdg._first_preset_wdg
-    assert wdg.preset_name_lineedit.text() == "NewPreset"
+    assert wdg.preset_name_lineedit.placeholderText() == "NewPreset"
 
     wdg.table.cellWidget(0, 1).setValue(2)
     wdg.table.cellWidget(1, 1).setValue(8)

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QCheckBox
 
+from pymmcore_widgets import PresetsWidget
+from pymmcore_widgets._group_preset_widget._add_group_widget import AddGroupWidget
 from pymmcore_widgets._group_preset_widget._group_preset_table_widget import (
     GroupPresetTableWidget,
 )
@@ -52,3 +55,124 @@ def test_populating_group_preset_table(global_mmcore: CMMCorePlus, qtbot: QtBot)
             assert type(wdg.value()) == float
             wdg.setValue(0.1)
             assert global_mmcore.getProperty("Camera", "TestProperty1") == "0.1000"
+
+
+def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
+    gp = GroupPresetTableWidget()
+    qtbot.addWidget(gp)
+    add_gp_wdg = AddGroupWidget()
+    qtbot.addWidget(add_gp_wdg)
+    mmc = global_mmcore
+
+    assert "NewGroup" not in mmc.getAvailableConfigGroups()
+    groups_in_table = [
+        gp.table_wdg.item(r, 0).text() for r in range(gp.table_wdg.rowCount())
+    ]
+    assert "NewGroup" not in groups_in_table
+
+    table = add_gp_wdg._prop_table
+
+    dev_prop_list = ["Camera-Binning", "Camera-BitDepth", "Camera-CCDTemperature"]
+
+    for idx, i in enumerate(dev_prop_list):
+        dev_prop = table.item((idx + 1), 1).text()
+        assert dev_prop == i
+        cbox = table.cellWidget((idx + 1), 0)
+        assert type(cbox) == QCheckBox
+        cbox.setChecked(True)
+        assert cbox.isChecked()
+
+    add_gp_wdg.group_lineedit.setText("NewGroup")
+
+    add_gp_wdg.new_group_btn.click()
+
+    assert hasattr(add_gp_wdg, "_first_preset_wdg")
+
+    wdg = add_gp_wdg._first_preset_wdg
+    assert wdg.preset_name_lineedit.text() == "NewPreset"
+
+    wdg.table.cellWidget(0, 1).setValue(2)
+    wdg.table.cellWidget(1, 1).setValue(8)
+    wdg.table.cellWidget(2, 1).setValue(0.1)
+
+    with qtbot.waitSignal(mmc.events.newGroupPreset):
+        wdg.apply_button.click()
+
+    assert "NewGroup" in mmc.getAvailableConfigGroups()
+    groups_in_table = [
+        gp.table_wdg.item(r, 0).text() for r in range(gp.table_wdg.rowCount())
+    ]
+    assert "NewGroup" in groups_in_table
+
+    dev_prop_val = [
+        (k[0], k[1], k[2]) for k in mmc.getConfigData("NewGroup", "NewPreset")
+    ]
+
+    assert [
+        ("Camera", "Binning", "2"),
+        ("Camera", "BitDepth", "8"),
+        ("Camera", "CCDTemperature", "0.1"),
+    ] == dev_prop_val
+
+
+def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
+    pass
+
+
+def test_delete_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
+    gp = GroupPresetTableWidget()
+    qtbot.addWidget(gp)
+    mmc = global_mmcore
+
+    assert "Camera" in mmc.getAvailableConfigGroups()
+
+    for r in range(gp.table_wdg.rowCount()):
+
+        group_name = gp.table_wdg.item(r, 0).text()
+
+        if group_name == "Camera":
+
+            with qtbot.waitSignal(mmc.events.groupDeleted):
+                mmc.deleteConfigGroup("Camera")
+            break
+
+    assert "Camera" not in mmc.getAvailableConfigGroups()
+    groups_in_table = [
+        gp.table_wdg.item(r, 0).text() for r in range(gp.table_wdg.rowCount())
+    ]
+    assert "Camera" not in groups_in_table
+
+
+def test_add_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
+    pass
+
+
+def test_edit_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
+    pass
+
+
+def test_delete_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
+    gp = GroupPresetTableWidget()
+    qtbot.addWidget(gp)
+    mmc = global_mmcore
+
+    assert "Camera" in mmc.getAvailableConfigGroups()
+    assert ["HighRes", "LowRes", "MedRes"] == list(mmc.getAvailableConfigs("Camera"))
+
+    camera_group_row = 0
+    for r in range(gp.table_wdg.rowCount()):
+
+        group_name = gp.table_wdg.item(r, 0).text()
+        wdg = cast(PresetsWidget, gp.table_wdg.cellWidget(r, 1))
+
+        if group_name == "Camera":
+            camera_group_row = r
+            assert wdg.allowedValues() == mmc.getAvailableConfigs("Camera")
+            break
+
+    with qtbot.waitSignal(mmc.events.presetDeleted):
+        mmc.deleteConfig("Camera", "LowRes")
+
+    assert "LowRes" not in mmc.getAvailableConfigs("Camera")
+    wdg = cast(PresetsWidget, gp.table_wdg.cellWidget(camera_group_row, 1))
+    assert "LowRes" not in wdg.allowedValues()

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -141,12 +141,17 @@ def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
     table = edit_gp._prop_table
 
-    cbox_1 = table.cellWidget(1, 0)
-    cbox_2 = table.cellWidget(2, 0)
-    assert isinstance(cbox_1, QCheckBox)
-    assert isinstance(cbox_2, QCheckBox)
-    assert cbox_1.isChecked()
-    assert cbox_2.isChecked()
+    bin_match = table.findItems("Camera-Binning", Qt.MatchExactly)
+    bin_row = bin_match[0].row()
+    bit_match = table.findItems("Camera-BitDepth", Qt.MatchExactly)
+    bit_row = bit_match[0].row()
+
+    bin_cbox = table.cellWidget(bin_row, 0)
+    bit_cbox = table.cellWidget(bit_row, 0)
+    assert isinstance(bin_cbox, QCheckBox)
+    assert isinstance(bit_cbox, QCheckBox)
+    assert bin_cbox.isChecked()
+    assert bit_cbox.isChecked()
     assert table.item(1, 1).text() == "Camera-Binning"
     assert table.item(2, 1).text() == "Camera-BitDepth"
 

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+import pytest
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QCheckBox
 
 from pymmcore_widgets import PresetsWidget
 from pymmcore_widgets._group_preset_widget._add_group_widget import AddGroupWidget
+from pymmcore_widgets._group_preset_widget._add_preset_widget import AddPresetWidget
+from pymmcore_widgets._group_preset_widget._edit_group_widget import EditGroupWidget
+from pymmcore_widgets._group_preset_widget._edit_preset_widget import EditPresetWidget
 from pymmcore_widgets._group_preset_widget._group_preset_table_widget import (
     GroupPresetTableWidget,
 )
@@ -116,7 +120,35 @@ def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
 
 def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
-    pass
+    edit_gp = EditGroupWidget("Camera")
+    qtbot.addWidget(edit_gp)
+    mmc = global_mmcore
+
+    table = edit_gp._prop_table
+
+    cbox_1 = table.cellWidget(1, 0)
+    cbox_2 = table.cellWidget(2, 0)
+    assert isinstance(cbox_1, QCheckBox)
+    assert isinstance(cbox_2, QCheckBox)
+    assert cbox_1.isChecked()
+    assert cbox_2.isChecked()
+    assert table.item(1, 1).text() == "Camera-Binning"
+    assert table.item(2, 1).text() == "Camera-BitDepth"
+
+    edit_gp.new_group_btn.click()
+    assert edit_gp.info_lbl.text() == ""
+
+    cbox_3 = table.cellWidget(3, 0)
+    assert isinstance(cbox_3, QCheckBox)
+    assert not cbox_3.isChecked()
+    cbox_3.setChecked(True)
+    assert table.item(3, 1).text() == "Camera-CCDTemperature"
+
+    edit_gp.new_group_btn.click()
+    assert edit_gp.info_lbl.text() == "Camera Group Modified."
+
+    dp = [(k[0], k[1]) for k in mmc.getConfigData("Camera", "LowRes")]
+    assert ("Camera", "CCDTemperature") in dp
 
 
 def test_delete_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
@@ -144,11 +176,68 @@ def test_delete_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
 
 def test_add_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
-    pass
+    add_prs = AddPresetWidget("Channel")
+    qtbot.addWidget(add_prs)
+    gp = GroupPresetTableWidget()
+    qtbot.addWidget(gp)
+    mmc = global_mmcore
+
+    add_prs.preset_name_lineedit.setText("New")
+
+    mode = add_prs.table.cellWidget(3, 1)
+    mode.setValue("Color Test Pattern")
+    wdg = add_prs.table.cellWidget(5, 1)
+    wdg.setValue("Shutter")
+
+    with pytest.warns(UserWarning):
+        add_prs.add_preset_button.click()
+        assert add_prs.info_lbl.text() == "DAPI already has the same properties!"
+
+    mode.setValue("Noise")
+    add_prs.add_preset_button.click()
+    assert add_prs.info_lbl.text() == "New has been added!"
+
+    assert "New" in mmc.getAvailableConfigs("Channel")
+
+    dpv = [(k[0], k[1], k[2]) for k in mmc.getConfigData("Channel", "New")]
+    assert dpv == [
+        ("Dichroic", "Label", "400DCLP"),
+        ("Emission", "Label", "Chroma-HQ620"),
+        ("Excitation", "Label", "Chroma-D360"),
+        ("Camera", "Mode", "Noise"),
+        ("Multi Shutter", "Physical Shutter 1", "Undefined"),
+        ("Multi Shutter", "Physical Shutter 2", "Shutter"),
+        ("Multi Shutter", "Physical Shutter 3", "Undefined"),
+        ("Multi Shutter", "Physical Shutter 4", "Undefined"),
+    ]
+
+    for r in range(gp.table_wdg.rowCount()):
+
+        group_name = gp.table_wdg.item(r, 0).text()
+        if group_name == "Channel":
+            wdg = cast(PresetsWidget, gp.table_wdg.cellWidget(r, 1))
+            assert wdg.allowedValues() == mmc.getAvailableConfigs("Channel")
+            break
 
 
 def test_edit_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
-    pass
+    edit_ps = EditPresetWidget("Objective", "10X")
+    qtbot.addWidget(edit_ps)
+    mmc = global_mmcore
+
+    assert edit_ps.table.item(0, 0).text() == "Objective-State"
+    wdg = edit_ps.table.cellWidget(0, 1)
+    wdg.setValue(3)
+
+    with pytest.warns(UserWarning):
+        edit_ps.apply_button.click()
+        assert edit_ps.info_lbl.text() == "20X already has the same properties!"
+
+    wdg.setValue(5)
+    edit_ps.apply_button.click()
+
+    dpv = [(k[0], k[1], k[2]) for k in mmc.getConfigData("Objective", "10X")]
+    assert dpv == [("Objective", "State", "5")]
 
 
 def test_delete_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from pymmcore_plus import CMMCorePlus
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QCheckBox
 
 from pymmcore_widgets import PresetsWidget
@@ -78,10 +79,16 @@ def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
     dev_prop_list = ["Camera-Binning", "Camera-BitDepth", "Camera-CCDTemperature"]
 
+    bin_match = table.findItems("Camera-Binning", Qt.MatchExactly)
+    bit_match = table.findItems("Camera-BitDepth", Qt.MatchExactly)
+    t_match = table.findItems("Camera-CCDTemperature", Qt.MatchExactly)
+
+    rows = [bin_match[0].row(), bit_match[0].row(), t_match[0].row()]
+
     for idx, i in enumerate(dev_prop_list):
-        dev_prop = table.item((idx + 1), 1).text()
+        dev_prop = table.item(rows[idx], 1).text()
         assert dev_prop == i
-        cbox = table.cellWidget((idx + 1), 0)
+        cbox = table.cellWidget(rows[idx], 0)
         assert type(cbox) == QCheckBox
         cbox.setChecked(True)
         assert cbox.isChecked()

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -86,6 +86,14 @@ def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
         cbox.setChecked(True)
         assert cbox.isChecked()
 
+    with pytest.warns(UserWarning):
+        add_gp_wdg.new_group_btn.click()
+        assert add_gp_wdg.info_lbl.text() == "Give a name to the group!"
+
+        add_gp_wdg.group_lineedit.setText("Camera")
+        add_gp_wdg.new_group_btn.click()
+        assert add_gp_wdg.info_lbl.text() == "Camera already exist!"
+
     add_gp_wdg.group_lineedit.setText("NewGroup")
 
     add_gp_wdg.new_group_btn.click()

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -158,11 +158,14 @@ def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     edit_gp.new_group_btn.click()
     assert edit_gp.info_lbl.text() == ""
 
-    cbox_3 = table.cellWidget(3, 0)
-    assert isinstance(cbox_3, QCheckBox)
-    assert not cbox_3.isChecked()
-    cbox_3.setChecked(True)
-    assert table.item(3, 1).text() == "Camera-CCDTemperature"
+    t_match = table.findItems("Camera-CCDTemperature", Qt.MatchExactly)
+    t_row = t_match[0].row()
+
+    t_cbox = table.cellWidget(t_row, 0)
+    assert isinstance(t_cbox, QCheckBox)
+    assert not t_cbox.isChecked()
+    t_cbox.setChecked(True)
+    assert table.item(t_row, 1).text() == "Camera-CCDTemperature"
 
     edit_gp.new_group_btn.click()
     assert edit_gp.info_lbl.text() == "'Camera' Group Modified."

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -114,7 +114,7 @@ def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     wdg.table.cellWidget(1, 1).setValue(8)
     wdg.table.cellWidget(2, 1).setValue(0.1)
 
-    with qtbot.waitSignal(mmc.events.newGroupPreset):
+    with qtbot.waitSignal(mmc.events.configDefined):
         wdg.apply_button.click()
 
     assert "NewGroup" in mmc.getAvailableConfigGroups()
@@ -187,7 +187,7 @@ def test_delete_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
         if group_name == "Camera":
 
-            with qtbot.waitSignal(mmc.events.groupDeleted):
+            with qtbot.waitSignal(mmc.events.configGroupDeleted):
                 mmc.deleteConfigGroup("Camera")
             break
 
@@ -282,7 +282,7 @@ def test_delete_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
             assert wdg.allowedValues() == mmc.getAvailableConfigs("Camera")
             break
 
-    with qtbot.waitSignal(mmc.events.presetDeleted):
+    with qtbot.waitSignal(mmc.events.configDeleted):
         mmc.deleteConfig("Camera", "LowRes")
 
     assert "LowRes" not in mmc.getAvailableConfigs("Camera")

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 
 from pymmcore_plus import CMMCorePlus
 
-from pymmcore_widgets._group_preset_table_widget import GroupPresetTableWidget
+from pymmcore_widgets._group_preset_widget._group_preset_table_widget import (
+    GroupPresetTableWidget,
+)
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from pymmcore_widgets._presets_widget import PresetsWidget
 
 if TYPE_CHECKING:
@@ -43,7 +45,42 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
             assert wdg._combo.currentText() == "MedRes"
             assert wdg._combo.styleSheet() == ""
 
+            warning_string = (
+                "'test' preset is missing the following properties:"
+                "[('Camera', 'BitDepth')]"
+            )
+            with pytest.warns(UserWarning, match=warning_string):
+                global_mmcore.defineConfig("Camera", "test", "Camera", "Binning", "4")
+                assert len(wdg.allowedValues()) == 4
+                assert "test" in wdg.allowedValues()
+                global_mmcore.deleteConfig("Camera", "test")
+                assert len(wdg.allowedValues()) == 3
+                assert "test" not in wdg.allowedValues()
+
+            warning_string = (
+                "[('Dichroic', 'Label')]are not included in the 'Camera' group "
+                "and will not be added!"
+            )
+            with pytest.warns(UserWarning, match=warning_string):
+                global_mmcore.defineConfig(
+                    "Camera", "test", "Dichroic", "Label", "400DCLP"
+                )
+                assert len(wdg.allowedValues()) == 3
+                assert "test" not in wdg.allowedValues()
+
+            warning_string = (
+                "'HighRes' preset is missing the following properties:"
+                "[('Camera', 'Binning')]"
+            )
+            with pytest.warns(UserWarning, match=warning_string):
+                global_mmcore.deletePresetDeviceProperties(
+                    "Camera", "HighRes", [("Camera", "Binning")]
+                )
+
         wdg._disconnect()
         # once disconnected, core changes shouldn't call out to the widget
         global_mmcore.setConfig(group, presets[1])
         assert global_mmcore.getCurrentConfig(group) != wdg.value()
+
+    global_mmcore.deleteConfigGroup("Camera")
+    assert "Camera" not in global_mmcore.getAvailableConfigGroups()

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -50,7 +50,7 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
                 "[('Camera', 'BitDepth')]"
             )
             with pytest.warns(UserWarning, match=warning_string):
-                with qtbot.waitSignals([global_mmcore.events.newGroupPreset]):
+                with qtbot.waitSignals([global_mmcore.events.configDefined]):
                     global_mmcore.defineConfig(
                         "Camera", "test", "Camera", "Binning", "4"
                     )
@@ -65,7 +65,7 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
                 "and will not be added!"
             )
             with pytest.warns(UserWarning, match=warning_string):
-                with qtbot.waitSignals([global_mmcore.events.newGroupPreset]):
+                with qtbot.waitSignals([global_mmcore.events.configDefined]):
                     global_mmcore.defineConfig(
                         "Camera", "test", "Dichroic", "Label", "400DCLP"
                     )

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -50,7 +50,10 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
                 "[('Camera', 'BitDepth')]"
             )
             with pytest.warns(UserWarning, match=warning_string):
-                global_mmcore.defineConfig("Camera", "test", "Camera", "Binning", "4")
+                with qtbot.waitSignals([global_mmcore.events.newGroupPreset]):
+                    global_mmcore.defineConfig(
+                        "Camera", "test", "Camera", "Binning", "4"
+                    )
                 assert len(wdg.allowedValues()) == 4
                 assert "test" in wdg.allowedValues()
                 global_mmcore.deleteConfig("Camera", "test")
@@ -62,20 +65,12 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
                 "and will not be added!"
             )
             with pytest.warns(UserWarning, match=warning_string):
-                global_mmcore.defineConfig(
-                    "Camera", "test", "Dichroic", "Label", "400DCLP"
-                )
+                with qtbot.waitSignals([global_mmcore.events.newGroupPreset]):
+                    global_mmcore.defineConfig(
+                        "Camera", "test", "Dichroic", "Label", "400DCLP"
+                    )
                 assert len(wdg.allowedValues()) == 3
                 assert "test" not in wdg.allowedValues()
-
-            warning_string = (
-                "'HighRes' preset is missing the following properties:"
-                "[('Camera', 'Binning')]"
-            )
-            with pytest.warns(UserWarning, match=warning_string):
-                global_mmcore.deletePresetDeviceProperties(
-                    "Camera", "HighRes", [("Camera", "Binning")]
-                )
 
         wdg._disconnect()
         # once disconnected, core changes shouldn't call out to the widget


### PR DESCRIPTION
This PR add the ability to create, delete or modify `groups` and `presets` directly from the `GroupPresetTableWidget`.

Uses the new sets of `pymmcore-plus` signals and methods from https://github.com/pymmcore-plus/pymmcore-plus/pull/139. 

*** to do: update pymmcore-plus pyproject.toml when https://github.com/pymmcore-plus/pymmcore-plus/pull/139 is merged.

<img width="447" alt="Screen Shot 2022-09-05 at 7 04 10 PM" src="https://user-images.githubusercontent.com/70725613/188519174-74a59d9b-c236-43fd-a5f1-5cd4a3da80ae.png">

<img width="797" alt="Screen Shot 2022-09-05 at 7 04 36 PM" src="https://user-images.githubusercontent.com/70725613/188519181-29cf4311-17d0-40c3-9adf-3ca01ffe399a.png">

<img width="807" alt="Screen Shot 2022-09-05 at 7 04 51 PM" src="https://user-images.githubusercontent.com/70725613/188519187-29f525f8-6226-410b-8d94-aa826609f4e8.png">

<img width="350" alt="Screen Shot 2022-09-05 at 7 05 05 PM" src="https://user-images.githubusercontent.com/70725613/188519192-d3b81d13-5df1-4bdd-ac34-44dd02ac0e90.png">

<img width="530" alt="Screen Shot 2022-09-05 at 7 05 17 PM" src="https://user-images.githubusercontent.com/70725613/188519195-75755514-b913-42f1-99d9-bc60866ab934.png">
