### PR TITLE
ci: add ci to build docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: docs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Install dependencies
+        run: |
+          pip install -e .[docs,image]
+          pip install pyside2
+          python -m pymmcore_plus.install
+
+      - name: Test docs
+        if: github.event_name == 'pull_request'
+        run: mkdocs build --strict
+
+      - name: Deploy docs
+        if: github.ref == 'refs/heads/main'
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install -e .[docs,image]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: Widgets to control micro-manager in python.
 repo_name: pymmcore-plus/pymmcore-widgets
 repo_url: https://github.com/pymmcore-plus/pymmcore-widgets
 edit_uri: edit/main/docs/
-# strict: true
+strict: true
 
 theme:
   name: "material"
@@ -88,7 +88,6 @@ plugins:
             show_source: false
             # show_bases: false
             # members_order: alphabetical # alphabetical/source
-
             # docstring_section_style: list # or table/list/spacy
 
 extra_css:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "rich",
 ]
 docs = [
+    "vispy",
     "mkdocs",
     "mkdocs-material",
     "mkdocstrings-python",


### PR DESCRIPTION
this will deploy docs to gh-pages on push to main, and test it on any pull-request