### PR TITLE
fix: use standard StateDeviceWidget if no FocusDevice

### DIFF
--- a/src/pymmcore_widgets/_objective_widget.py
+++ b/src/pymmcore_widgets/_objective_widget.py
@@ -69,8 +69,11 @@ class ObjectivesWidget(QWidget):
         self, device_label: Union[str, None]
     ) -> Union[StateDeviceWidget, QComboBox]:
         if device_label:
-            combo = _ObjectiveStateWidget(device_label, mmcore=self._mmc)
-            combo.setMinimumWidth(285)
+            combo = (
+                _ObjectiveStateWidget(device_label, mmcore=self._mmc)
+                if self._mmc.getFocusDevice()
+                else StateDeviceWidget(device_label, mmcore=self._mmc)
+            )
             combo._combo.currentIndexChanged.connect(self._on_obj_changed)
         else:
             combo = QComboBox()


### PR DESCRIPTION
This PR fixes an issue happening if there is no `FocusDevice` in the micromanager cfg.

Currently, the objective widget is using the `_ObjectiveStateWidget` subclass (objective moving up/down when changed) of the `StateDeviceWidget` class and it works well only if there is a `FocusDevice`. It will raise `RuntimeError: No device with label ""` if there is no `FocusDevice`.