### PR TITLE
fix: fix state error in snap and live buttons

### DIFF
--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -46,7 +46,6 @@ class LiveButton(QPushButton):
         super().__init__()
 
         self._mmc = mmcore or CMMCorePlus.instance()
-        self._camera = self._mmc.getCameraDevice()
         self.button_text_on = button_text_on_off[0]
         self.button_text_off = button_text_on_off[1]
         self.icon_size = icon_size
@@ -77,13 +76,12 @@ class LiveButton(QPushButton):
         self.clicked.connect(self._toggle_live_mode)
 
     def _on_system_cfg_loaded(self) -> None:
-        self._camera = self._mmc.getCameraDevice()
-        self.setEnabled(bool(self._camera))
+        self.setEnabled(bool(self._mmc.getCameraDevice()))
 
     def _toggle_live_mode(self) -> None:
         """Start/stop SequenceAcquisition."""
-        if self._mmc.isSequenceRunning(self._camera):
-            self._mmc.stopSequenceAcquisition(self._camera)  # pymmcore-plus method
+        if self._mmc.isSequenceRunning():
+            self._mmc.stopSequenceAcquisition()
             self._set_icon_state(False)
         else:
             self._mmc.startContinuousSequenceAcquisition()  # pymmcore-plus method

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -37,7 +37,6 @@ class SnapButton(QPushButton):
         self.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
 
         self._mmc = mmcore or CMMCorePlus.instance()
-        self._camera = self._mmc.getCameraDevice()
 
         self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)
         self._on_system_cfg_loaded()
@@ -56,8 +55,8 @@ class SnapButton(QPushButton):
         self.clicked.connect(self._snap)
 
     def _snap(self) -> None:
-        if self._mmc.isSequenceRunning(self._camera):
-            self._mmc.stopSequenceAcquisition(self._camera)
+        if self._mmc.isSequenceRunning():
+            self._mmc.stopSequenceAcquisition()
         if self._mmc.getAutoShutter():
             self._mmc.events.propertyChanged.emit(
                 self._mmc.getShutterDevice(), "State", True
@@ -65,8 +64,7 @@ class SnapButton(QPushButton):
         create_worker(self._mmc.snap, _start_thread=True)
 
     def _on_system_cfg_loaded(self) -> None:
-        self._camera = self._mmc.getCameraDevice()
-        self.setEnabled(bool(self._camera))
+        self.setEnabled(bool(self._mmc.getCameraDevice()))
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(


### PR DESCRIPTION
both the snap and live buttons have a bug where the internal state (`self._camera`) can go stale if the user uses `setCameraDevice`.  This PR removes the internal pointer to the device label, and always uses the core as the source of truth.

in general, I guess this is  reminder that we should, whenever possible, avoiding saving _any_ state on these widgets that has the potential to go out of sync with core (unless we _must_ save it for some reason)