### PR TITLE
fix: fix sequence acquisition signal names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    'pymmcore-plus>=0.5.0',
+    'pymmcore-plus>=0.6.0',
     'useq-schema >=0.1.2',
     'superqt >=0.3.1',
     'fonticon-materialdesignicons6',
     'qtpy',
-    'tifffile',
 ]
 
 # extras

--- a/src/pymmcore_widgets/_image_widget.py
+++ b/src/pymmcore_widgets/_image_widget.py
@@ -52,15 +52,15 @@ class ImagePreview(QWidget):
     def _connect(self) -> None:
         ev = self._mmc.events
         ev.imageSnapped.connect(self._on_image_snapped)
-        ev.startContinuousSequenceAcquisition.connect(self._on_streaming_start)
-        ev.stopSequenceAcquisition.connect(self._on_streaming_stop)
+        ev.continuousSequenceAcquisitionStarted.connect(self._on_streaming_start)
+        ev.sequenceAcquisitionStopped.connect(self._on_streaming_stop)
         ev.exposureChanged.connect(self._on_exposure_changed)
 
     def _disconnect(self) -> None:
         ev = self._mmc.events
         ev.imageSnapped.disconnect(self._on_image_snapped)
-        ev.startContinuousSequenceAcquisition.disconnect(self._on_streaming_start)
-        ev.stopSequenceAcquisition.disconnect(self._on_streaming_stop)
+        ev.continuousSequenceAcquisitionStarted.disconnect(self._on_streaming_start)
+        ev.sequenceAcquisitionStopped.disconnect(self._on_streaming_stop)
         ev.exposureChanged.disconnect(self._on_exposure_changed)
 
     def _on_streaming_start(self) -> None:

--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -21,8 +21,8 @@ class LiveButton(QPushButton):
     """Create a two-state (on-off) live mode QPushButton.
 
     When pressed, a 'ContinuousSequenceAcquisition' is started or stopped
-    and a pymmcore-plus signal 'startContinuousSequenceAcquisition' or
-    'stopSequenceAcquisition' is emitted.
+    and a pymmcore-plus signal 'continuousSequenceAcquisitionStarted' or
+    'sequenceAcquisitionStopped' is emitted.
     """
 
     def __init__(
@@ -44,10 +44,10 @@ class LiveButton(QPushButton):
 
         self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)
         self._on_system_cfg_loaded()
-        self._mmc.events.startContinuousSequenceAcquisition.connect(
+        self._mmc.events.continuousSequenceAcquisitionStarted.connect(
             self._on_sequence_started
         )
-        self._mmc.events.stopSequenceAcquisition.connect(self._on_sequence_stopped)
+        self._mmc.events.sequenceAcquisitionStopped.connect(self._on_sequence_stopped)
         self.destroyed.connect(self._disconnect)
 
         self._create_button()
@@ -154,7 +154,9 @@ class LiveButton(QPushButton):
         self._mmc.events.systemConfigurationLoaded.disconnect(
             self._on_system_cfg_loaded
         )
-        self._mmc.events.startContinuousSequenceAcquisition.disconnect(
+        self._mmc.events.continuousSequenceAcquisitionStarted.disconnect(
             self._on_sequence_started
         )
-        self._mmc.events.stopSequenceAcquisition.disconnect(self._on_sequence_stopped)
+        self._mmc.events.sequenceAcquisitionStopped.disconnect(
+            self._on_sequence_stopped
+        )

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -67,11 +67,11 @@ class ShuttersWidget(QtW.QWidget):
         self._mmc.events.systemConfigurationLoaded.connect(self._refresh_shutter_widget)
         self._mmc.events.autoShutterSet.connect(self._on_autoshutter_changed)
         self._mmc.events.propertyChanged.connect(self._on_prop_changed)
-        self._mmc.events.startContinuousSequenceAcquisition.connect(
+        self._mmc.events.continuousSequenceAcquisitionStarted.connect(
             self._on_seq_started
         )
-        self._mmc.events.startSequenceAcquisition.connect(self._on_seq_started)
-        self._mmc.events.stopSequenceAcquisition.connect(self._on_seq_stopped)
+        self._mmc.events.sequenceAcquisitionStarted.connect(self._on_seq_started)
+        self._mmc.events.sequenceAcquisitionStopped.connect(self._on_seq_stopped)
         self._mmc.events.imageSnapped.connect(self._on_seq_stopped)
         self._mmc.events.configSet.connect(self._on_channel_set)
 
@@ -335,10 +335,10 @@ class ShuttersWidget(QtW.QWidget):
         )
         self._mmc.events.autoShutterSet.disconnect(self._on_autoshutter_changed)
         self._mmc.events.propertyChanged.disconnect(self._on_prop_changed)
-        self._mmc.events.startContinuousSequenceAcquisition.disconnect(
+        self._mmc.events.continuousSequenceAcquisitionStarted.disconnect(
             self._on_seq_started
         )
-        self._mmc.events.startSequenceAcquisition.disconnect(self._on_seq_started)
-        self._mmc.events.stopSequenceAcquisition.disconnect(self._on_seq_stopped)
+        self._mmc.events.sequenceAcquisitionStarted.disconnect(self._on_seq_started)
+        self._mmc.events.sequenceAcquisitionStopped.disconnect(self._on_seq_stopped)
         self._mmc.events.imageSnapped.disconnect(self._on_seq_stopped)
         self._mmc.events.configSet.disconnect(self._on_channel_set)

--- a/tests/test_live_button.py
+++ b/tests/test_live_button.py
@@ -23,22 +23,22 @@ def test_live_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert live_btn.icon_color_off == "magenta"
 
     # test from direct mmcore signals
-    with qtbot.waitSignal(global_mmcore.events.startContinuousSequenceAcquisition):
+    with qtbot.waitSignal(global_mmcore.events.continuousSequenceAcquisitionStarted):
         global_mmcore.startContinuousSequenceAcquisition(0)
     assert live_btn.text() == "Stop"
 
-    with qtbot.waitSignal(global_mmcore.events.stopSequenceAcquisition):
+    with qtbot.waitSignal(global_mmcore.events.sequenceAcquisitionStopped):
         global_mmcore.stopSequenceAcquisition()
     assert not global_mmcore.isSequenceRunning()
     assert live_btn.text() == "Live"
 
     # test when button is pressed
-    with qtbot.waitSignal(global_mmcore.events.startContinuousSequenceAcquisition):
+    with qtbot.waitSignal(global_mmcore.events.continuousSequenceAcquisitionStarted):
         live_btn.click()
     assert live_btn.text() == "Stop"
     assert global_mmcore.isSequenceRunning()
 
-    with qtbot.waitSignal(global_mmcore.events.stopSequenceAcquisition):
+    with qtbot.waitSignal(global_mmcore.events.sequenceAcquisitionStopped):
         live_btn.click()
     assert not global_mmcore.isSequenceRunning()
     assert live_btn.text() == "Live"

--- a/tests/test_shutter_widget.py
+++ b/tests/test_shutter_widget.py
@@ -94,7 +94,7 @@ def test_shutter_widget_SequenceAcquisition(shutters, qtbot: QtBot):
     with qtbot.waitSignal(mmc.events.configSet):
         mmc.setConfig("Channel", "DAPI")
 
-    with qtbot.waitSignal(mmc.events.startContinuousSequenceAcquisition):
+    with qtbot.waitSignal(mmc.events.continuousSequenceAcquisitionStarted):
         mmc.startContinuousSequenceAcquisition()
         assert multi_shutter.shutter_button.text() == "Multi Shutter opened"
         assert not multi_shutter.shutter_button.isEnabled()
@@ -108,7 +108,7 @@ def test_shutter_widget_SequenceAcquisition(shutters, qtbot: QtBot):
     assert multi_shutter.shutter_button.text() == "Multi Shutter opened"
     assert shutter.shutter_button.text() == "Shutter opened"
 
-    with qtbot.waitSignal(mmc.events.stopSequenceAcquisition):
+    with qtbot.waitSignal(mmc.events.sequenceAcquisitionStopped):
         mmc.stopSequenceAcquisition()
     assert shutter.shutter_button.isEnabled()
     assert multi_shutter.shutter_button.isEnabled()
@@ -189,10 +189,10 @@ def test_shutter_widget_setters(shutters, qtbot: QtBot):
     shutter.button_text_closed = "C"
     assert shutter.button_text_closed == "C"
 
-    with qtbot.waitSignal(mmc.events.startContinuousSequenceAcquisition):
+    with qtbot.waitSignal(mmc.events.continuousSequenceAcquisitionStarted):
         mmc.startContinuousSequenceAcquisition()
     assert shutter.shutter_button.text() == "O"
-    with qtbot.waitSignal(mmc.events.stopSequenceAcquisition):
+    with qtbot.waitSignal(mmc.events.sequenceAcquisitionStopped):
         mmc.stopSequenceAcquisition()
     assert shutter.shutter_button.text() == "C"
 

--- a/tests/test_snap_button_widget.py
+++ b/tests/test_snap_button_widget.py
@@ -24,7 +24,7 @@ def test_snap_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
     with qtbot.waitSignals(
         [
-            global_mmcore.events.stopSequenceAcquisition,
+            global_mmcore.events.sequenceAcquisitionStopped,
             global_mmcore.events.imageSnapped,
         ]
     ):


### PR DESCRIPTION
This PR replaces the old sequence acquisition signals names. To be merged **AFTER** https://github.com/pymmcore-plus/pymmcore-plus/pull/163.