### PR TITLE
refactor: correct many Qt namespaces

### DIFF
--- a/src/pymmcore_widgets/_camera_roi_widget.py
+++ b/src/pymmcore_widgets/_camera_roi_widget.py
@@ -23,7 +23,7 @@ from superqt.utils import signals_blocked
 
 # from ._util import block_core
 
-fixed_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+fixed_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 FULL = "Full Chip"
 CUSTOM_ROI = "Custom ROI"
 
@@ -103,7 +103,9 @@ class CameraRoiWidget(QWidget):
         self.lbl_info = QLabel()
         bottom_layout.addWidget(self.lbl_info)
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         bottom_layout.addItem(spacer)
 
         self.snap_checkbox = QCheckBox(text="autoSnap")
@@ -140,7 +142,7 @@ class CameraRoiWidget(QWidget):
     def _create_selection_wdg(self) -> QGroupBox:
 
         wdg = QGroupBox()
-        wdg.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        wdg.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         layout = QVBoxLayout()
         layout.setSpacing(5)
         layout.setContentsMargins(3, 3, 3, 3)
@@ -168,14 +170,14 @@ class CameraRoiWidget(QWidget):
         self.start_x = QSpinBox()
         self.start_x.setMinimum(0)
         self.start_x.setMaximum(10000)
-        self.start_x.setAlignment(Qt.AlignCenter)
+        self.start_x.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.start_x.valueChanged.connect(self._on_start_spinbox_changed)
         roi_start_y_label = QLabel("Start y:")
         roi_start_y_label.setSizePolicy(fixed_sizepolicy)
         self.start_y = QSpinBox()
         self.start_y.setMinimum(0)
         self.start_y.setMaximum(10000)
-        self.start_y.setAlignment(Qt.AlignCenter)
+        self.start_y.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.start_y.valueChanged.connect(self._on_start_spinbox_changed)
 
         layout.addWidget(roi_start_x_label, 1, 0, 1, 1)
@@ -189,7 +191,7 @@ class CameraRoiWidget(QWidget):
         self.roi_width.setObjectName("roi_width")
         self.roi_width.setMinimum(1)
         self.roi_width.setMaximum(10000)
-        self.roi_width.setAlignment(Qt.AlignCenter)
+        self.roi_width.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.roi_width.valueChanged.connect(self._on_roi_spinbox_changed)
         roi_height_label = QLabel("Height:")
         roi_height_label.setSizePolicy(fixed_sizepolicy)
@@ -197,7 +199,7 @@ class CameraRoiWidget(QWidget):
         self.roi_height.setObjectName("roi_height")
         self.roi_height.setMinimum(1)
         self.roi_height.setMaximum(10000)
-        self.roi_height.setAlignment(Qt.AlignCenter)
+        self.roi_height.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.roi_height.valueChanged.connect(self._on_roi_spinbox_changed)
 
         layout.addWidget(roi_size_label, 1, 2, 1, 1)
@@ -455,9 +457,9 @@ class CameraRoiWidget(QWidget):
     def _hide_spinbox_button(self, spin_list: List[QSpinBox], hide: bool) -> None:
         for spin in spin_list:
             if hide:
-                spin.setButtonSymbols(QAbstractSpinBox.NoButtons)
+                spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
             else:
-                spin.setButtonSymbols(QAbstractSpinBox.PlusMinus)
+                spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.PlusMinus)
 
     def _check_size_reset_snap(self, snap: bool = True) -> None:
         x, y, w, h = self._mmc.getROI()

--- a/src/pymmcore_widgets/_exposure_widget.py
+++ b/src/pymmcore_widgets/_exposure_widget.py
@@ -27,7 +27,7 @@ class ExposureWidget(QtW.QWidget):
         self.label.setText(" ms")
         self.label.setMaximumWidth(30)
         self.spinBox = QtW.QDoubleSpinBox()
-        self.spinBox.setAlignment(Qt.AlignCenter)
+        self.spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.spinBox.setMinimum(1.0)
         self.spinBox.setMaximum(100000.0)
         self.spinBox.setKeyboardTracking(False)

--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -75,7 +75,7 @@ class AddFirstPresetWidget(QDialog):
         wdg_layout.setContentsMargins(5, 5, 5, 5)
         wdg.setLayout(wdg_layout)
 
-        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         gp_lbl = QLabel(text="Group:")
         gp_lbl.setSizePolicy(lbl_sizepolicy)
@@ -87,7 +87,7 @@ class AddFirstPresetWidget(QDialog):
         self.preset_name_lineedit = QLineEdit()
         self.preset_name_lineedit.setPlaceholderText(self._get_placeholder_name())
 
-        spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
+        spacer = QSpacerItem(30, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         wdg_layout.addWidget(gp_lbl)
         wdg_layout.addWidget(group_name_lbl)
@@ -111,11 +111,13 @@ class AddFirstPresetWidget(QDialog):
 
         self.apply_button = QPushButton(text="Create Preset")
         self.apply_button.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.apply_button.clicked.connect(self._create_first_preset)
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
 
         wdg_layout.addItem(spacer)
         wdg_layout.addWidget(self.apply_button)
@@ -165,11 +167,11 @@ class _Table(QTableWidget):
         super().__init__()
         hdr = self.horizontalHeader()
         hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        hdr.setDefaultAlignment(Qt.AlignHCenter)
+        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
         vh = self.verticalHeader()
         vh.setVisible(False)
         vh.setSectionResizeMode(vh.ResizeMode.Fixed)
         vh.setDefaultSectionSize(24)
-        self.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Device-Property", "Value"])

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -129,7 +129,9 @@ class AddGroupWidget(QDialog):
         wdg.setLayout(layout)
 
         group_lbl = QLabel(text="Group name:")
-        group_lbl.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
+        group_lbl.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        )
 
         self.group_lineedit = QLineEdit()
 
@@ -183,7 +185,7 @@ class AddGroupWidget(QDialog):
 
         self.new_group_btn = QPushButton(text="Create New Group")
         self.new_group_btn.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.new_group_btn.clicked.connect(self._add_group)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -70,7 +70,7 @@ class AddPresetWidget(QDialog):
         wdg_layout.setContentsMargins(5, 5, 5, 5)
         wdg.setLayout(wdg_layout)
 
-        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         gp_lbl = QLabel(text="Group:")
         gp_lbl.setSizePolicy(lbl_sizepolicy)
@@ -82,7 +82,7 @@ class AddPresetWidget(QDialog):
         self.preset_name_lineedit = QLineEdit()
         self.preset_name_lineedit.setPlaceholderText(self._get_placeholder_name())
 
-        spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
+        spacer = QSpacerItem(30, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         wdg_layout.addWidget(gp_lbl)
         wdg_layout.addWidget(group_name_lbl)
@@ -107,7 +107,7 @@ class AddPresetWidget(QDialog):
         self.info_lbl = QLabel()
         self.add_preset_button = QPushButton(text="Add Preset")
         self.add_preset_button.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.add_preset_button.clicked.connect(self._add_preset)
 
@@ -190,11 +190,11 @@ class _Table(QTableWidget):
         super().__init__()
         hdr = self.horizontalHeader()
         hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        hdr.setDefaultAlignment(Qt.AlignHCenter)
+        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
         vh = self.verticalHeader()
         vh.setVisible(False)
         vh.setSectionResizeMode(vh.ResizeMode.Fixed)
         vh.setDefaultSectionSize(24)
-        self.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Device-Property", "Value"])

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -146,7 +146,9 @@ class EditGroupWidget(QDialog):
         wdg.setLayout(layout)
 
         group_lbl = QLabel(text="Group name:")
-        group_lbl.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed))
+        group_lbl.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        )
 
         self.group_lineedit = QLineEdit()
 
@@ -200,7 +202,7 @@ class EditGroupWidget(QDialog):
 
         self.new_group_btn = QPushButton(text="Modify Group")
         self.new_group_btn.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.new_group_btn.clicked.connect(self._add_group)
 

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_preset_widget.py
@@ -85,7 +85,7 @@ class EditPresetWidget(QDialog):
         wdg_layout.setContentsMargins(5, 5, 5, 5)
         wdg.setLayout(wdg_layout)
 
-        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         gp_lbl = QLabel(text="Group:")
         gp_lbl.setSizePolicy(lbl_sizepolicy)
@@ -100,11 +100,11 @@ class EditPresetWidget(QDialog):
         ps_lbl.setSizePolicy(lbl_sizepolicy)
         self.preset_name_lineedit = QLineEdit()
         self.preset_name_lineedit.setSizePolicy(
-            QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         )
         self.preset_name_lineedit.setText(f"{self._preset}")
 
-        spacer = QSpacerItem(30, 10, QSizePolicy.Fixed, QSizePolicy.Fixed)
+        spacer = QSpacerItem(30, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         wdg_layout.addWidget(gp_lbl)
         wdg_layout.addWidget(group_name_lbl)
@@ -126,7 +126,7 @@ class EditPresetWidget(QDialog):
         self.info_lbl = QLabel()
         self.apply_button = QPushButton(text="Apply Changes")
         self.apply_button.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.apply_button.clicked.connect(self._apply_changes)
 
@@ -228,11 +228,11 @@ class _Table(QTableWidget):
         super().__init__()
         hdr = self.horizontalHeader()
         hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        hdr.setDefaultAlignment(Qt.AlignHCenter)
+        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
         vh = self.verticalHeader()
         vh.setVisible(False)
         vh.setSectionResizeMode(vh.ResizeMode.Fixed)
         vh.setDefaultSectionSize(24)
-        self.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Device-Property", "Value"])

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -37,13 +37,13 @@ class _MainTable(QTableWidget):
         super().__init__()
         hdr = self.horizontalHeader()
         hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        hdr.setDefaultAlignment(Qt.AlignHCenter)
+        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
         vh = self.verticalHeader()
         vh.setVisible(False)
         vh.setSectionResizeMode(vh.ResizeMode.Fixed)
         vh.setDefaultSectionSize(24)
-        self.setEditTriggers(QTableWidget.NoEditTriggers)
-        self.setSelectionBehavior(QTableWidget.SelectRows)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Group", "Preset"])
         self.setMinimumHeight(200)
@@ -106,7 +106,7 @@ class GroupPresetTableWidget(QGroupBox):
         main_wdg_layout.setContentsMargins(0, 0, 0, 0)
         main_wdg.setLayout(main_wdg_layout)
 
-        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         # groups
         groups_btn_wdg = QWidget()
@@ -162,7 +162,9 @@ class GroupPresetTableWidget(QGroupBox):
         save_btn_layout.setContentsMargins(0, 0, 0, 0)
         save_btn_wdg.setLayout(save_btn_layout)
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         save_btn_layout.addItem(spacer)
         self.save_btn = QPushButton(text="Save cfg")
         self.save_btn.clicked.connect(self._save_cfg)
@@ -201,7 +203,7 @@ class GroupPresetTableWidget(QGroupBox):
         if not device or not property or not value:
             return
 
-        if matching_item := self.table_wdg.findItems(group, Qt.MatchExactly):
+        if matching_item := self.table_wdg.findItems(group, Qt.MatchFlag.MatchExactly):
             row = matching_item[0].row()
 
             if isinstance(self.table_wdg.cellWidget(row, 1), PropertyWidget):
@@ -304,21 +306,23 @@ class GroupPresetTableWidget(QGroupBox):
 
         msg = self._msg_box(f"Delete '{',  '.join(groups)}'?")
 
-        if msg == QMessageBox.Ok:
+        if msg == QMessageBox.StandardButton.Ok:
             for row, group in enumerate(groups):
                 self.table_wdg.removeRow(row)
                 self._mmc.deleteConfigGroup(group)
 
     def _msg_box(self, msg: str) -> Any:
         msgBox = QMessageBox(parent=self)
-        msgBox.setIcon(QMessageBox.Warning)
+        msgBox.setIcon(QMessageBox.Icon.Warning)
         msgBox.setWindowTitle("Delete")
         msgBox.setText(msg)
-        msgBox.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+        msgBox.setStandardButtons(
+            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
+        )
         return msgBox.exec()
 
     def _on_group_deleted(self, group: str) -> None:
-        if matching_item := self.table_wdg.findItems(group, Qt.MatchExactly):
+        if matching_item := self.table_wdg.findItems(group, Qt.MatchFlag.MatchExactly):
             self.table_wdg.removeRow(matching_item[0].row())
 
     def _edit_group(self) -> None:
@@ -368,7 +372,7 @@ class GroupPresetTableWidget(QGroupBox):
 
         msg = self._msg_box(f"Delete '{',  '.join(_text)}'?")
 
-        if msg == QMessageBox.Ok:
+        if msg == QMessageBox.StandardButton.Ok:
             for row, group, wdg in groups_preset:
                 if isinstance(wdg, PresetsWidget):
                     preset = wdg._combo.currentText()

--- a/src/pymmcore_widgets/_mda_widget/_grid_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_grid_widget.py
@@ -48,14 +48,16 @@ class GridWidget(QDialog):
 
     def _create_row_cols_overlap_group(self) -> QGroupBox:
         group = QGroupBox(title="Grid Parameters")
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        group.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         group_layout = QGridLayout()
         group_layout.setSpacing(10)
         group_layout.setContentsMargins(10, 20, 10, 20)
         group.setLayout(group_layout)
 
         fix_size = 75
-        lbl_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        lbl_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         # row
         self.row_wdg = QWidget()
@@ -70,7 +72,7 @@ class GridWidget(QDialog):
         self.scan_size_spinBox_r = QSpinBox()
         self.scan_size_spinBox_r.setMinimumWidth(fix_size)
         self.scan_size_spinBox_r.setMinimum(1)
-        self.scan_size_spinBox_r.setAlignment(Qt.AlignCenter)
+        self.scan_size_spinBox_r.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.scan_size_spinBox_r.valueChanged.connect(self._update_info_label)
         row_wdg_lay.addWidget(row_label)
         row_wdg_lay.addWidget(self.scan_size_spinBox_r)
@@ -88,7 +90,7 @@ class GridWidget(QDialog):
         self.scan_size_spinBox_c = QSpinBox()
         self.scan_size_spinBox_c.setMinimumWidth(fix_size)
         self.scan_size_spinBox_c.setMinimum(1)
-        self.scan_size_spinBox_c.setAlignment(Qt.AlignCenter)
+        self.scan_size_spinBox_c.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.scan_size_spinBox_c.valueChanged.connect(self._update_info_label)
         col_wdg_lay.addWidget(col_label)
         col_wdg_lay.addWidget(self.scan_size_spinBox_c)
@@ -105,14 +107,14 @@ class GridWidget(QDialog):
         overlap_label.setSizePolicy(lbl_sizepolicy)
         self.ovelap_spinBox = QSpinBox()
         self.ovelap_spinBox.setMinimumWidth(fix_size)
-        self.ovelap_spinBox.setAlignment(Qt.AlignCenter)
+        self.ovelap_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.ovelap_spinBox.valueChanged.connect(self._update_info_label)
         ovl_wdg_lay.addWidget(overlap_label)
         ovl_wdg_lay.addWidget(self.ovelap_spinBox)
 
         # label info
         self.info_lbl = QLabel(text="_ µm x _ µm")
-        self.info_lbl.setAlignment(Qt.AlignCenter)
+        self.info_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         group_layout.addWidget(self.row_wdg, 0, 0)
         group_layout.addWidget(self.col_wdg, 1, 0)
@@ -133,7 +135,9 @@ class GridWidget(QDialog):
         wdg_layout.addWidget(self.clear_checkbox)
 
         self.generate_position_btn = QPushButton(text="Generate Position List")
-        self.generate_position_btn.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.generate_position_btn.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
         self.generate_position_btn.clicked.connect(self._send_positions_grid)
         wdg_layout.addWidget(self.generate_position_btn)
 

--- a/src/pymmcore_widgets/_mda_widget/_mda_gui.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_gui.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import (
 )
 from superqt.fonticon import icon
 
-LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
 
 class _MDAWidgetGui(QWidget):
@@ -100,7 +100,7 @@ class _MDAWidgetGui(QWidget):
         group_layout.addWidget(self.channel_tableWidget, 0, 0, 3, 1)
 
         # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         min_size = 100
         self.add_ch_button = QPushButton(text="Add")
         self.add_ch_button.setMinimumWidth(min_size)
@@ -125,7 +125,9 @@ class _MDAWidgetGui(QWidget):
         group = QGroupBox(title="Time")
         group.setCheckable(True)
         group.setChecked(False)
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        group.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         # group_layout = QHBoxLayout()
         group_layout = QGridLayout()
         group_layout.setSpacing(5)
@@ -144,9 +146,9 @@ class _MDAWidgetGui(QWidget):
         self.timepoints_spinBox.setMinimum(1)
         self.timepoints_spinBox.setMaximum(1000000)
         self.timepoints_spinBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         )
-        self.timepoints_spinBox.setAlignment(Qt.AlignCenter)
+        self.timepoints_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         wdg_lay.addWidget(lbl)
         wdg_lay.addWidget(self.timepoints_spinBox)
         group_layout.addWidget(wdg, 0, 0)
@@ -164,16 +166,16 @@ class _MDAWidgetGui(QWidget):
         self.interval_spinBox.setMinimum(0)
         self.interval_spinBox.setMaximum(100000)
         self.interval_spinBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         )
-        self.interval_spinBox.setAlignment(Qt.AlignCenter)
+        self.interval_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         wdg1_lay.addWidget(lbl1)
         wdg1_lay.addWidget(self.interval_spinBox)
         group_layout.addWidget(wdg1)
 
         self.time_comboBox = QComboBox()
         self.time_comboBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.time_comboBox.addItems(["ms", "sec", "min", "hours"])
         self.time_comboBox.setCurrentText("sec")
@@ -186,14 +188,16 @@ class _MDAWidgetGui(QWidget):
         wdg2_lay.setContentsMargins(0, 0, 0, 0)
         wdg2.setLayout(wdg2_lay)
         self._icon_lbl = QLabel()
-        self._icon_lbl.setAlignment(Qt.AlignLeft)
+        self._icon_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._icon_lbl.setSizePolicy(LBL_SIZEPOLICY)
         wdg2_lay.addWidget(self._icon_lbl)
         self._time_lbl = QLabel()
-        self._time_lbl.setAlignment(Qt.AlignLeft)
+        self._time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._time_lbl.setSizePolicy(LBL_SIZEPOLICY)
         wdg2_lay.addWidget(self._time_lbl)
-        spacer = QSpacerItem(10, 0, QSizePolicy.Expanding, QSizePolicy.Expanding)
+        spacer = QSpacerItem(
+            10, 0, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         wdg2_lay.addItem(spacer)
         group_layout.addWidget(wdg2, 1, 0, 1, 2)
 
@@ -206,7 +210,9 @@ class _MDAWidgetGui(QWidget):
         group = QGroupBox(title="Z Stacks")
         group.setCheckable(True)
         group.setChecked(False)
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        group.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         group_layout = QVBoxLayout()
         group_layout.setSpacing(10)
         group_layout.setContentsMargins(10, 10, 10, 10)
@@ -230,25 +236,25 @@ class _MDAWidgetGui(QWidget):
         self.set_bottom_Button = QPushButton(text="Set Bottom")
 
         lbl_range_tb = QLabel(text="Range (µm):")
-        lbl_range_tb.setAlignment(Qt.AlignCenter)
+        lbl_range_tb.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.z_top_doubleSpinBox = QDoubleSpinBox()
-        self.z_top_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_top_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_top_doubleSpinBox.setMinimum(0.0)
         self.z_top_doubleSpinBox.setMaximum(100000)
         self.z_top_doubleSpinBox.setDecimals(2)
 
         self.z_bottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_bottom_doubleSpinBox.setMinimum(0.0)
         self.z_bottom_doubleSpinBox.setMaximum(100000)
         self.z_bottom_doubleSpinBox.setDecimals(2)
 
         self.z_range_topbottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_range_topbottom_doubleSpinBox.setMaximum(10000000)
         self.z_range_topbottom_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.NoButtons
+            QAbstractSpinBox.ButtonSymbols.NoButtons
         )
         self.z_range_topbottom_doubleSpinBox.setReadOnly(True)
 
@@ -273,11 +279,11 @@ class _MDAWidgetGui(QWidget):
 
         self.zrange_spinBox = QSpinBox()
         self.zrange_spinBox.setValue(5)
-        self.zrange_spinBox.setAlignment(Qt.AlignCenter)
+        self.zrange_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.zrange_spinBox.setMaximum(100000)
 
         self.range_around_label = QLabel(text="-2.5 µm <- z -> +2.5 µm")
-        self.range_around_label.setAlignment(Qt.AlignCenter)
+        self.range_around_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         ra_layout.addWidget(lbl_range_ra)
         ra_layout.addWidget(self.zrange_spinBox)
@@ -292,30 +298,30 @@ class _MDAWidgetGui(QWidget):
         ab.setLayout(ab_layout)
 
         lbl_above = QLabel(text="Above (µm):")
-        lbl_above.setAlignment(Qt.AlignCenter)
+        lbl_above.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.above_doubleSpinBox = QDoubleSpinBox()
-        self.above_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.above_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.above_doubleSpinBox.setMinimum(0.05)
         self.above_doubleSpinBox.setMaximum(10000)
         self.above_doubleSpinBox.setSingleStep(0.5)
         self.above_doubleSpinBox.setDecimals(2)
 
         lbl_below = QLabel(text="Below (µm):")
-        lbl_below.setAlignment(Qt.AlignCenter)
+        lbl_below.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.below_doubleSpinBox = QDoubleSpinBox()
-        self.below_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.below_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.below_doubleSpinBox.setMinimum(0.05)
         self.below_doubleSpinBox.setMaximum(10000)
         self.below_doubleSpinBox.setSingleStep(0.5)
         self.below_doubleSpinBox.setDecimals(2)
 
         lbl_range = QLabel(text="Range (µm):")
-        lbl_range.setAlignment(Qt.AlignCenter)
+        lbl_range.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_range_abovebelow_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_range_abovebelow_doubleSpinBox.setMaximum(10000000)
         self.z_range_abovebelow_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.NoButtons
+            QAbstractSpinBox.ButtonSymbols.NoButtons
         )
         self.z_range_abovebelow_doubleSpinBox.setReadOnly(True)
 
@@ -343,7 +349,7 @@ class _MDAWidgetGui(QWidget):
         lbl = QLabel(text="Step Size (µm):")
         lbl.setSizePolicy(LBL_SIZEPOLICY)
         self.step_size_doubleSpinBox = QDoubleSpinBox()
-        self.step_size_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.step_size_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.step_size_doubleSpinBox.setMinimum(0.05)
         self.step_size_doubleSpinBox.setValue(1)
         self.step_size_doubleSpinBox.setMaximum(10000)
@@ -373,7 +379,9 @@ class _MDAWidgetGui(QWidget):
 
         # table
         self.stage_tableWidget = QTableWidget()
-        self.stage_tableWidget.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.stage_tableWidget.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
         hdr = self.stage_tableWidget.horizontalHeader()
         hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
         self.stage_tableWidget.verticalHeader().setVisible(False)
@@ -384,7 +392,7 @@ class _MDAWidgetGui(QWidget):
         group_layout.addWidget(self.stage_tableWidget, 0, 0, 5, 1)
 
         # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         min_size = 100
         self.add_pos_Button = QPushButton(text="Add")
         self.add_pos_Button.setMinimumWidth(min_size)
@@ -416,11 +424,11 @@ class _MDAWidgetGui(QWidget):
         wdg_lay = QHBoxLayout()
         wdg_lay.setSpacing(5)
         wdg_lay.setContentsMargins(10, 5, 10, 5)
-        wdg_lay.setAlignment(Qt.AlignLeft)
+        wdg_lay.setAlignment(Qt.AlignmentFlag.AlignLeft)
         wdg.setLayout(wdg_lay)
 
         self._total_time_lbl = QLabel()
-        self._total_time_lbl.setAlignment(Qt.AlignLeft)
+        self._total_time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._total_time_lbl.setSizePolicy(LBL_SIZEPOLICY)
         wdg_lay.addWidget(self._total_time_lbl)
 
@@ -429,9 +437,11 @@ class _MDAWidgetGui(QWidget):
     def _create_bottom_wdg(self) -> QWidget:
 
         wdg = QWidget()
-        wdg.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        wdg.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         wdg_layout = QHBoxLayout()
-        wdg_layout.setAlignment(Qt.AlignVCenter)
+        wdg_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
         wdg_layout.setSpacing(10)
         wdg_layout.setContentsMargins(10, 5, 10, 10)
         wdg.setLayout(wdg_layout)
@@ -449,7 +459,9 @@ class _MDAWidgetGui(QWidget):
         acq_wdg_layout.addWidget(acquisition_order_label)
         acq_wdg_layout.addWidget(self.acquisition_order_comboBox)
 
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        btn_sizepolicy = QSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
         min_width = 130
         icon_size = 40
         self.run_Button = QPushButton(text="Run")
@@ -470,7 +482,9 @@ class _MDAWidgetGui(QWidget):
         self.cancel_Button.setIcon(icon(MDI6.stop_circle_outline, color="magenta"))
         self.cancel_Button.setIconSize(QSize(icon_size, icon_size))
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Expanding)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
 
         wdg_layout.addWidget(acq_wdg)
         wdg_layout.addItem(spacer)

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -63,8 +63,12 @@ class MDAWidget(_MDAWidgetGui):
 
         self._mmc = mmcore or CMMCorePlus.instance()
 
-        self.pause_Button.released.connect(lambda: self._mmc.mda.toggle_pause())
-        self.cancel_Button.released.connect(lambda: self._mmc.mda.cancel())
+        self.pause_Button.released.connect(
+            lambda: self._mmc.mda.toggle_pause()  # type: ignore [no-untyped-call]
+        )
+        self.cancel_Button.released.connect(
+            lambda: self._mmc.mda.cancel()  # type: ignore [no-untyped-call]
+        )
 
         # connect buttons
         self.add_pos_Button.clicked.connect(self._add_position)
@@ -162,13 +166,21 @@ class MDAWidget(_MDAWidgetGui):
             self.stage_tableWidget.insertRow(rows)
 
             item = QtW.QTableWidgetItem(f"Grid{grid_number:03d}_Pos{idx:03d}")
-            item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            item.setTextAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+            )
             x = QtW.QTableWidgetItem(str(position[0]))
-            x.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            x.setTextAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+            )
             y = QtW.QTableWidgetItem(str(position[1]))
-            y.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            y.setTextAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+            )
             z = QtW.QTableWidgetItem(str(position[2]))
-            z.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            z.setTextAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+            )
 
             self.stage_tableWidget.setItem(rows, 0, item)
             self.stage_tableWidget.setItem(rows, 1, x)
@@ -372,7 +384,9 @@ class MDAWidget(_MDAWidgetGui):
                 if ax == "P":
                     count = self.stage_tableWidget.rowCount() - 1
                     item = QtW.QTableWidgetItem(f"Pos{count:03d}")
-                    item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+                    item.setTextAlignment(
+                        Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+                    )
                     self.stage_tableWidget.setItem(idx, c, item)
                     self._rename_positions(["Pos"])
                     continue
@@ -381,7 +395,9 @@ class MDAWidget(_MDAWidgetGui):
                     continue
                 cur = getattr(self._mmc, f"get{ax}Position")()
                 item = QtW.QTableWidgetItem(str(cur))
-                item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+                item.setTextAlignment(
+                    Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+                )
                 self.stage_tableWidget.setItem(idx, c, item)
 
             self._calculate_total_time()
@@ -421,7 +437,9 @@ class MDAWidget(_MDAWidgetGui):
                 else:
                     continue
                 item = QtW.QTableWidgetItem(new_name)
-                item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+                item.setTextAlignment(
+                    Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+                )
                 self.stage_tableWidget.setItem(r, 0, item)
 
     def _clear_positions(self) -> None:
@@ -527,7 +545,9 @@ class MDAWidget(_MDAWidgetGui):
                         item = QtW.QTableWidgetItem(str(pos_name))
                     else:
                         item = QtW.QTableWidgetItem(str(getattr(pos, ax)))
-                    item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+                    item.setTextAlignment(
+                        Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+                    )
                     self.stage_tableWidget.setItem(idx, c, item)
         else:
             self.stage_pos_groupBox.setChecked(False)

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -63,12 +63,8 @@ class MDAWidget(_MDAWidgetGui):
 
         self._mmc = mmcore or CMMCorePlus.instance()
 
-        self.pause_Button.released.connect(
-            lambda: self._mmc.mda.toggle_pause()  # type: ignore [no-untyped-call]
-        )
-        self.cancel_Button.released.connect(
-            lambda: self._mmc.mda.cancel()  # type: ignore [no-untyped-call]
-        )
+        self.pause_Button.released.connect(lambda: self._mmc.mda.toggle_pause())
+        self.cancel_Button.released.connect(lambda: self._mmc.mda.cancel())
 
         # connect buttons
         self.add_pos_Button.clicked.connect(self._add_position)

--- a/src/pymmcore_widgets/_pixel_size_widget.py
+++ b/src/pymmcore_widgets/_pixel_size_widget.py
@@ -38,12 +38,12 @@ class PixelSizeTable(QtW.QTableWidget):
         self._mmc = mmcore
         hh = self.horizontalHeader()
         hh.setSectionResizeMode(hh.ResizeMode.Stretch)
-        hh.setDefaultAlignment(Qt.AlignHCenter)
+        hh.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
         vh = self.verticalHeader()
         vh.setVisible(False)
         vh.setSectionResizeMode(hh.ResizeMode.Stretch)
-        self.setSelectionBehavior(QtW.QAbstractItemView.SelectItems)
-        self.setDragDropMode(QtW.QAbstractItemView.NoDragDrop)
+        self.setSelectionBehavior(QtW.QAbstractItemView.SelectionBehavior.SelectItems)
+        self.setDragDropMode(QtW.QAbstractItemView.DragDropMode.NoDragDrop)
 
     def _rebuild(
         self, obj_dev: str, _cam_mag_dict: Dict[str, Tuple[float, float]] = None  # type: ignore # noqa:E501
@@ -152,7 +152,7 @@ class PixelSizeTable(QtW.QTableWidget):
 
     def _new_line_edit(self, value: Any) -> QtW.QLineEdit:
         item = QtW.QLineEdit(str(value))
-        item.setAlignment(Qt.AlignCenter)
+        item.setAlignment(Qt.AlignmentFlag.AlignCenter)
         item.setFrame(False)
         if isinstance(value, (int, float)):
             item.setValidator(QDoubleValidator())
@@ -160,7 +160,9 @@ class PixelSizeTable(QtW.QTableWidget):
 
     def _new_table_item(self, value: Any, row: int) -> None:
         objective_item = QtW.QTableWidgetItem(value)
-        objective_item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+        objective_item.setFlags(
+            Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
+        )
         self.setItem(row, OBJECTIVE_LABEL, objective_item)
 
     def _new_delete_btn(self) -> QtW.QWidget:
@@ -168,12 +170,12 @@ class PixelSizeTable(QtW.QTableWidget):
         layout = QtW.QHBoxLayout()
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setAlignment(Qt.AlignCenter)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         wdg.setLayout(layout)
 
         btn = QtW.QPushButton(text="Delete")
         btn.setFixedWidth(70)
-        btn.setSizePolicy(QtW.QSizePolicy.Fixed, QtW.QSizePolicy.Fixed)
+        btn.setSizePolicy(QtW.QSizePolicy.Policy.Fixed, QtW.QSizePolicy.Policy.Fixed)
         btn.setToolTip("Delete configuration.")
         btn.clicked.connect(self._delete_cfg)
 
@@ -219,7 +221,7 @@ class PixelSizeWidget(QtW.QDialog):
         main_layout = QtW.QVBoxLayout()
         main_layout.setSpacing(0)
         main_layout.setContentsMargins(5, 5, 5, 5)
-        main_layout.setAlignment(Qt.AlignCenter)
+        main_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setLayout(main_layout)
 
         wdg = QtW.QGroupBox()
@@ -251,7 +253,7 @@ class PixelSizeWidget(QtW.QDialog):
         self.img_px_radiobtn.toggled.connect(self._on_img_toggle)
 
         spacer = QtW.QSpacerItem(
-            10, 10, QtW.QSizePolicy.Expanding, QtW.QSizePolicy.Minimum
+            10, 10, QtW.QSizePolicy.Policy.Expanding, QtW.QSizePolicy.Policy.Minimum
         )
         layout.addItem(spacer)
 

--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -117,7 +117,9 @@ class PresetsWidget(QWidget):
             dev_prop = self._get_preset_dev_prop(self._group, preset)
             if len(dev_prop) != len(self.dev_prop):
                 idx = self._presets.index(preset)
-                self._combo.setItemData(idx, QBrush(Qt.magenta), Qt.TextColorRole)
+                self._combo.setItemData(
+                    idx, QBrush(Qt.GlobalColor.magenta), Qt.ItemDataRole.ForegroundRole
+                )
 
     def _on_cfg_set(self, group: str, preset: str) -> None:
 

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (
 from superqt import QCollapsible
 from superqt.fonticon import icon
 
-LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
 
 class SampleExplorerGui(QWidget):
@@ -68,7 +68,9 @@ class SampleExplorerGui(QWidget):
         mda_options = self._create_mda_options()
         wdg_layout.addWidget(mda_options)
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+        )
         wdg_layout.addItem(spacer)
 
         return wdg
@@ -76,7 +78,9 @@ class SampleExplorerGui(QWidget):
     def _create_row_cols_overlap_group(self) -> QGroupBox:
 
         group = QGroupBox(title="Grid Parameters")
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        group.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         group_layout = QGridLayout()
         group_layout.setSpacing(10)
         group_layout.setContentsMargins(10, 20, 10, 20)
@@ -95,7 +99,7 @@ class SampleExplorerGui(QWidget):
         row_label.setSizePolicy(LBL_SIZEPOLICY)
         self.scan_size_spinBox_r = QSpinBox()
         self.scan_size_spinBox_r.setMinimum(1)
-        self.scan_size_spinBox_r.setAlignment(Qt.AlignCenter)
+        self.scan_size_spinBox_r.setAlignment(Qt.AlignmentFlag.AlignCenter)
         row_wdg_lay.addWidget(row_label)
         row_wdg_lay.addWidget(self.scan_size_spinBox_r)
 
@@ -111,7 +115,7 @@ class SampleExplorerGui(QWidget):
         self.scan_size_spinBox_c = QSpinBox()
         self.scan_size_spinBox_c.setSizePolicy
         self.scan_size_spinBox_c.setMinimum(1)
-        self.scan_size_spinBox_c.setAlignment(Qt.AlignCenter)
+        self.scan_size_spinBox_c.setAlignment(Qt.AlignmentFlag.AlignCenter)
         col_wdg_lay.addWidget(col_label)
         col_wdg_lay.addWidget(self.scan_size_spinBox_c)
 
@@ -125,7 +129,7 @@ class SampleExplorerGui(QWidget):
         overlap_label.setMaximumWidth(100)
         overlap_label.setSizePolicy(LBL_SIZEPOLICY)
         self.ovelap_spinBox = QSpinBox()
-        self.ovelap_spinBox.setAlignment(Qt.AlignCenter)
+        self.ovelap_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         ovl_wdg_lay.addWidget(overlap_label)
         ovl_wdg_lay.addWidget(self.ovelap_spinBox)
 
@@ -165,7 +169,7 @@ class SampleExplorerGui(QWidget):
         group_layout.addWidget(self.channel_explorer_tableWidget, 0, 0, 3, 1)
 
         # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         min_size = 100
         self.add_ch_explorer_Button = QPushButton(text="Add")
         self.add_ch_explorer_Button.setMinimumWidth(min_size)
@@ -202,7 +206,9 @@ class SampleExplorerGui(QWidget):
         group_layout.setContentsMargins(10, 15, 10, 15)
         group.setLayout(group_layout)
 
-        coll_sizepolicy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        coll_sizepolicy = QSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
 
         self.time_coll = QCollapsible(title="Time")
         self.time_coll.setSizePolicy(coll_sizepolicy)
@@ -244,7 +250,9 @@ class SampleExplorerGui(QWidget):
         group = QGroupBox()
         group.setCheckable(True)
         group.setChecked(False)
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        group.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         group_layout = QGridLayout()
         group_layout.setHorizontalSpacing(20)
         group_layout.setVerticalSpacing(5)
@@ -262,7 +270,7 @@ class SampleExplorerGui(QWidget):
         self.timepoints_spinBox = QSpinBox()
         self.timepoints_spinBox.setMinimum(1)
         self.timepoints_spinBox.setMaximum(10000)
-        self.timepoints_spinBox.setAlignment(Qt.AlignCenter)
+        self.timepoints_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         wdg_lay.addWidget(lbl)
         wdg_lay.addWidget(self.timepoints_spinBox)
         group_layout.addWidget(wdg, 0, 0)
@@ -278,14 +286,14 @@ class SampleExplorerGui(QWidget):
         self.interval_spinBox = QSpinBox()
         self.interval_spinBox.setMinimum(0)
         self.interval_spinBox.setMaximum(10000)
-        self.interval_spinBox.setAlignment(Qt.AlignCenter)
+        self.interval_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         wdg1_lay.addWidget(lbl1)
         wdg1_lay.addWidget(self.interval_spinBox)
         group_layout.addWidget(wdg1, 0, 1)
 
         self.time_comboBox = QComboBox()
         self.time_comboBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         )
         self.time_comboBox.addItems(["ms", "sec", "min", "hours"])
         group_layout.addWidget(self.time_comboBox, 0, 2)
@@ -296,14 +304,16 @@ class SampleExplorerGui(QWidget):
         wdg2_lay.setContentsMargins(0, 0, 0, 0)
         wdg2.setLayout(wdg2_lay)
         self._icon_lbl = QLabel()
-        self._icon_lbl.setAlignment(Qt.AlignLeft)
+        self._icon_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._icon_lbl.setSizePolicy(LBL_SIZEPOLICY)
         wdg2_lay.addWidget(self._icon_lbl)
         self._time_lbl = QLabel()
-        self._time_lbl.setAlignment(Qt.AlignLeft)
+        self._time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._time_lbl.setSizePolicy(LBL_SIZEPOLICY)
         wdg2_lay.addWidget(self._time_lbl)
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Expanding)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         wdg2_lay.addItem(spacer)
         group_layout.addWidget(wdg2, 1, 0, 1, 2)
 
@@ -317,7 +327,9 @@ class SampleExplorerGui(QWidget):
         group = QGroupBox()
         group.setCheckable(True)
         group.setChecked(False)
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        group.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         group_layout = QVBoxLayout()
         group_layout.setSpacing(10)
         group_layout.setContentsMargins(10, 10, 10, 10)
@@ -341,25 +353,25 @@ class SampleExplorerGui(QWidget):
         self.set_bottom_Button = QPushButton(text="Set Bottom")
 
         lbl_range_tb = QLabel(text="Range (µm):")
-        lbl_range_tb.setAlignment(Qt.AlignCenter)
+        lbl_range_tb.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.z_top_doubleSpinBox = QDoubleSpinBox()
-        self.z_top_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_top_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_top_doubleSpinBox.setMinimum(0.0)
         self.z_top_doubleSpinBox.setMaximum(100000)
         self.z_top_doubleSpinBox.setDecimals(2)
 
         self.z_bottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_bottom_doubleSpinBox.setMinimum(0.0)
         self.z_bottom_doubleSpinBox.setMaximum(100000)
         self.z_bottom_doubleSpinBox.setDecimals(2)
 
         self.z_range_topbottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_range_topbottom_doubleSpinBox.setMaximum(10000000)
         self.z_range_topbottom_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.NoButtons
+            QAbstractSpinBox.ButtonSymbols.NoButtons
         )
         self.z_range_topbottom_doubleSpinBox.setReadOnly(True)
 
@@ -384,11 +396,11 @@ class SampleExplorerGui(QWidget):
 
         self.zrange_spinBox = QSpinBox()
         self.zrange_spinBox.setValue(5)
-        self.zrange_spinBox.setAlignment(Qt.AlignCenter)
+        self.zrange_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.zrange_spinBox.setMaximum(100000)
 
         self.range_around_label = QLabel(text="-2.5 µm <- z -> +2.5 µm")
-        self.range_around_label.setAlignment(Qt.AlignCenter)
+        self.range_around_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         ra_layout.addWidget(lbl_range_ra)
         ra_layout.addWidget(self.zrange_spinBox)
@@ -403,30 +415,30 @@ class SampleExplorerGui(QWidget):
         ab.setLayout(ab_layout)
 
         lbl_above = QLabel(text="Above (µm):")
-        lbl_above.setAlignment(Qt.AlignCenter)
+        lbl_above.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.above_doubleSpinBox = QDoubleSpinBox()
-        self.above_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.above_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.above_doubleSpinBox.setMinimum(0.05)
         self.above_doubleSpinBox.setMaximum(10000)
         self.above_doubleSpinBox.setSingleStep(0.5)
         self.above_doubleSpinBox.setDecimals(2)
 
         lbl_below = QLabel(text="Below (µm):")
-        lbl_below.setAlignment(Qt.AlignCenter)
+        lbl_below.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.below_doubleSpinBox = QDoubleSpinBox()
-        self.below_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.below_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.below_doubleSpinBox.setMinimum(0.05)
         self.below_doubleSpinBox.setMaximum(10000)
         self.below_doubleSpinBox.setSingleStep(0.5)
         self.below_doubleSpinBox.setDecimals(2)
 
         lbl_range = QLabel(text="Range (µm):")
-        lbl_range.setAlignment(Qt.AlignCenter)
+        lbl_range.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_range_abovebelow_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.z_range_abovebelow_doubleSpinBox.setMaximum(10000000)
         self.z_range_abovebelow_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.NoButtons
+            QAbstractSpinBox.ButtonSymbols.NoButtons
         )
         self.z_range_abovebelow_doubleSpinBox.setReadOnly(True)
 
@@ -454,7 +466,7 @@ class SampleExplorerGui(QWidget):
         lbl = QLabel(text="Step Size (µm):")
         lbl.setSizePolicy(LBL_SIZEPOLICY)
         self.step_size_doubleSpinBox = QDoubleSpinBox()
-        self.step_size_doubleSpinBox.setAlignment(Qt.AlignCenter)
+        self.step_size_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.step_size_doubleSpinBox.setMinimum(0.05)
         self.step_size_doubleSpinBox.setMaximum(10000)
         self.step_size_doubleSpinBox.setSingleStep(0.5)
@@ -484,7 +496,9 @@ class SampleExplorerGui(QWidget):
 
         # table
         self.stage_tableWidget = QTableWidget()
-        self.stage_tableWidget.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.stage_tableWidget.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
         hdr = self.stage_tableWidget.horizontalHeader()
         hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
         self.stage_tableWidget.verticalHeader().setVisible(False)
@@ -495,7 +509,7 @@ class SampleExplorerGui(QWidget):
         group_layout.addWidget(self.stage_tableWidget, 0, 0, 4, 1)
 
         # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         min_size = 100
         self.add_pos_Button = QPushButton(text="Add")
         self.add_pos_Button.setMinimumWidth(min_size)
@@ -520,7 +534,9 @@ class SampleExplorerGui(QWidget):
     def _create_start_stop_buttons(self) -> QWidget:
 
         wdg = QWidget()
-        wdg.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        wdg.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
         wdg_layout = QHBoxLayout()
         wdg_layout.setSpacing(10)
         wdg_layout.setContentsMargins(10, 5, 10, 10)
@@ -540,10 +556,14 @@ class SampleExplorerGui(QWidget):
         acq_wdg_layout.addWidget(self.acquisition_order_comboBox)
         wdg_layout.addWidget(acq_wdg)
 
-        spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Fixed)
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         wdg_layout.addItem(spacer)
 
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        btn_sizepolicy = QSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
         min_width = 100
         icon_size = 40
         self.start_scan_Button = QPushButton(text="Run")
@@ -583,11 +603,11 @@ class SampleExplorerGui(QWidget):
         wdg_lay = QHBoxLayout()
         wdg_lay.setSpacing(3)
         wdg_lay.setContentsMargins(10, 5, 10, 5)
-        wdg_lay.setAlignment(Qt.AlignLeft)
+        wdg_lay.setAlignment(Qt.AlignmentFlag.AlignLeft)
         wdg.setLayout(wdg_lay)
 
         self._total_time_lbl = QLabel()
-        self._total_time_lbl.setAlignment(Qt.AlignLeft)
+        self._total_time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._total_time_lbl.setSizePolicy(LBL_SIZEPOLICY)
         wdg_lay.addWidget(self._total_time_lbl)
 

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -95,7 +95,9 @@ class SampleExplorerWidget(SampleExplorerGui):
         if self._include_run_button:
             self.start_scan_Button.clicked.connect(self._start_scan)
         self.cancel_scan_Button.clicked.connect(self._mmc.mda.cancel)
-        self.pause_scan_Button.clicked.connect(lambda: self._mmc.mda.toggle_pause())
+        self.pause_scan_Button.clicked.connect(
+            lambda: self._mmc.mda.toggle_pause()  # type: ignore [no-untyped-call]
+        )
 
         # connect toggle
         self.time_groupBox.toggled.connect(self._calculate_total_time)
@@ -273,7 +275,9 @@ class SampleExplorerWidget(SampleExplorerGui):
                     count = self.stage_tableWidget.rowCount()
                     item = QtW.QTableWidgetItem(f"Grid_{count:03d}")
                     item.setWhatsThis(f"Grid_{count:03d}")
-                    item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+                    item.setTextAlignment(
+                        Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+                    )
                     self.stage_tableWidget.setItem(idx, c, item)
                     self._rename_positions()
                     continue
@@ -283,7 +287,9 @@ class SampleExplorerWidget(SampleExplorerGui):
 
                 cur = getattr(self._mmc, f"get{ax}Position")()
                 item = QtW.QTableWidgetItem(str(cur))
-                item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+                item.setTextAlignment(
+                    Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+                )
                 self.stage_tableWidget.setItem(idx, c, item)
 
         self._calculate_total_time()
@@ -319,7 +325,9 @@ class SampleExplorerWidget(SampleExplorerGui):
             new_whatisthis = f"Grid_{grid_count:03d}"
 
             item = QtW.QTableWidgetItem(new_name)
-            item.setTextAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            item.setTextAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+            )
             item.setWhatsThis(new_whatisthis)
             self.stage_tableWidget.setItem(r, 0, item)
 

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -95,9 +95,7 @@ class SampleExplorerWidget(SampleExplorerGui):
         if self._include_run_button:
             self.start_scan_Button.clicked.connect(self._start_scan)
         self.cancel_scan_Button.clicked.connect(self._mmc.mda.cancel)
-        self.pause_scan_Button.clicked.connect(
-            lambda: self._mmc.mda.toggle_pause()  # type: ignore [no-untyped-call]
-        )
+        self.pause_scan_Button.clicked.connect(lambda: self._mmc.mda.toggle_pause())
 
         # connect toggle
         self.time_groupBox.toggled.connect(self._calculate_total_time)

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -200,7 +200,9 @@ class ShuttersWidget(QtW.QWidget):
         main_layout.setSpacing(3)
 
         self.shutter_button = QtW.QPushButton(text=self._button_text_closed)
-        sizepolicy_btn = QtW.QSizePolicy(QtW.QSizePolicy.Fixed, QtW.QSizePolicy.Fixed)
+        sizepolicy_btn = QtW.QSizePolicy(
+            QtW.QSizePolicy.Policy.Fixed, QtW.QSizePolicy.Policy.Fixed
+        )
         self.shutter_button.setSizePolicy(sizepolicy_btn)
         self.shutter_button.setIcon(
             icon(self._icon_closed, color=self._icon_color_closed)
@@ -211,7 +213,7 @@ class ShuttersWidget(QtW.QWidget):
 
         self.autoshutter_checkbox = QtW.QCheckBox(text="Auto")
         sizepolicy_checkbox = QtW.QSizePolicy(
-            QtW.QSizePolicy.Fixed, QtW.QSizePolicy.Fixed
+            QtW.QSizePolicy.Policy.Fixed, QtW.QSizePolicy.Policy.Fixed
         )
         self.autoshutter_checkbox.setSizePolicy(sizepolicy_checkbox)
         self.autoshutter_checkbox.setChecked(False)

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -34,7 +34,9 @@ class SnapButton(QPushButton):
 
         super().__init__(parent)
 
-        self.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
+        self.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        )
 
         self._mmc = mmcore or CMMCorePlus.instance()
 

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -79,9 +79,9 @@ def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
     dev_prop_list = ["Camera-Binning", "Camera-BitDepth", "Camera-CCDTemperature"]
 
-    bin_match = table.findItems("Camera-Binning", Qt.MatchExactly)
-    bit_match = table.findItems("Camera-BitDepth", Qt.MatchExactly)
-    t_match = table.findItems("Camera-CCDTemperature", Qt.MatchExactly)
+    bin_match = table.findItems("Camera-Binning", Qt.MatchFlag.MatchExactly)
+    bit_match = table.findItems("Camera-BitDepth", Qt.MatchFlag.MatchExactly)
+    t_match = table.findItems("Camera-CCDTemperature", Qt.MatchFlag.MatchExactly)
 
     rows = [bin_match[0].row(), bit_match[0].row(), t_match[0].row()]
 
@@ -141,9 +141,9 @@ def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
     table = edit_gp._prop_table
 
-    bin_match = table.findItems("Camera-Binning", Qt.MatchExactly)
+    bin_match = table.findItems("Camera-Binning", Qt.MatchFlag.MatchExactly)
     bin_row = bin_match[0].row()
-    bit_match = table.findItems("Camera-BitDepth", Qt.MatchExactly)
+    bit_match = table.findItems("Camera-BitDepth", Qt.MatchFlag.MatchExactly)
     bit_row = bit_match[0].row()
 
     bin_cbox = table.cellWidget(bin_row, 0)
@@ -158,7 +158,7 @@ def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     edit_gp.new_group_btn.click()
     assert edit_gp.info_lbl.text() == ""
 
-    t_match = table.findItems("Camera-CCDTemperature", Qt.MatchExactly)
+    t_match = table.findItems("Camera-CCDTemperature", Qt.MatchFlag.MatchExactly)
     t_row = t_match[0].row()
 
     t_cbox = table.cellWidget(t_row, 0)


### PR DESCRIPTION
This fixes a lot more Qt namespaces.

@fdrgsp  ... the longer story here is that Qt has moved away from putting all Enums of a given class at the top level, and now requires the full namespace.  For example, rather than `QSizePolicy.Fixed`, it should be `QSizePolicy.Policy.Fixed` ... and so on.  They've supported the new full namespace since about 5.12 (and deprecated the top level access back then as well)... and are finally removing them, which is why you saw that PySide6 error.

so we should just always prefer the full name