### PR TITLE
feat: General Widgets for MDAs

### DIFF
--- a/src/pymmcore_widgets/_general_mda_widgets.py
+++ b/src/pymmcore_widgets/_general_mda_widgets.py
@@ -1,0 +1,478 @@
+from typing import List, Optional
+
+from fonticon_mdi6 import MDI6
+from qtpy.QtCore import QSize, Qt
+from qtpy.QtWidgets import (
+    QAbstractItemView,
+    QAbstractSpinBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QSpacerItem,
+    QSpinBox,
+    QTableWidget,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+from superqt.fonticon import icon
+
+
+class MDAChannelTable(QGroupBox):
+    def __init__(self, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent=parent)
+
+        self.setTitle("Channels")
+        # self.setMinimumHeight(200)
+
+        group_layout = QHBoxLayout()
+        group_layout.setSpacing(15)
+        group_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(group_layout)
+
+        # channel table
+        self.channel_tableWidget = QTableWidget()
+
+        self.channel_tableWidget.setMinimumHeight(100)
+        hdr = self.channel_tableWidget.horizontalHeader()
+        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
+        self.channel_tableWidget.verticalHeader().setVisible(False)
+        self.channel_tableWidget.setTabKeyNavigation(True)
+        self.channel_tableWidget.setColumnCount(2)
+        self.channel_tableWidget.setRowCount(0)
+        self.channel_tableWidget.setHorizontalHeaderLabels(
+            ["Channel", "Exposure Time (ms)"]
+        )
+        group_layout.addWidget(self.channel_tableWidget)
+
+        # buttons
+        wdg = QWidget()
+        layout = QVBoxLayout()
+        layout.setSpacing(10)
+        layout.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(layout)
+
+        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        min_size = 100
+        self.add_ch_button = QPushButton(text="Add")
+        self.add_ch_button.setMinimumWidth(min_size)
+        self.add_ch_button.setSizePolicy(btn_sizepolicy)
+        self.remove_ch_button = QPushButton(text="Remove")
+        self.remove_ch_button.setMinimumWidth(min_size)
+        self.remove_ch_button.setSizePolicy(btn_sizepolicy)
+        self.clear_ch_button = QPushButton(text="Clear")
+        self.clear_ch_button.setMinimumWidth(min_size)
+        self.clear_ch_button.setSizePolicy(btn_sizepolicy)
+        spacer = QSpacerItem(
+            10, 0, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+        )
+
+        layout.addWidget(self.add_ch_button)
+        layout.addWidget(self.remove_ch_button)
+        layout.addWidget(self.clear_ch_button)
+        layout.addItem(spacer)
+
+        group_layout.addWidget(wdg)
+
+
+class MDATimeWidget(QGroupBox):
+    def __init__(self, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent=parent)
+
+        self.setTitle("Time")
+
+        self.setCheckable(True)
+        self.setChecked(False)
+        self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+
+        group_layout = QGridLayout()
+        group_layout.setSpacing(5)
+        group_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(group_layout)
+
+        # Timepoints
+        wdg = QWidget()
+        wdg_lay = QHBoxLayout()
+        wdg_lay.setSpacing(5)
+        wdg_lay.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(wdg_lay)
+        lbl = QLabel(text="Timepoints:")
+        lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.timepoints_spinBox = QSpinBox()
+        self.timepoints_spinBox.setMinimum(1)
+        self.timepoints_spinBox.setMaximum(1000000)
+        self.timepoints_spinBox.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        )
+        self.timepoints_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        wdg_lay.addWidget(lbl)
+        wdg_lay.addWidget(self.timepoints_spinBox)
+        group_layout.addWidget(wdg, 0, 0)
+
+        # Interval
+        wdg1 = QWidget()
+        wdg1_lay = QHBoxLayout()
+        wdg1_lay.setSpacing(5)
+        wdg1_lay.setContentsMargins(0, 0, 0, 0)
+        wdg1.setLayout(wdg1_lay)
+        lbl1 = QLabel(text="Interval:  ")
+        lbl1.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.interval_spinBox = QDoubleSpinBox()
+        self.interval_spinBox.setValue(1.0)
+        self.interval_spinBox.setMinimum(0)
+        self.interval_spinBox.setMaximum(100000)
+        self.interval_spinBox.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self.interval_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        wdg1_lay.addWidget(lbl1)
+        wdg1_lay.addWidget(self.interval_spinBox)
+        group_layout.addWidget(wdg1)
+
+        self.time_comboBox = QComboBox()
+        self.time_comboBox.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        self.time_comboBox.addItems(["ms", "sec", "min", "hours"])
+        self.time_comboBox.setCurrentText("sec")
+        wdg1_lay.addWidget(self.time_comboBox)
+        group_layout.addWidget(wdg1, 0, 1)
+
+        wdg2 = QWidget()
+        wdg2_lay = QHBoxLayout()
+        wdg2_lay.setSpacing(5)
+        wdg2_lay.setContentsMargins(0, 0, 0, 0)
+        wdg2.setLayout(wdg2_lay)
+        self._icon_lbl = QLabel()
+        self._icon_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self._icon_lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        wdg2_lay.addWidget(self._icon_lbl)
+        self._time_lbl = QLabel()
+        self._time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self._time_lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        wdg2_lay.addWidget(self._time_lbl)
+        spacer = QSpacerItem(
+            10, 0, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
+        wdg2_lay.addItem(spacer)
+        group_layout.addWidget(wdg2, 1, 0, 1, 2)
+
+        self._time_lbl.hide()
+        self._icon_lbl.hide()
+
+
+class MDAStackWidget(QGroupBox):
+    def __init__(self, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent=parent)
+
+        self.setTitle("Z Stack")
+
+        self.setCheckable(True)
+        self.setChecked(False)
+        self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+
+        group_layout = QVBoxLayout()
+        group_layout.setSpacing(10)
+        group_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(group_layout)
+
+        # tab
+        self.z_tabWidget = QTabWidget()
+        z_tab_layout = QVBoxLayout()
+        z_tab_layout.setSpacing(0)
+        z_tab_layout.setContentsMargins(0, 0, 0, 0)
+        self.z_tabWidget.setLayout(z_tab_layout)
+        group_layout.addWidget(self.z_tabWidget)
+
+        # top bottom
+        tb = QWidget()
+        tb_layout = QGridLayout()
+        tb_layout.setContentsMargins(10, 10, 10, 10)
+        tb.setLayout(tb_layout)
+
+        self.set_top_Button = QPushButton(text="Set Top")
+        self.set_bottom_Button = QPushButton(text="Set Bottom")
+
+        lbl_range_tb = QLabel(text="Range (µm):")
+        lbl_range_tb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.z_top_doubleSpinBox = QDoubleSpinBox()
+        self.z_top_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_top_doubleSpinBox.setMinimum(0.0)
+        self.z_top_doubleSpinBox.setMaximum(100000)
+        self.z_top_doubleSpinBox.setDecimals(2)
+
+        self.z_bottom_doubleSpinBox = QDoubleSpinBox()
+        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_bottom_doubleSpinBox.setMinimum(0.0)
+        self.z_bottom_doubleSpinBox.setMaximum(100000)
+        self.z_bottom_doubleSpinBox.setDecimals(2)
+
+        self.z_range_topbottom_doubleSpinBox = QDoubleSpinBox()
+        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_range_topbottom_doubleSpinBox.setMaximum(10000000)
+        self.z_range_topbottom_doubleSpinBox.setButtonSymbols(
+            QAbstractSpinBox.ButtonSymbols.NoButtons
+        )
+        self.z_range_topbottom_doubleSpinBox.setReadOnly(True)
+
+        tb_layout.addWidget(self.set_top_Button, 0, 0)
+        tb_layout.addWidget(self.z_top_doubleSpinBox, 1, 0)
+        tb_layout.addWidget(self.set_bottom_Button, 0, 1)
+        tb_layout.addWidget(self.z_bottom_doubleSpinBox, 1, 1)
+        tb_layout.addWidget(lbl_range_tb, 0, 2)
+        tb_layout.addWidget(self.z_range_topbottom_doubleSpinBox, 1, 2)
+
+        self.z_tabWidget.addTab(tb, "TopBottom")
+
+        # range around
+        ra = QWidget()
+        ra_layout = QHBoxLayout()
+        ra_layout.setSpacing(10)
+        ra_layout.setContentsMargins(10, 10, 10, 10)
+        ra.setLayout(ra_layout)
+
+        lbl_range_ra = QLabel(text="Range (µm):")
+        lbl_range_ra.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+
+        self.zrange_spinBox = QSpinBox()
+        self.zrange_spinBox.setValue(5)
+        self.zrange_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.zrange_spinBox.setMaximum(100000)
+
+        self.range_around_label = QLabel(text="-2.5 µm <- z -> +2.5 µm")
+        self.range_around_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        ra_layout.addWidget(lbl_range_ra)
+        ra_layout.addWidget(self.zrange_spinBox)
+        ra_layout.addWidget(self.range_around_label)
+
+        self.z_tabWidget.addTab(ra, "RangeAround")
+
+        # above below wdg
+        ab = QWidget()
+        ab_layout = QGridLayout()
+        ab_layout.setContentsMargins(10, 0, 10, 15)
+        ab.setLayout(ab_layout)
+
+        lbl_above = QLabel(text="Above (µm):")
+        lbl_above.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.above_doubleSpinBox = QDoubleSpinBox()
+        self.above_doubleSpinBox.setValue(2)
+        self.above_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.above_doubleSpinBox.setMinimum(0.05)
+        self.above_doubleSpinBox.setMaximum(10000)
+        self.above_doubleSpinBox.setSingleStep(0.5)
+        self.above_doubleSpinBox.setDecimals(2)
+
+        lbl_below = QLabel(text="Below (µm):")
+        lbl_below.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.below_doubleSpinBox = QDoubleSpinBox()
+        self.below_doubleSpinBox.setValue(2)
+        self.below_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.below_doubleSpinBox.setMinimum(0.05)
+        self.below_doubleSpinBox.setMaximum(10000)
+        self.below_doubleSpinBox.setSingleStep(0.5)
+        self.below_doubleSpinBox.setDecimals(2)
+
+        lbl_range = QLabel(text="Range (µm):")
+        lbl_range.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_range_abovebelow_doubleSpinBox = QDoubleSpinBox()
+        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_range_abovebelow_doubleSpinBox.setMaximum(10000000)
+        self.z_range_abovebelow_doubleSpinBox.setButtonSymbols(
+            QAbstractSpinBox.ButtonSymbols.NoButtons
+        )
+        self.z_range_abovebelow_doubleSpinBox.setReadOnly(True)
+
+        ab_layout.addWidget(lbl_above, 0, 0)
+        ab_layout.addWidget(self.above_doubleSpinBox, 1, 0)
+        ab_layout.addWidget(lbl_below, 0, 1)
+        ab_layout.addWidget(self.below_doubleSpinBox, 1, 1)
+        ab_layout.addWidget(lbl_range, 0, 2)
+        ab_layout.addWidget(self.z_range_abovebelow_doubleSpinBox, 1, 2)
+
+        self.z_tabWidget.addTab(ab, "AboveBelow")
+
+        # step size wdg
+        step_wdg = QWidget()
+        step_wdg_layout = QHBoxLayout()
+        step_wdg_layout.setSpacing(15)
+        step_wdg_layout.setContentsMargins(0, 10, 0, 0)
+        step_wdg.setLayout(step_wdg_layout)
+
+        s = QWidget()
+        s_layout = QHBoxLayout()
+        s_layout.setSpacing(0)
+        s_layout.setContentsMargins(0, 0, 0, 0)
+        s.setLayout(s_layout)
+        lbl = QLabel(text="Step Size (µm):")
+        lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.step_size_doubleSpinBox = QDoubleSpinBox()
+        self.step_size_doubleSpinBox.setValue(1)
+        self.step_size_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.step_size_doubleSpinBox.setMinimum(0.05)
+        self.step_size_doubleSpinBox.setMaximum(10000)
+        self.step_size_doubleSpinBox.setSingleStep(0.5)
+        self.step_size_doubleSpinBox.setDecimals(2)
+        s_layout.addWidget(lbl)
+        s_layout.addWidget(self.step_size_doubleSpinBox)
+
+        self.n_images_label = QLabel(text="Number of Images:")
+
+        step_wdg_layout.addWidget(s)
+        step_wdg_layout.addWidget(self.n_images_label)
+        group_layout.addWidget(step_wdg)
+
+
+class MDAPositionTable(QGroupBox):
+    def __init__(self, header: List[str], *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent=parent)
+
+        self.setTitle("Stage Positions")
+
+        self.setCheckable(True)
+        self.setChecked(False)
+        # self.setMinimumHeight(230)
+
+        group_layout = QHBoxLayout()
+        group_layout.setSpacing(15)
+        group_layout.setContentsMargins(10, 10, 10, 10)
+        self.setLayout(group_layout)
+
+        # table
+        self.stage_tableWidget = QTableWidget()
+        self.stage_tableWidget.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        hdr = self.stage_tableWidget.horizontalHeader()
+        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
+        self.stage_tableWidget.verticalHeader().setVisible(False)
+        self.stage_tableWidget.setTabKeyNavigation(True)
+        self.stage_tableWidget.setColumnCount(4)
+        self.stage_tableWidget.setRowCount(0)
+        self.stage_tableWidget.setHorizontalHeaderLabels(header)
+        group_layout.addWidget(self.stage_tableWidget)
+
+        # buttons
+        wdg = QWidget()
+        layout = QVBoxLayout()
+        layout.setSpacing(10)
+        layout.setContentsMargins(0, 0, 0, 0)
+        wdg.setLayout(layout)
+
+        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        min_size = 100
+        self.add_pos_Button = QPushButton(text="Add")
+        self.add_pos_Button.setMinimumWidth(min_size)
+        self.add_pos_Button.setSizePolicy(btn_sizepolicy)
+        self.remove_pos_Button = QPushButton(text="Remove")
+        self.remove_pos_Button.setMinimumWidth(min_size)
+        self.remove_pos_Button.setSizePolicy(btn_sizepolicy)
+        self.clear_pos_Button = QPushButton(text="Clear")
+        self.clear_pos_Button.setMinimumWidth(min_size)
+        self.clear_pos_Button.setSizePolicy(btn_sizepolicy)
+        self.grid_Button = QPushButton(text="Grid")
+        self.grid_Button.setMinimumWidth(min_size)
+        self.grid_Button.setSizePolicy(btn_sizepolicy)
+        self.go = QPushButton(text="Go")
+        self.go.setMinimumWidth(min_size)
+        self.go.setSizePolicy(btn_sizepolicy)
+
+        spacer = QSpacerItem(
+            10, 0, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+        )
+
+        layout.addWidget(self.add_pos_Button)
+        layout.addWidget(self.remove_pos_Button)
+        layout.addWidget(self.clear_pos_Button)
+        layout.addWidget(self.grid_Button)
+        layout.addWidget(self.go)
+        layout.addItem(spacer)
+
+        group_layout.addWidget(wdg)
+
+
+class MDAControlButtons(QWidget):
+    def __init__(self, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent=parent)
+
+        self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        wdg_layout = QHBoxLayout()
+        wdg_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
+        wdg_layout.setSpacing(10)
+        wdg_layout.setContentsMargins(10, 5, 10, 10)
+        self.setLayout(wdg_layout)
+
+        acq_wdg = QWidget()
+        acq_wdg_layout = QHBoxLayout()
+        acq_wdg_layout.setSpacing(0)
+        acq_wdg_layout.setContentsMargins(0, 0, 0, 0)
+        acq_wdg.setLayout(acq_wdg_layout)
+        acquisition_order_label = QLabel(text="Acquisition Order:")
+        acquisition_order_label.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        self.acquisition_order_comboBox = QComboBox()
+        self.acquisition_order_comboBox.setMinimumWidth(100)
+        self.acquisition_order_comboBox.addItems(["tpcz", "tpzc", "ptzc", "ptcz"])
+        acq_wdg_layout.addWidget(acquisition_order_label)
+        acq_wdg_layout.addWidget(self.acquisition_order_comboBox)
+
+        btn_sizepolicy = QSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
+        min_width = 130
+        icon_size = 40
+        self.run_button = QPushButton(text="Run")
+        self.run_button.setEnabled(False)
+        self.run_button.setMinimumWidth(min_width)
+        self.run_button.setStyleSheet("QPushButton { text-align: center; }")
+        self.run_button.setSizePolicy(btn_sizepolicy)
+        self.run_button.setIcon(icon(MDI6.play_circle_outline, color=(0, 255, 0)))
+        self.run_button.setIconSize(QSize(icon_size, icon_size))
+        self.pause_button = QPushButton("Pause")
+        self.pause_button.setStyleSheet("QPushButton { text-align: center; }")
+        self.pause_button.setSizePolicy(btn_sizepolicy)
+        self.pause_button.setIcon(icon(MDI6.pause_circle_outline, color="green"))
+        self.pause_button.setIconSize(QSize(icon_size, icon_size))
+        self.pause_button.hide()
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.setStyleSheet("QPushButton { text-align: center; }")
+        self.cancel_button.setSizePolicy(btn_sizepolicy)
+        self.cancel_button.setIcon(icon(MDI6.stop_circle_outline, color="magenta"))
+        self.cancel_button.setIconSize(QSize(icon_size, icon_size))
+        self.cancel_button.hide()
+
+        spacer = QSpacerItem(
+            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
+
+        wdg_layout.addWidget(acq_wdg)
+        wdg_layout.addItem(spacer)
+        wdg_layout.addWidget(self.run_button)
+        wdg_layout.addWidget(self.pause_button)
+        wdg_layout.addWidget(self.cancel_button)
+
+
+class MDATimeLabel(QWidget):
+    def __init__(self, *, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent=parent)
+
+        wdg_lay = QHBoxLayout()
+        wdg_lay.setSpacing(5)
+        wdg_lay.setContentsMargins(10, 5, 10, 5)
+        wdg_lay.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self.setLayout(wdg_lay)
+
+        self._total_time_lbl = QLabel()
+        self._total_time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self._total_time_lbl.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        wdg_lay.addWidget(self._total_time_lbl)

--- a/src/pymmcore_widgets/_general_mda_widgets.py
+++ b/src/pymmcore_widgets/_general_mda_widgets.py
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (
 from superqt.fonticon import icon
 
 
-class MDAChannelTable(QGroupBox):
+class _MDAChannelTable(QGroupBox):
     def __init__(self, *, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent=parent)
 
@@ -78,7 +78,7 @@ class MDAChannelTable(QGroupBox):
         group_layout.addWidget(wdg, 0, 1)
 
 
-class MDATimeWidget(QGroupBox):
+class _MDATimeWidget(QGroupBox):
     def __init__(self, *, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent=parent)
 
@@ -164,7 +164,7 @@ class MDATimeWidget(QGroupBox):
         self._icon_lbl.hide()
 
 
-class MDAStackWidget(QGroupBox):
+class _MDAStackWidget(QGroupBox):
     def __init__(self, *, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent=parent)
 
@@ -328,7 +328,7 @@ class MDAStackWidget(QGroupBox):
         group_layout.addWidget(step_wdg)
 
 
-class MDAPositionTable(QGroupBox):
+class _MDAPositionTable(QGroupBox):
     def __init__(self, header: List[str], *, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent=parent)
 
@@ -409,7 +409,7 @@ class MDAPositionTable(QGroupBox):
         self._mmc.setPosition(self._mmc.getFocusDevice(), float(z_val))
 
 
-class MDAControlButtons(QWidget):
+class _MDAControlButtons(QWidget):
     def __init__(self, *, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent=parent)
 
@@ -471,7 +471,7 @@ class MDAControlButtons(QWidget):
         wdg_layout.addWidget(self.cancel_button)
 
 
-class MDATimeLabel(QWidget):
+class _MDATimeLabel(QWidget):
     def __init__(self, *, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent=parent)
 

--- a/src/pymmcore_widgets/_mda_widget/_mda_gui.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_gui.py
@@ -56,14 +56,14 @@ class _MDAWidgetGui(QWidget):
             self._enable_run_btn
         )
 
-        self.time_groupBox = _MDATimeWidget()
-        wdg_layout.addWidget(self.time_groupBox)
+        self.time_groupbox = _MDATimeWidget()
+        wdg_layout.addWidget(self.time_groupbox)
 
-        self.stack_groupBox = _MDAStackWidget()
-        wdg_layout.addWidget(self.stack_groupBox)
+        self.stack_groupbox = _MDAStackWidget()
+        wdg_layout.addWidget(self.stack_groupbox)
 
-        self.stage_pos_groupBox = _MDAPositionTable(["Pos", "X", "Y", "Z"])
-        wdg_layout.addWidget(self.stage_pos_groupBox)
+        self.stage_pos_groupbox = _MDAPositionTable(["Pos", "X", "Y", "Z"])
+        wdg_layout.addWidget(self.stage_pos_groupbox)
 
         return wdg
 

--- a/src/pymmcore_widgets/_mda_widget/_mda_gui.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_gui.py
@@ -4,12 +4,12 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QScrollArea, QSizePolicy, QVBoxLayout, QWidget
 
 from pymmcore_widgets._general_mda_widgets import (
-    MDAChannelTable,
-    MDAControlButtons,
-    MDAPositionTable,
-    MDAStackWidget,
-    MDATimeLabel,
-    MDATimeWidget,
+    _MDAChannelTable,
+    _MDAControlButtons,
+    _MDAPositionTable,
+    _MDAStackWidget,
+    _MDATimeLabel,
+    _MDATimeWidget,
 )
 
 LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
@@ -33,11 +33,11 @@ class _MDAWidgetGui(QWidget):
         self._scroll.setWidget(self._wdg)
         self.layout().addWidget(self._scroll)
 
-        self.time_lbl = MDATimeLabel()
+        self.time_lbl = _MDATimeLabel()
         self.layout().addWidget(self.time_lbl)
 
         # acq order and buttons wdg
-        self.buttons_wdg = MDAControlButtons()
+        self.buttons_wdg = _MDAControlButtons()
         self.layout().addWidget(self.buttons_wdg)
 
     def _create_gui(self) -> QWidget:
@@ -47,7 +47,7 @@ class _MDAWidgetGui(QWidget):
         wdg_layout.setContentsMargins(10, 10, 10, 10)
         wdg.setLayout(wdg_layout)
 
-        self.channel_groupbox = MDAChannelTable()
+        self.channel_groupbox = _MDAChannelTable()
         wdg_layout.addWidget(self.channel_groupbox)
         self.channel_groupbox.channel_tableWidget.model().rowsInserted.connect(
             self._enable_run_btn
@@ -56,13 +56,13 @@ class _MDAWidgetGui(QWidget):
             self._enable_run_btn
         )
 
-        self.time_groupBox = MDATimeWidget()
+        self.time_groupBox = _MDATimeWidget()
         wdg_layout.addWidget(self.time_groupBox)
 
-        self.stack_groupBox = MDAStackWidget()
+        self.stack_groupBox = _MDAStackWidget()
         wdg_layout.addWidget(self.stack_groupBox)
 
-        self.stage_pos_groupBox = MDAPositionTable(["Pos", "X", "Y", "Z"])
+        self.stage_pos_groupBox = _MDAPositionTable(["Pos", "X", "Y", "Z"])
         wdg_layout.addWidget(self.stage_pos_groupBox)
 
         return wdg

--- a/src/pymmcore_widgets/_mda_widget/_mda_gui.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_gui.py
@@ -1,27 +1,16 @@
 from typing import Optional
 
-from fonticon_mdi6 import MDI6
-from qtpy.QtCore import QSize, Qt
-from qtpy.QtWidgets import (
-    QAbstractItemView,
-    QAbstractSpinBox,
-    QComboBox,
-    QDoubleSpinBox,
-    QGridLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QScrollArea,
-    QSizePolicy,
-    QSpacerItem,
-    QSpinBox,
-    QTableWidget,
-    QTabWidget,
-    QVBoxLayout,
-    QWidget,
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QScrollArea, QSizePolicy, QVBoxLayout, QWidget
+
+from pymmcore_widgets._general_mda_widgets import (
+    MDAChannelTable,
+    MDAControlButtons,
+    MDAPositionTable,
+    MDAStackWidget,
+    MDATimeLabel,
+    MDATimeWidget,
 )
-from superqt.fonticon import icon
 
 LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
@@ -44,12 +33,12 @@ class _MDAWidgetGui(QWidget):
         self._scroll.setWidget(self._wdg)
         self.layout().addWidget(self._scroll)
 
-        lbl = self._create_label()
-        self.layout().addWidget(lbl)
+        self.time_lbl = MDATimeLabel()
+        self.layout().addWidget(self.time_lbl)
 
         # acq order and buttons wdg
-        self.bottom_wdg = self._create_bottom_wdg()
-        self.layout().addWidget(self.bottom_wdg)
+        self.buttons_wdg = MDAControlButtons()
+        self.layout().addWidget(self.buttons_wdg)
 
     def _create_gui(self) -> QWidget:
         wdg = QWidget()
@@ -58,441 +47,30 @@ class _MDAWidgetGui(QWidget):
         wdg_layout.setContentsMargins(10, 10, 10, 10)
         wdg.setLayout(wdg_layout)
 
-        self.channel_groupBox = self._create_channel_group()
-        wdg_layout.addWidget(self.channel_groupBox)
+        self.channel_groupbox = MDAChannelTable()
+        wdg_layout.addWidget(self.channel_groupbox)
+        self.channel_groupbox.channel_tableWidget.model().rowsInserted.connect(
+            self._enable_run_btn
+        )
+        self.channel_groupbox.channel_tableWidget.model().rowsRemoved.connect(
+            self._enable_run_btn
+        )
 
-        self.time_groupBox = self._create_time_group()
+        self.time_groupBox = MDATimeWidget()
         wdg_layout.addWidget(self.time_groupBox)
 
-        self.stack_groupBox = self._create_stack_groupBox()
+        self.stack_groupBox = MDAStackWidget()
         wdg_layout.addWidget(self.stack_groupBox)
 
-        self.stage_pos_groupBox = self._create_stage_pos_groupBox()
+        self.stage_pos_groupBox = MDAPositionTable(["Pos", "X", "Y", "Z"])
         wdg_layout.addWidget(self.stage_pos_groupBox)
 
         return wdg
 
-    def _create_channel_group(self) -> QGroupBox:
-
-        group = QGroupBox(title="Channels")
-        group.setMinimumHeight(230)
-        group_layout = QGridLayout()
-        group_layout.setHorizontalSpacing(15)
-        group_layout.setVerticalSpacing(0)
-        group_layout.setContentsMargins(10, 0, 10, 0)
-        group.setLayout(group_layout)
-
-        # table
-        self.channel_tableWidget = QTableWidget()
-        self.channel_tableWidget.model().rowsInserted.connect(self._enable_run_btn)
-        self.channel_tableWidget.model().rowsRemoved.connect(self._enable_run_btn)
-
-        self.channel_tableWidget.setMinimumHeight(90)
-        hdr = self.channel_tableWidget.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        self.channel_tableWidget.verticalHeader().setVisible(False)
-        self.channel_tableWidget.setTabKeyNavigation(True)
-        self.channel_tableWidget.setColumnCount(2)
-        self.channel_tableWidget.setRowCount(0)
-        self.channel_tableWidget.setHorizontalHeaderLabels(
-            ["Channel", "Exposure Time (ms)"]
-        )
-        group_layout.addWidget(self.channel_tableWidget, 0, 0, 3, 1)
-
-        # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        min_size = 100
-        self.add_ch_button = QPushButton(text="Add")
-        self.add_ch_button.setMinimumWidth(min_size)
-        self.add_ch_button.setSizePolicy(btn_sizepolicy)
-        self.remove_ch_button = QPushButton(text="Remove")
-        self.remove_ch_button.setMinimumWidth(min_size)
-        self.remove_ch_button.setSizePolicy(btn_sizepolicy)
-        self.clear_ch_button = QPushButton(text="Clear")
-        self.clear_ch_button.setMinimumWidth(min_size)
-        self.clear_ch_button.setSizePolicy(btn_sizepolicy)
-
-        group_layout.addWidget(self.add_ch_button, 0, 1, 1, 1)
-        group_layout.addWidget(self.remove_ch_button, 1, 1, 1, 2)
-        group_layout.addWidget(self.clear_ch_button, 2, 1, 1, 2)
-
-        return group
-
     def _enable_run_btn(self) -> None:
-        self.run_Button.setEnabled(self.channel_tableWidget.rowCount() > 0)
-
-    def _create_time_group(self) -> QGroupBox:
-        group = QGroupBox(title="Time")
-        group.setCheckable(True)
-        group.setChecked(False)
-        group.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        self.buttons_wdg.run_Button.setEnabled(
+            self.channel_groupbox.channel_tableWidget.rowCount() > 0
         )
-        # group_layout = QHBoxLayout()
-        group_layout = QGridLayout()
-        group_layout.setSpacing(5)
-        group_layout.setContentsMargins(10, 10, 10, 10)
-        group.setLayout(group_layout)
-
-        # Timepoints
-        wdg = QWidget()
-        wdg_lay = QHBoxLayout()
-        wdg_lay.setSpacing(5)
-        wdg_lay.setContentsMargins(0, 0, 0, 0)
-        wdg.setLayout(wdg_lay)
-        lbl = QLabel(text="Timepoints:")
-        lbl.setSizePolicy(LBL_SIZEPOLICY)
-        self.timepoints_spinBox = QSpinBox()
-        self.timepoints_spinBox.setMinimum(1)
-        self.timepoints_spinBox.setMaximum(1000000)
-        self.timepoints_spinBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        )
-        self.timepoints_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        wdg_lay.addWidget(lbl)
-        wdg_lay.addWidget(self.timepoints_spinBox)
-        group_layout.addWidget(wdg, 0, 0)
-
-        # Interval
-        wdg1 = QWidget()
-        wdg1_lay = QHBoxLayout()
-        wdg1_lay.setSpacing(5)
-        wdg1_lay.setContentsMargins(0, 0, 0, 0)
-        wdg1.setLayout(wdg1_lay)
-        lbl1 = QLabel(text="Interval:  ")
-        lbl1.setSizePolicy(LBL_SIZEPOLICY)
-        self.interval_spinBox = QDoubleSpinBox()
-        self.interval_spinBox.setValue(1.0)
-        self.interval_spinBox.setMinimum(0)
-        self.interval_spinBox.setMaximum(100000)
-        self.interval_spinBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        )
-        self.interval_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        wdg1_lay.addWidget(lbl1)
-        wdg1_lay.addWidget(self.interval_spinBox)
-        group_layout.addWidget(wdg1)
-
-        self.time_comboBox = QComboBox()
-        self.time_comboBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        )
-        self.time_comboBox.addItems(["ms", "sec", "min", "hours"])
-        self.time_comboBox.setCurrentText("sec")
-        wdg1_lay.addWidget(self.time_comboBox)
-        group_layout.addWidget(wdg1, 0, 1)
-
-        wdg2 = QWidget()
-        wdg2_lay = QHBoxLayout()
-        wdg2_lay.setSpacing(5)
-        wdg2_lay.setContentsMargins(0, 0, 0, 0)
-        wdg2.setLayout(wdg2_lay)
-        self._icon_lbl = QLabel()
-        self._icon_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._icon_lbl.setSizePolicy(LBL_SIZEPOLICY)
-        wdg2_lay.addWidget(self._icon_lbl)
-        self._time_lbl = QLabel()
-        self._time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._time_lbl.setSizePolicy(LBL_SIZEPOLICY)
-        wdg2_lay.addWidget(self._time_lbl)
-        spacer = QSpacerItem(
-            10, 0, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
-        wdg2_lay.addItem(spacer)
-        group_layout.addWidget(wdg2, 1, 0, 1, 2)
-
-        self._time_lbl.hide()
-        self._icon_lbl.hide()
-
-        return group
-
-    def _create_stack_groupBox(self) -> QGroupBox:
-        group = QGroupBox(title="Z Stacks")
-        group.setCheckable(True)
-        group.setChecked(False)
-        group.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        )
-        group_layout = QVBoxLayout()
-        group_layout.setSpacing(10)
-        group_layout.setContentsMargins(10, 10, 10, 10)
-        group.setLayout(group_layout)
-
-        # tab
-        self.z_tabWidget = QTabWidget()
-        z_tab_layout = QVBoxLayout()
-        z_tab_layout.setSpacing(0)
-        z_tab_layout.setContentsMargins(0, 0, 0, 0)
-        self.z_tabWidget.setLayout(z_tab_layout)
-        group_layout.addWidget(self.z_tabWidget)
-
-        # top bottom
-        tb = QWidget()
-        tb_layout = QGridLayout()
-        tb_layout.setContentsMargins(10, 10, 10, 10)
-        tb.setLayout(tb_layout)
-
-        self.set_top_Button = QPushButton(text="Set Top")
-        self.set_bottom_Button = QPushButton(text="Set Bottom")
-
-        lbl_range_tb = QLabel(text="Range (µm):")
-        lbl_range_tb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.z_top_doubleSpinBox = QDoubleSpinBox()
-        self.z_top_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_top_doubleSpinBox.setMinimum(0.0)
-        self.z_top_doubleSpinBox.setMaximum(100000)
-        self.z_top_doubleSpinBox.setDecimals(2)
-
-        self.z_bottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_bottom_doubleSpinBox.setMinimum(0.0)
-        self.z_bottom_doubleSpinBox.setMaximum(100000)
-        self.z_bottom_doubleSpinBox.setDecimals(2)
-
-        self.z_range_topbottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_range_topbottom_doubleSpinBox.setMaximum(10000000)
-        self.z_range_topbottom_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.ButtonSymbols.NoButtons
-        )
-        self.z_range_topbottom_doubleSpinBox.setReadOnly(True)
-
-        tb_layout.addWidget(self.set_top_Button, 0, 0)
-        tb_layout.addWidget(self.z_top_doubleSpinBox, 1, 0)
-        tb_layout.addWidget(self.set_bottom_Button, 0, 1)
-        tb_layout.addWidget(self.z_bottom_doubleSpinBox, 1, 1)
-        tb_layout.addWidget(lbl_range_tb, 0, 2)
-        tb_layout.addWidget(self.z_range_topbottom_doubleSpinBox, 1, 2)
-
-        self.z_tabWidget.addTab(tb, "TopBottom")
-
-        # range around
-        ra = QWidget()
-        ra_layout = QHBoxLayout()
-        ra_layout.setSpacing(10)
-        ra_layout.setContentsMargins(10, 10, 10, 10)
-        ra.setLayout(ra_layout)
-
-        lbl_range_ra = QLabel(text="Range (µm):")
-        lbl_range_ra.setSizePolicy(LBL_SIZEPOLICY)
-
-        self.zrange_spinBox = QSpinBox()
-        self.zrange_spinBox.setValue(5)
-        self.zrange_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.zrange_spinBox.setMaximum(100000)
-
-        self.range_around_label = QLabel(text="-2.5 µm <- z -> +2.5 µm")
-        self.range_around_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        ra_layout.addWidget(lbl_range_ra)
-        ra_layout.addWidget(self.zrange_spinBox)
-        ra_layout.addWidget(self.range_around_label)
-
-        self.z_tabWidget.addTab(ra, "RangeAround")
-
-        # above below wdg
-        ab = QWidget()
-        ab_layout = QGridLayout()
-        ab_layout.setContentsMargins(10, 0, 10, 15)
-        ab.setLayout(ab_layout)
-
-        lbl_above = QLabel(text="Above (µm):")
-        lbl_above.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.above_doubleSpinBox = QDoubleSpinBox()
-        self.above_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.above_doubleSpinBox.setMinimum(0.05)
-        self.above_doubleSpinBox.setMaximum(10000)
-        self.above_doubleSpinBox.setSingleStep(0.5)
-        self.above_doubleSpinBox.setDecimals(2)
-
-        lbl_below = QLabel(text="Below (µm):")
-        lbl_below.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.below_doubleSpinBox = QDoubleSpinBox()
-        self.below_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.below_doubleSpinBox.setMinimum(0.05)
-        self.below_doubleSpinBox.setMaximum(10000)
-        self.below_doubleSpinBox.setSingleStep(0.5)
-        self.below_doubleSpinBox.setDecimals(2)
-
-        lbl_range = QLabel(text="Range (µm):")
-        lbl_range.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_range_abovebelow_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_range_abovebelow_doubleSpinBox.setMaximum(10000000)
-        self.z_range_abovebelow_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.ButtonSymbols.NoButtons
-        )
-        self.z_range_abovebelow_doubleSpinBox.setReadOnly(True)
-
-        ab_layout.addWidget(lbl_above, 0, 0)
-        ab_layout.addWidget(self.above_doubleSpinBox, 1, 0)
-        ab_layout.addWidget(lbl_below, 0, 1)
-        ab_layout.addWidget(self.below_doubleSpinBox, 1, 1)
-        ab_layout.addWidget(lbl_range, 0, 2)
-        ab_layout.addWidget(self.z_range_abovebelow_doubleSpinBox, 1, 2)
-
-        self.z_tabWidget.addTab(ab, "AboveBelow")
-
-        # step size wdg
-        step_wdg = QWidget()
-        step_wdg_layout = QHBoxLayout()
-        step_wdg_layout.setSpacing(15)
-        step_wdg_layout.setContentsMargins(0, 10, 0, 0)
-        step_wdg.setLayout(step_wdg_layout)
-
-        s = QWidget()
-        s_layout = QHBoxLayout()
-        s_layout.setSpacing(0)
-        s_layout.setContentsMargins(0, 0, 0, 0)
-        s.setLayout(s_layout)
-        lbl = QLabel(text="Step Size (µm):")
-        lbl.setSizePolicy(LBL_SIZEPOLICY)
-        self.step_size_doubleSpinBox = QDoubleSpinBox()
-        self.step_size_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.step_size_doubleSpinBox.setMinimum(0.05)
-        self.step_size_doubleSpinBox.setValue(1)
-        self.step_size_doubleSpinBox.setMaximum(10000)
-        self.step_size_doubleSpinBox.setSingleStep(0.5)
-        self.step_size_doubleSpinBox.setDecimals(2)
-        s_layout.addWidget(lbl)
-        s_layout.addWidget(self.step_size_doubleSpinBox)
-
-        self.n_images_label = QLabel(text="Number of Images:")
-
-        step_wdg_layout.addWidget(s)
-        step_wdg_layout.addWidget(self.n_images_label)
-        group_layout.addWidget(step_wdg)
-
-        return group
-
-    def _create_stage_pos_groupBox(self) -> QGroupBox:
-        group = QGroupBox(title="Stage Positions")
-        group.setCheckable(True)
-        group.setChecked(False)
-        group.setMinimumHeight(230)
-        group_layout = QGridLayout()
-        group_layout.setHorizontalSpacing(15)
-        group_layout.setVerticalSpacing(0)
-        group_layout.setContentsMargins(10, 0, 10, 0)
-        group.setLayout(group_layout)
-
-        # table
-        self.stage_tableWidget = QTableWidget()
-        self.stage_tableWidget.setSelectionBehavior(
-            QAbstractItemView.SelectionBehavior.SelectRows
-        )
-        hdr = self.stage_tableWidget.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        self.stage_tableWidget.verticalHeader().setVisible(False)
-        self.stage_tableWidget.setTabKeyNavigation(True)
-        self.stage_tableWidget.setColumnCount(4)
-        self.stage_tableWidget.setRowCount(0)
-        self.stage_tableWidget.setHorizontalHeaderLabels(["Pos", "X", "Y", "Z"])
-        group_layout.addWidget(self.stage_tableWidget, 0, 0, 5, 1)
-
-        # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        min_size = 100
-        self.add_pos_Button = QPushButton(text="Add")
-        self.add_pos_Button.setMinimumWidth(min_size)
-        self.add_pos_Button.setSizePolicy(btn_sizepolicy)
-        self.remove_pos_Button = QPushButton(text="Remove")
-        self.remove_pos_Button.setMinimumWidth(min_size)
-        self.remove_pos_Button.setSizePolicy(btn_sizepolicy)
-        self.clear_pos_Button = QPushButton(text="Clear")
-        self.clear_pos_Button.setMinimumWidth(min_size)
-        self.clear_pos_Button.setSizePolicy(btn_sizepolicy)
-        self.grid_Button = QPushButton(text="Grid")
-        self.grid_Button.setMinimumWidth(min_size)
-        self.grid_Button.setSizePolicy(btn_sizepolicy)
-        self.go = QPushButton(text="Go")
-        self.go.setMinimumWidth(min_size)
-        self.go.setSizePolicy(btn_sizepolicy)
-
-        group_layout.addWidget(self.add_pos_Button, 0, 1, 1, 2)
-        group_layout.addWidget(self.remove_pos_Button, 1, 1, 1, 2)
-        group_layout.addWidget(self.clear_pos_Button, 2, 1, 1, 2)
-        group_layout.addWidget(self.grid_Button, 3, 1, 1, 2)
-        group_layout.addWidget(self.go, 4, 1, 1, 2)
-
-        return group
-
-    def _create_label(self) -> QWidget:
-
-        wdg = QWidget()
-        wdg_lay = QHBoxLayout()
-        wdg_lay.setSpacing(5)
-        wdg_lay.setContentsMargins(10, 5, 10, 5)
-        wdg_lay.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        wdg.setLayout(wdg_lay)
-
-        self._total_time_lbl = QLabel()
-        self._total_time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._total_time_lbl.setSizePolicy(LBL_SIZEPOLICY)
-        wdg_lay.addWidget(self._total_time_lbl)
-
-        return wdg
-
-    def _create_bottom_wdg(self) -> QWidget:
-
-        wdg = QWidget()
-        wdg.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        )
-        wdg_layout = QHBoxLayout()
-        wdg_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
-        wdg_layout.setSpacing(10)
-        wdg_layout.setContentsMargins(10, 5, 10, 10)
-        wdg.setLayout(wdg_layout)
-
-        acq_wdg = QWidget()
-        acq_wdg_layout = QHBoxLayout()
-        acq_wdg_layout.setSpacing(0)
-        acq_wdg_layout.setContentsMargins(0, 0, 0, 0)
-        acq_wdg.setLayout(acq_wdg_layout)
-        acquisition_order_label = QLabel(text="Acquisition Order:")
-        acquisition_order_label.setSizePolicy(LBL_SIZEPOLICY)
-        self.acquisition_order_comboBox = QComboBox()
-        self.acquisition_order_comboBox.setMinimumWidth(100)
-        self.acquisition_order_comboBox.addItems(["tpcz", "tpzc", "ptzc", "ptcz"])
-        acq_wdg_layout.addWidget(acquisition_order_label)
-        acq_wdg_layout.addWidget(self.acquisition_order_comboBox)
-
-        btn_sizepolicy = QSizePolicy(
-            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
-        )
-        min_width = 130
-        icon_size = 40
-        self.run_Button = QPushButton(text="Run")
-        self.run_Button.setEnabled(False)
-        self.run_Button.setMinimumWidth(min_width)
-        self.run_Button.setStyleSheet("QPushButton { text-align: center; }")
-        self.run_Button.setSizePolicy(btn_sizepolicy)
-        self.run_Button.setIcon(icon(MDI6.play_circle_outline, color=(0, 255, 0)))
-        self.run_Button.setIconSize(QSize(icon_size, icon_size))
-        self.pause_Button = QPushButton("Pause")
-        self.pause_Button.setStyleSheet("QPushButton { text-align: center; }")
-        self.pause_Button.setSizePolicy(btn_sizepolicy)
-        self.pause_Button.setIcon(icon(MDI6.pause_circle_outline, color="green"))
-        self.pause_Button.setIconSize(QSize(icon_size, icon_size))
-        self.cancel_Button = QPushButton("Cancel")
-        self.cancel_Button.setStyleSheet("QPushButton { text-align: center; }")
-        self.cancel_Button.setSizePolicy(btn_sizepolicy)
-        self.cancel_Button.setIcon(icon(MDI6.stop_circle_outline, color="magenta"))
-        self.cancel_Button.setIconSize(QSize(icon_size, icon_size))
-
-        spacer = QSpacerItem(
-            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
-
-        wdg_layout.addWidget(acq_wdg)
-        wdg_layout.addItem(spacer)
-        wdg_layout.addWidget(self.run_Button)
-        wdg_layout.addWidget(self.pause_Button)
-        wdg_layout.addWidget(self.cancel_Button)
-
-        return wdg
 
 
 if __name__ == "__main__":

--- a/src/pymmcore_widgets/_mda_widget/_mda_gui.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_gui.py
@@ -68,7 +68,7 @@ class _MDAWidgetGui(QWidget):
         return wdg
 
     def _enable_run_btn(self) -> None:
-        self.buttons_wdg.run_Button.setEnabled(
+        self.buttons_wdg.run_button.setEnabled(
             self.channel_groupbox.channel_tableWidget.rowCount() > 0
         )
 

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -83,8 +83,8 @@ class MDAWidget(_MDAWidgetGui):
         self.ch_gb.clear_ch_button.clicked.connect(self._clear_channel)
 
         # connection for z stack
-        self.z_gp.set_top_Button.clicked.connect(self._set_top)
-        self.z_gp.set_bottom_Button.clicked.connect(self._set_bottom)
+        self.z_gp.set_top_button.clicked.connect(self._set_top)
+        self.z_gp.set_bottom_button.clicked.connect(self._set_bottom)
         self.z_gp.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
         self.z_gp.z_bottom_doubleSpinBox.valueChanged.connect(
             self._update_topbottom_range
@@ -114,7 +114,6 @@ class MDAWidget(_MDAWidgetGui):
         self.pos_gp.remove_pos_button.clicked.connect(self._remove_position)
         self.pos_gp.clear_pos_button.clicked.connect(self._clear_positions)
         self.pos_gp.grid_button.clicked.connect(self._grid_widget)
-        self.pos_gp.go.clicked.connect(self._move_to_position)
         self.pos_gp.toggled.connect(self._calculate_total_time)
 
         # connection for time
@@ -313,16 +312,6 @@ class MDAWidget(_MDAWidgetGui):
         self.pos_gp.stage_tableWidget.clearContents()
         self.pos_gp.stage_tableWidget.setRowCount(0)
         self._calculate_total_time()
-
-    def _move_to_position(self) -> None:
-        if not self._mmc.getXYStageDevice():
-            return
-        curr_row = self.pos_gp.stage_tableWidget.currentRow()
-        x_val = self.pos_gp.stage_tableWidget.item(curr_row, 1).text()
-        y_val = self.pos_gp.stage_tableWidget.item(curr_row, 2).text()
-        z_val = self.pos_gp.stage_tableWidget.item(curr_row, 3).text()
-        self._mmc.setXYPosition(float(x_val), float(y_val))
-        self._mmc.setPosition(self._mmc.getFocusDevice(), float(z_val))
 
     def _grid_widget(self) -> None:
         if not self._mmc.getXYStageDevice():

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -54,56 +54,77 @@ class MDAWidget(_MDAWidgetGui):
     ) -> None:
         super().__init__(parent=parent)
 
-        self._include_run_button = include_run_button
-
-        self.pause_Button.hide()
-        self.cancel_Button.hide()
-        if not self._include_run_button:
-            self.run_Button.hide()
-
         self._mmc = mmcore or CMMCorePlus.instance()
 
-        self.pause_Button.released.connect(lambda: self._mmc.mda.toggle_pause())
-        self.cancel_Button.released.connect(lambda: self._mmc.mda.cancel())
+        self._include_run_button = include_run_button
 
-        # connect buttons
-        self.add_pos_Button.clicked.connect(self._add_position)
-        self.remove_pos_Button.clicked.connect(self._remove_position)
-        self.clear_pos_Button.clicked.connect(self._clear_positions)
-        self.add_ch_button.clicked.connect(self._add_channel)
-        self.remove_ch_button.clicked.connect(self._remove_channel)
-        self.clear_ch_button.clicked.connect(self._clear_channel)
-        self.grid_Button.clicked.connect(self._grid_widget)
+        self.buttons_wdg.pause_button.hide()
+        self.buttons_wdg.cancel_button.hide()
+        if not self._include_run_button:
+            self.buttons_wdg.run_button.hide()
+
+        self.buttons_wdg.pause_button.released.connect(
+            lambda: self._mmc.mda.toggle_pause()
+        )
+        self.buttons_wdg.cancel_button.released.connect(lambda: self._mmc.mda.cancel())
+
+        self.ch_gb = self.channel_groupbox
+        self.tm_gp = self.time_groupBox
+        self.z_gp = self.stack_groupBox
+        self.pos_gp = self.stage_pos_groupBox
+
+        # connect run button
         if self._include_run_button:
-            self.run_Button.clicked.connect(self._on_run_clicked)
+            self.buttons_wdg.run_button.clicked.connect(self._on_run_clicked)
 
-        # connect buttons for z stack
-        self.set_top_Button.clicked.connect(self._set_top)
-        self.set_bottom_Button.clicked.connect(self._set_bottom)
-        self.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
-        self.z_bottom_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
-        self.zrange_spinBox.valueChanged.connect(self._update_rangearound_label)
-        self.above_doubleSpinBox.valueChanged.connect(self._update_abovebelow_range)
-        self.below_doubleSpinBox.valueChanged.connect(self._update_abovebelow_range)
-        self.z_range_abovebelow_doubleSpinBox.valueChanged.connect(
+        # connection for channel
+        self.ch_gb.add_ch_button.clicked.connect(self._add_channel)
+        self.ch_gb.remove_ch_button.clicked.connect(self._remove_channel)
+        self.ch_gb.clear_ch_button.clicked.connect(self._clear_channel)
+
+        # connection for z stack
+        self.z_gp.set_top_Button.clicked.connect(self._set_top)
+        self.z_gp.set_bottom_Button.clicked.connect(self._set_bottom)
+        self.z_gp.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
+        self.z_gp.z_bottom_doubleSpinBox.valueChanged.connect(
+            self._update_topbottom_range
+        )
+        self.z_gp.zrange_spinBox.valueChanged.connect(self._update_rangearound_label)
+        self.z_gp.above_doubleSpinBox.valueChanged.connect(
+            self._update_abovebelow_range
+        )
+        self.z_gp.below_doubleSpinBox.valueChanged.connect(
+            self._update_abovebelow_range
+        )
+        self.z_gp.z_range_abovebelow_doubleSpinBox.valueChanged.connect(
             self._update_n_images
         )
-        self.zrange_spinBox.valueChanged.connect(self._update_n_images)
-        self.z_range_topbottom_doubleSpinBox.valueChanged.connect(self._update_n_images)
-        self.step_size_doubleSpinBox.valueChanged.connect(self._update_n_images)
-        self.z_tabWidget.currentChanged.connect(self._update_n_images)
-        self.stack_groupBox.toggled.connect(self._update_n_images)
+        self.z_gp.zrange_spinBox.valueChanged.connect(self._update_n_images)
+        self.z_gp.z_range_topbottom_doubleSpinBox.valueChanged.connect(
+            self._update_n_images
+        )
+        self.z_gp.step_size_doubleSpinBox.valueChanged.connect(self._update_n_images)
+        self.z_gp.z_tabWidget.currentChanged.connect(self._update_n_images)
+        self.z_gp.toggled.connect(self._update_n_images)
+        self.z_gp.toggled.connect(self._calculate_total_time)
 
-        # toggle connect
-        self.time_groupBox.toggled.connect(self._calculate_total_time)
-        self.interval_spinBox.valueChanged.connect(self._calculate_total_time)
-        self.timepoints_spinBox.valueChanged.connect(self._calculate_total_time)
-        self.stack_groupBox.toggled.connect(self._calculate_total_time)
-        self.stage_pos_groupBox.toggled.connect(self._calculate_total_time)
-        self.time_comboBox.currentIndexChanged.connect(self._calculate_total_time)
-        self.go.clicked.connect(self._move_to_position)
+        # connection for positions
+        self.pos_gp = self.pos_gp
+        self.pos_gp.add_pos_Button.clicked.connect(self._add_position)
+        self.pos_gp.remove_pos_Button.clicked.connect(self._remove_position)
+        self.pos_gp.clear_pos_Button.clicked.connect(self._clear_positions)
+        self.pos_gp.grid_Button.clicked.connect(self._grid_widget)
+        self.pos_gp.go.clicked.connect(self._move_to_position)
+        self.pos_gp.toggled.connect(self._calculate_total_time)
 
-        # events
+        # connection for time
+        self.tm_gp = self.tm_gp
+        self.tm_gp.toggled.connect(self._calculate_total_time)
+        self.tm_gp.interval_spinBox.valueChanged.connect(self._calculate_total_time)
+        self.tm_gp.timepoints_spinBox.valueChanged.connect(self._calculate_total_time)
+        self.tm_gp.time_comboBox.currentIndexChanged.connect(self._calculate_total_time)
+
+        # connect mmcore signals
         self._mmc.mda.events.sequenceStarted.connect(self._on_mda_started)
         self._mmc.mda.events.sequenceFinished.connect(self._on_mda_finished)
         self._mmc.mda.events.sequencePauseToggled.connect(self._on_mda_paused)
@@ -116,21 +137,21 @@ class MDAWidget(_MDAWidgetGui):
             self._mmc.setChannelGroup(channel_group)
 
     def _set_enabled(self, enabled: bool) -> None:
-        self.time_groupBox.setEnabled(enabled)
-        self.acquisition_order_comboBox.setEnabled(enabled)
-        self.channel_groupBox.setEnabled(enabled)
+        self.tm_gp.setEnabled(enabled)
+        self.buttons_wdg.acquisition_order_comboBox.setEnabled(enabled)
+        self.ch_gb.setEnabled(enabled)
 
         if not self._mmc.getXYStageDevice():
-            self.stage_pos_groupBox.setChecked(False)
-            self.stage_pos_groupBox.setEnabled(False)
+            self.pos_gp.setChecked(False)
+            self.pos_gp.setEnabled(False)
         else:
-            self.stage_pos_groupBox.setEnabled(enabled)
+            self.pos_gp.setEnabled(enabled)
 
         if not self._mmc.getFocusDevice():
-            self.stack_groupBox.setChecked(False)
-            self.stack_groupBox.setEnabled(False)
+            self.z_gp.setChecked(False)
+            self.z_gp.setEnabled(False)
         else:
-            self.stack_groupBox.setEnabled(enabled)
+            self.z_gp.setEnabled(enabled)
 
     def _grid_widget(self) -> None:
         if not self._mmc.getXYStageDevice():
@@ -148,8 +169,8 @@ class MDAWidget(_MDAWidgetGui):
         if clear:
             self._clear_positions()
         else:
-            for r in range(self.stage_tableWidget.rowCount()):
-                pos_name = self.stage_tableWidget.item(r, 0).text()
+            for r in range(self.pos_gp.stage_tableWidget.rowCount()):
+                pos_name = self.pos_gp.stage_tableWidget.item(r, 0).text()
                 grid_name = pos_name.split("_")[0]
                 if "Grid" in grid_name:
                     grid_n = grid_name[-3:]
@@ -158,8 +179,8 @@ class MDAWidget(_MDAWidgetGui):
             grid_number += 1
 
         for idx, position in enumerate(position_list):
-            rows = self.stage_tableWidget.rowCount()
-            self.stage_tableWidget.insertRow(rows)
+            rows = self.pos_gp.stage_tableWidget.rowCount()
+            self.pos_gp.stage_tableWidget.insertRow(rows)
 
             item = QtW.QTableWidgetItem(f"Grid{grid_number:03d}_Pos{idx:03d}")
             item.setTextAlignment(
@@ -178,60 +199,67 @@ class MDAWidget(_MDAWidgetGui):
                 Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
             )
 
-            self.stage_tableWidget.setItem(rows, 0, item)
-            self.stage_tableWidget.setItem(rows, 1, x)
-            self.stage_tableWidget.setItem(rows, 2, y)
-            self.stage_tableWidget.setItem(rows, 3, z)
+            self.pos_gp.stage_tableWidget.setItem(rows, 0, item)
+            self.pos_gp.stage_tableWidget.setItem(rows, 1, x)
+            self.pos_gp.stage_tableWidget.setItem(rows, 2, y)
+            self.pos_gp.stage_tableWidget.setItem(rows, 3, z)
 
     def _set_top(self) -> None:
-        self.z_top_doubleSpinBox.setValue(self._mmc.getZPosition())
+        self.z_gp.z_top_doubleSpinBox.setValue(self._mmc.getZPosition())
 
     def _set_bottom(self) -> None:
-        self.z_bottom_doubleSpinBox.setValue(self._mmc.getZPosition())
+        self.z_gp.z_bottom_doubleSpinBox.setValue(self._mmc.getZPosition())
 
     def _update_topbottom_range(self) -> None:
-        self.z_range_topbottom_doubleSpinBox.setValue(
-            abs(self.z_top_doubleSpinBox.value() - self.z_bottom_doubleSpinBox.value())
+        self.z_gp.z_range_topbottom_doubleSpinBox.setValue(
+            abs(
+                self.z_gp.z_top_doubleSpinBox.value()
+                - self.z_gp.z_bottom_doubleSpinBox.value()
+            )
         )
 
     def _update_rangearound_label(self, value: int) -> None:
-        self.range_around_label.setText(f"-{value/2} µm <- z -> +{value/2} µm")
+        self.z_gp.range_around_label.setText(f"-{value/2} µm <- z -> +{value/2} µm")
 
     def _update_abovebelow_range(self) -> None:
-        self.z_range_abovebelow_doubleSpinBox.setValue(
-            self.above_doubleSpinBox.value() + self.below_doubleSpinBox.value()
+        self.z_gp.z_range_abovebelow_doubleSpinBox.setValue(
+            self.z_gp.above_doubleSpinBox.value()
+            + self.z_gp.below_doubleSpinBox.value()
         )
 
     def _update_n_images(self) -> None:
-        step = self.step_size_doubleSpinBox.value()
+        step = self.z_gp.step_size_doubleSpinBox.value()
         # set what is the range to consider depending on the z_stack mode
-        if self.z_tabWidget.currentIndex() == 0:
-            _range = self.z_range_topbottom_doubleSpinBox.value()
-        if self.z_tabWidget.currentIndex() == 1:
-            _range = self.zrange_spinBox.value()
-        if self.z_tabWidget.currentIndex() == 2:
-            _range = self.z_range_abovebelow_doubleSpinBox.value()
+        if self.z_gp.z_tabWidget.currentIndex() == 0:
+            _range = self.z_gp.z_range_topbottom_doubleSpinBox.value()
+        if self.z_gp.z_tabWidget.currentIndex() == 1:
+            _range = self.z_gp.zrange_spinBox.value()
+        if self.z_gp.z_tabWidget.currentIndex() == 2:
+            _range = self.z_gp.z_range_abovebelow_doubleSpinBox.value()
 
-        self.n_images_label.setText(f"Number of Images: {round((_range / step) + 1)}")
+        self.z_gp.n_images_label.setText(
+            f"Number of Images: {round((_range / step) + 1)}"
+        )
         self._calculate_total_time()
 
     def _calculate_total_time(self) -> None:
 
         # channel
         exp: list = []
-        ch = self.channel_tableWidget.rowCount()
+        ch = self.ch_gb.channel_tableWidget.rowCount()
         if ch > 0:
             exp.extend(
-                self.channel_tableWidget.cellWidget(r, 1).value() for r in range(ch)
+                self.ch_gb.channel_tableWidget.cellWidget(r, 1).value()
+                for r in range(ch)
             )
         else:
             exp = []
 
         # time
-        if self.time_groupBox.isChecked():
-            timepoints = self.timepoints_spinBox.value()
-            interval = self.interval_spinBox.value()
-            int_unit = self.time_comboBox.currentText()
+        if self.tm_gp.isChecked():
+            timepoints = self.tm_gp.timepoints_spinBox.value()
+            interval = self.tm_gp.interval_spinBox.value()
+            int_unit = self.tm_gp.time_comboBox.currentText()
             if int_unit != "sec":
                 interval = _time_in_sec(interval, int_unit)
         else:
@@ -239,14 +267,14 @@ class MDAWidget(_MDAWidgetGui):
             interval = -1.0
 
         # z stack
-        if self.stack_groupBox.isChecked():
-            n_z_images = int(self.n_images_label.text()[18:])
+        if self.z_gp.isChecked():
+            n_z_images = int(self.z_gp.n_images_label.text()[18:])
         else:
             n_z_images = 1
 
         # positions
-        if self.stage_pos_groupBox.isChecked():
-            n_pos = self.stage_tableWidget.rowCount() or 1
+        if self.pos_gp.isChecked():
+            n_pos = self.pos_gp.stage_tableWidget.rowCount() or 1
         else:
             n_pos = 1
         n_pos = n_pos
@@ -283,43 +311,43 @@ class MDAWidget(_MDAWidgetGui):
             (time_chs * timepoints) + addition_time - effective_interval
         )
 
-        self._icon_lbl.clear()
-        self._time_lbl.clear()
-        self._time_lbl.setStyleSheet(stylesheet)
+        self.tm_gp._icon_lbl.clear()
+        self.tm_gp._time_lbl.clear()
+        self.tm_gp._time_lbl.setStyleSheet(stylesheet)
         if _icon:
-            self._icon_lbl.show()
-            self._icon_lbl.setPixmap(_icon)
-            self._time_lbl.show()
-            self._time_lbl.setText(f"{warning_msg}")
-            self._time_lbl.adjustSize()
+            self.tm_gp._icon_lbl.show()
+            self.tm_gp._icon_lbl.setPixmap(_icon)
+            self.tm_gp._time_lbl.show()
+            self.tm_gp._time_lbl.setText(f"{warning_msg}")
+            self.tm_gp._time_lbl.adjustSize()
         else:
-            self._time_lbl.hide()
-            self._icon_lbl.hide()
+            self.tm_gp._time_lbl.hide()
+            self.tm_gp._icon_lbl.hide()
 
         t_per_tp_msg = ""
         tot_acq_msg = f"Minimum total acquisition time: {min_tot_time:.4f} {unit_4}.\n"
-        if self.time_groupBox.isChecked():
+        if self.tm_gp.isChecked():
             t_per_tp_msg = (
                 f"Minimum acquisition time per timepoint: {min_aq_tp:.4f} {unit_1}."
             )
-        self._total_time_lbl.setText(f"{tot_acq_msg}{t_per_tp_msg}")
+        self.time_lbl._total_time_lbl.setText(f"{tot_acq_msg}{t_per_tp_msg}")
 
     def _on_mda_started(self) -> None:
         self._set_enabled(False)
         if self._include_run_button:
-            self.pause_Button.show()
-            self.cancel_Button.show()
-        self.run_Button.hide()
+            self.buttons_wdg.pause_button.show()
+            self.buttons_wdg.cancel_button.show()
+        self.buttons_wdg.run_button.hide()
 
     def _on_mda_finished(self) -> None:
         self._set_enabled(True)
-        self.pause_Button.hide()
-        self.cancel_Button.hide()
+        self.buttons_wdg.pause_button.hide()
+        self.buttons_wdg.cancel_button.hide()
         if self._include_run_button:
-            self.run_Button.show()
+            self.buttons_wdg.run_button.show()
 
     def _on_mda_paused(self, paused: bool) -> None:
-        self.pause_Button.setText("Resume" if paused else "Pause")
+        self.buttons_wdg.pause_button.setText("Resume" if paused else "Pause")
 
     def _add_channel(self) -> bool:
         """Add, remove or clear channel table.  Return True if anyting was changed."""
@@ -330,8 +358,8 @@ class MDAWidget(_MDAWidgetGui):
         if not channel_group:
             return False
 
-        idx = self.channel_tableWidget.rowCount()
-        self.channel_tableWidget.insertRow(idx)
+        idx = self.ch_gb.channel_tableWidget.rowCount()
+        self.ch_gb.channel_tableWidget.insertRow(idx)
 
         # create a combo_box for channels in the table
         channel_comboBox = QtW.QComboBox(self)
@@ -344,8 +372,8 @@ class MDAWidget(_MDAWidgetGui):
             channel_list = list(self._mmc.getAvailableConfigs(channel_group))
             channel_comboBox.addItems(channel_list)
 
-        self.channel_tableWidget.setCellWidget(idx, 0, channel_comboBox)
-        self.channel_tableWidget.setCellWidget(idx, 1, channel_exp_spinBox)
+        self.ch_gb.channel_tableWidget.setCellWidget(idx, 0, channel_comboBox)
+        self.ch_gb.channel_tableWidget.setCellWidget(idx, 1, channel_exp_spinBox)
 
         self._calculate_total_time()
 
@@ -353,16 +381,16 @@ class MDAWidget(_MDAWidgetGui):
 
     def _remove_channel(self) -> None:
         # remove selected position
-        rows = {r.row() for r in self.channel_tableWidget.selectedIndexes()}
+        rows = {r.row() for r in self.ch_gb.channel_tableWidget.selectedIndexes()}
         for idx in sorted(rows, reverse=True):
-            self.channel_tableWidget.removeRow(idx)
+            self.ch_gb.channel_tableWidget.removeRow(idx)
 
         self._calculate_total_time()
 
     def _clear_channel(self) -> None:
         # clear all positions
-        self.channel_tableWidget.clearContents()
-        self.channel_tableWidget.setRowCount(0)
+        self.ch_gb.channel_tableWidget.clearContents()
+        self.ch_gb.channel_tableWidget.setRowCount(0)
 
         self._calculate_total_time()
 
@@ -378,12 +406,12 @@ class MDAWidget(_MDAWidgetGui):
             for c, ax in enumerate("PXYZ"):
 
                 if ax == "P":
-                    count = self.stage_tableWidget.rowCount() - 1
+                    count = self.pos_gp.stage_tableWidget.rowCount() - 1
                     item = QtW.QTableWidgetItem(f"Pos{count:03d}")
                     item.setTextAlignment(
                         Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                     )
-                    self.stage_tableWidget.setItem(idx, c, item)
+                    self.pos_gp.stage_tableWidget.setItem(idx, c, item)
                     self._rename_positions(["Pos"])
                     continue
 
@@ -394,27 +422,27 @@ class MDAWidget(_MDAWidgetGui):
                 item.setTextAlignment(
                     Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                 )
-                self.stage_tableWidget.setItem(idx, c, item)
+                self.pos_gp.stage_tableWidget.setItem(idx, c, item)
 
             self._calculate_total_time()
 
     def _add_position_row(self) -> int:
-        idx = self.stage_tableWidget.rowCount()
-        self.stage_tableWidget.insertRow(idx)
+        idx = self.pos_gp.stage_tableWidget.rowCount()
+        self.pos_gp.stage_tableWidget.insertRow(idx)
         return idx  # type: ignore [no-any-return]
 
     def _remove_position(self) -> None:
         # remove selected position
-        rows = {r.row() for r in self.stage_tableWidget.selectedIndexes()}
+        rows = {r.row() for r in self.pos_gp.stage_tableWidget.selectedIndexes()}
         removed = []
         for idx in sorted(rows, reverse=True):
-            name = self.stage_tableWidget.item(idx, 0).text().split("_")[0]
+            name = self.pos_gp.stage_tableWidget.item(idx, 0).text().split("_")[0]
             if "Pos" in name:
                 if "Pos" not in removed:
                     removed.append("Pos")
             elif name not in removed:
                 removed.append(name)
-            self.stage_tableWidget.removeRow(idx)
+            self.pos_gp.stage_tableWidget.removeRow(idx)
         self._rename_positions(removed)
         self._calculate_total_time()
 
@@ -422,8 +450,8 @@ class MDAWidget(_MDAWidgetGui):
         for name in names:
             grid_count = 0
             pos_count = 0
-            for r in range(self.stage_tableWidget.rowCount()):
-                start = self.stage_tableWidget.item(r, 0).text().split("_")[0]
+            for r in range(self.pos_gp.stage_tableWidget.rowCount()):
+                start = self.pos_gp.stage_tableWidget.item(r, 0).text().split("_")[0]
                 if start == name:  # Grid
                     new_name = f"{name}_Pos{grid_count:03d}"
                     grid_count += 1
@@ -436,21 +464,21 @@ class MDAWidget(_MDAWidgetGui):
                 item.setTextAlignment(
                     Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                 )
-                self.stage_tableWidget.setItem(r, 0, item)
+                self.pos_gp.stage_tableWidget.setItem(r, 0, item)
 
     def _clear_positions(self) -> None:
         # clear all positions
-        self.stage_tableWidget.clearContents()
-        self.stage_tableWidget.setRowCount(0)
+        self.pos_gp.stage_tableWidget.clearContents()
+        self.pos_gp.stage_tableWidget.setRowCount(0)
         self._calculate_total_time()
 
     def _move_to_position(self) -> None:
         if not self._mmc.getXYStageDevice():
             return
-        curr_row = self.stage_tableWidget.currentRow()
-        x_val = self.stage_tableWidget.item(curr_row, 1).text()
-        y_val = self.stage_tableWidget.item(curr_row, 2).text()
-        z_val = self.stage_tableWidget.item(curr_row, 3).text()
+        curr_row = self.pos_gp.stage_tableWidget.currentRow()
+        x_val = self.pos_gp.stage_tableWidget.item(curr_row, 1).text()
+        y_val = self.pos_gp.stage_tableWidget.item(curr_row, 2).text()
+        z_val = self.pos_gp.stage_tableWidget.item(curr_row, 3).text()
         self._mmc.setXYPosition(float(x_val), float(y_val))
         self._mmc.setPosition(self._mmc.getFocusDevice(), float(z_val))
 
@@ -470,7 +498,7 @@ class MDAWidget(_MDAWidgetGui):
         if not isinstance(state, MDASequence):
             raise TypeError("state must be an MDASequence, dict, or yaml file")
 
-        self.acquisition_order_comboBox.setCurrentText(state.axis_order)
+        self.buttons_wdg.acquisition_order_comboBox.setCurrentText(state.axis_order)
 
         # set channel table
         self._clear_channel()
@@ -482,57 +510,61 @@ class MDAWidget(_MDAWidgetGui):
             if not self._add_channel():
                 break
             if ch.config in channel_list:
-                self.channel_tableWidget.cellWidget(idx, 0).setCurrentText(ch.config)
+                self.ch_gb.channel_tableWidget.cellWidget(idx, 0).setCurrentText(
+                    ch.config
+                )
             else:
                 warnings.warn(
                     f"Unrecognized channel: {ch.config!r}. "
                     f"Valid channels include {channel_list}"
                 )
             if ch.exposure:
-                self.channel_tableWidget.cellWidget(idx, 1).setValue(int(ch.exposure))
+                self.ch_gb.channel_tableWidget.cellWidget(idx, 1).setValue(
+                    int(ch.exposure)
+                )
 
         # set Z
         if state.z_plan:
-            self.stack_groupBox.setChecked(True)
+            self.z_gp.setChecked(True)
             if hasattr(state.z_plan, "top") and hasattr(state.z_plan, "bottom"):
-                self.z_top_doubleSpinBox.setValue(state.z_plan.top)
-                self.z_bottom_doubleSpinBox.setValue(state.z_plan.bottom)
-                self.z_tabWidget.setCurrentIndex(0)
+                self.z_gp.z_top_doubleSpinBox.setValue(state.z_plan.top)
+                self.z_gp.z_bottom_doubleSpinBox.setValue(state.z_plan.bottom)
+                self.z_gp.z_tabWidget.setCurrentIndex(0)
             elif hasattr(state.z_plan, "above") and hasattr(state.z_plan, "below"):
-                self.above_doubleSpinBox.setValue(state.z_plan.above)
-                self.below_doubleSpinBox.setValue(state.z_plan.below)
-                self.z_tabWidget.setCurrentIndex(2)
+                self.z_gp.above_doubleSpinBox.setValue(state.z_plan.above)
+                self.z_gp.below_doubleSpinBox.setValue(state.z_plan.below)
+                self.z_gp.z_tabWidget.setCurrentIndex(2)
             elif hasattr(state.z_plan, "range"):
-                self.zrange_spinBox.setValue(int(state.z_plan.range))
-                self.z_tabWidget.setCurrentIndex(1)
+                self.z_gp.zrange_spinBox.setValue(int(state.z_plan.range))
+                self.z_gp.z_tabWidget.setCurrentIndex(1)
             if hasattr(state.z_plan, "step"):
-                self.step_size_doubleSpinBox.setValue(state.z_plan.step)
+                self.z_gp.step_size_doubleSpinBox.setValue(state.z_plan.step)
         else:
-            self.stack_groupBox.setChecked(False)
+            self.z_gp.setChecked(False)
 
         # set time
         # currently only `TIntervalLoops` is supported
         if hasattr(state.time_plan, "interval") and hasattr(state.time_plan, "loops"):
-            self.time_groupBox.setChecked(True)
-            self.timepoints_spinBox.setValue(state.time_plan.loops)
+            self.tm_gp.setChecked(True)
+            self.tm_gp.timepoints_spinBox.setValue(state.time_plan.loops)
 
             sec = state.time_plan.interval.total_seconds()
             if sec >= 60:
-                self.time_comboBox.setCurrentText("min")
-                self.interval_spinBox.setValue(sec // 60)
+                self.tm_gp.time_comboBox.setCurrentText("min")
+                self.tm_gp.interval_spinBox.setValue(sec // 60)
             elif sec >= 1:
-                self.time_comboBox.setCurrentText("sec")
-                self.interval_spinBox.setValue(int(sec))
+                self.tm_gp.time_comboBox.setCurrentText("sec")
+                self.tm_gp.interval_spinBox.setValue(int(sec))
             else:
-                self.time_comboBox.setCurrentText("ms")
-                self.interval_spinBox.setValue(int(sec * 1000))
+                self.tm_gp.time_comboBox.setCurrentText("ms")
+                self.tm_gp.interval_spinBox.setValue(int(sec * 1000))
         else:
-            self.time_groupBox.setChecked(False)
+            self.tm_gp.setChecked(False)
 
         # set stage positions
         self._clear_positions()
         if state.stage_positions:
-            self.stage_pos_groupBox.setChecked(True)
+            self.pos_gp.setChecked(True)
             for idx, pos in enumerate(state.stage_positions):
                 self._add_position_row()
                 for c, ax in enumerate("pxyz"):
@@ -544,9 +576,9 @@ class MDAWidget(_MDAWidgetGui):
                     item.setTextAlignment(
                         Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                     )
-                    self.stage_tableWidget.setItem(idx, c, item)
+                    self.pos_gp.stage_tableWidget.setItem(idx, c, item)
         else:
-            self.stage_pos_groupBox.setChecked(False)
+            self.pos_gp.setChecked(False)
 
     def get_state(self) -> MDASequence:
         """Get current state of widget and build a useq.MDASequence.
@@ -557,60 +589,57 @@ class MDAWidget(_MDAWidgetGui):
         """
         channels: list[dict] = [
             {
-                "config": self.channel_tableWidget.cellWidget(c, 0).currentText(),
+                "config": self.ch_gb.channel_tableWidget.cellWidget(c, 0).currentText(),
                 "group": self._mmc.getChannelGroup() or "Channel",
-                "exposure": self.channel_tableWidget.cellWidget(c, 1).value(),
+                "exposure": self.ch_gb.channel_tableWidget.cellWidget(c, 1).value(),
             }
-            for c in range(self.channel_tableWidget.rowCount())
+            for c in range(self.ch_gb.channel_tableWidget.rowCount())
         ]
 
         z_plan: dict | None = None
-        if self.stack_groupBox.isChecked():
-            if self.z_tabWidget.currentIndex() == 0:
+        if self.z_gp.isChecked():
+            if self.z_gp.z_tabWidget.currentIndex() == 0:
                 z_plan = {
-                    "top": self.z_top_doubleSpinBox.value(),
-                    "bottom": self.z_bottom_doubleSpinBox.value(),
-                    "step": self.step_size_doubleSpinBox.value(),
+                    "top": self.z_gp.z_top_doubleSpinBox.value(),
+                    "bottom": self.z_gp.z_bottom_doubleSpinBox.value(),
+                    "step": self.z_gp.step_size_doubleSpinBox.value(),
                 }
 
-            elif self.z_tabWidget.currentIndex() == 1:
+            elif self.z_gp.z_tabWidget.currentIndex() == 1:
                 z_plan = {
-                    "range": self.zrange_spinBox.value(),
-                    "step": self.step_size_doubleSpinBox.value(),
+                    "range": self.z_gp.zrange_spinBox.value(),
+                    "step": self.z_gp.step_size_doubleSpinBox.value(),
                 }
-            elif self.z_tabWidget.currentIndex() == 2:
+            elif self.z_gp.z_tabWidget.currentIndex() == 2:
                 z_plan = {
-                    "above": self.above_doubleSpinBox.value(),
-                    "below": self.below_doubleSpinBox.value(),
-                    "step": self.step_size_doubleSpinBox.value(),
+                    "above": self.z_gp.above_doubleSpinBox.value(),
+                    "below": self.z_gp.below_doubleSpinBox.value(),
+                    "step": self.z_gp.step_size_doubleSpinBox.value(),
                 }
 
         time_plan: dict | None = None
-        if self.time_groupBox.isChecked():
+        if self.tm_gp.isChecked():
             unit = {"min": "minutes", "sec": "seconds", "ms": "milliseconds"}[
-                self.time_comboBox.currentText()
+                self.tm_gp.time_comboBox.currentText()
             ]
             time_plan = {
-                "interval": {unit: self.interval_spinBox.value()},
-                "loops": self.timepoints_spinBox.value(),
+                "interval": {unit: self.tm_gp.interval_spinBox.value()},
+                "loops": self.tm_gp.timepoints_spinBox.value(),
             }
 
         # position settings
         stage_positions: list = []
 
         if self._mmc.getXYStageDevice():
-            if (
-                self.stage_pos_groupBox.isChecked()
-                and self.stage_tableWidget.rowCount() > 0
-            ):
-                for r in range(self.stage_tableWidget.rowCount()):
+            if self.pos_gp.isChecked() and self.pos_gp.stage_tableWidget.rowCount() > 0:
+                for r in range(self.pos_gp.stage_tableWidget.rowCount()):
                     pos = {
-                        "name": self.stage_tableWidget.item(r, 0).text(),
-                        "x": float(self.stage_tableWidget.item(r, 1).text()),
-                        "y": float(self.stage_tableWidget.item(r, 2).text()),
+                        "name": self.pos_gp.stage_tableWidget.item(r, 0).text(),
+                        "x": float(self.pos_gp.stage_tableWidget.item(r, 1).text()),
+                        "y": float(self.pos_gp.stage_tableWidget.item(r, 2).text()),
                     }
                     if self._mmc.getFocusDevice():
-                        pos["z"] = float(self.stage_tableWidget.item(r, 3).text())
+                        pos["z"] = float(self.z_gp.stage_tableWidget.item(r, 3).text())
                     stage_positions.append(pos)
             else:
                 pos = {
@@ -623,7 +652,7 @@ class MDAWidget(_MDAWidgetGui):
                 stage_positions.append(pos)
 
         return MDASequence(
-            axis_order=self.acquisition_order_comboBox.currentText(),
+            axis_order=self.buttons_wdg.acquisition_order_comboBox.currentText(),
             channels=channels,
             stage_positions=stage_positions,
             z_plan=z_plan,

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -69,9 +69,9 @@ class MDAWidget(_MDAWidgetGui):
         self.buttons_wdg.cancel_button.released.connect(lambda: self._mmc.mda.cancel())
 
         self.ch_gb = self.channel_groupbox
-        self.tm_gp = self.time_groupBox
-        self.z_gp = self.stack_groupBox
-        self.pos_gp = self.stage_pos_groupBox
+        self.tm_gp = self.time_groupbox
+        self.z_gp = self.stack_groupbox
+        self.pos_gp = self.stage_pos_groupbox
 
         # connect run button
         if self._include_run_button:
@@ -628,7 +628,9 @@ class MDAWidget(_MDAWidgetGui):
                         "y": float(self.pos_gp.stage_tableWidget.item(r, 2).text()),
                     }
                     if self._mmc.getFocusDevice():
-                        pos["z"] = float(self.z_gp.stage_tableWidget.item(r, 3).text())
+                        pos["z"] = float(
+                            self.pos_gp.stage_tableWidget.item(r, 3).text()
+                        )
                     stage_positions.append(pos)
             else:
                 pos = {

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -374,13 +374,13 @@ class MDAWidget(_MDAWidgetGui):
         self.buttons_wdg.acquisition_order_comboBox.setCurrentText(state.axis_order)
 
         # set channel table
-        self._clear_channel()
+        self.ch_gb._clear_channel()
         if channel_group := self._mmc.getChannelGroup():
             channel_list = list(self._mmc.getAvailableConfigs(channel_group))
         else:
             channel_list = []
         for idx, ch in enumerate(state.channels):
-            if not self._add_channel():
+            if not self.ch_gb._add_channel():
                 break
             if ch.config in channel_list:
                 self.ch_gb.channel_tableWidget.cellWidget(idx, 0).setCurrentText(

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -110,10 +110,10 @@ class MDAWidget(_MDAWidgetGui):
 
         # connection for positions
         self.pos_gp = self.pos_gp
-        self.pos_gp.add_pos_Button.clicked.connect(self._add_position)
-        self.pos_gp.remove_pos_Button.clicked.connect(self._remove_position)
-        self.pos_gp.clear_pos_Button.clicked.connect(self._clear_positions)
-        self.pos_gp.grid_Button.clicked.connect(self._grid_widget)
+        self.pos_gp.add_pos_button.clicked.connect(self._add_position)
+        self.pos_gp.remove_pos_button.clicked.connect(self._remove_position)
+        self.pos_gp.clear_pos_button.clicked.connect(self._clear_positions)
+        self.pos_gp.grid_button.clicked.connect(self._grid_widget)
         self.pos_gp.go.clicked.connect(self._move_to_position)
         self.pos_gp.toggled.connect(self._calculate_total_time)
 

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -73,60 +73,25 @@ class MDAWidget(_MDAWidgetGui):
         self.z_gp = self.stack_groupbox
         self.pos_gp = self.stage_pos_groupbox
 
+        # connect valueUpdated signal
+        self.ch_gb.valueUpdated.connect(self._update_total_time)
+        self.z_gp.valueUpdated.connect(self._update_total_time)
+        self.tm_gp.valueUpdated.connect(self._update_total_time)
+
         # connect run button
         if self._include_run_button:
             self.buttons_wdg.run_button.clicked.connect(self._on_run_clicked)
 
-        # connection for channel
-        self.ch_gb.add_ch_button.clicked.connect(self._add_channel)
-        self.ch_gb.remove_ch_button.clicked.connect(self._remove_channel)
-        self.ch_gb.clear_ch_button.clicked.connect(self._clear_channel)
-
-        # connection for z stack
-        self.z_gp.set_top_button.clicked.connect(self._set_top)
-        self.z_gp.set_bottom_button.clicked.connect(self._set_bottom)
-        self.z_gp.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
-        self.z_gp.z_bottom_doubleSpinBox.valueChanged.connect(
-            self._update_topbottom_range
-        )
-        self.z_gp.zrange_spinBox.valueChanged.connect(self._update_rangearound_label)
-        self.z_gp.above_doubleSpinBox.valueChanged.connect(
-            self._update_abovebelow_range
-        )
-        self.z_gp.below_doubleSpinBox.valueChanged.connect(
-            self._update_abovebelow_range
-        )
-        self.z_gp.z_range_abovebelow_doubleSpinBox.valueChanged.connect(
-            self._update_n_images
-        )
-        self.z_gp.zrange_spinBox.valueChanged.connect(self._update_n_images)
-        self.z_gp.z_range_topbottom_doubleSpinBox.valueChanged.connect(
-            self._update_n_images
-        )
-        self.z_gp.step_size_doubleSpinBox.valueChanged.connect(self._update_n_images)
-        self.z_gp.z_tabWidget.currentChanged.connect(self._update_n_images)
-        self.z_gp.toggled.connect(self._update_n_images)
-        self.z_gp.toggled.connect(self._calculate_total_time)
-
         # connection for positions
-        self.pos_gp = self.pos_gp
         self.pos_gp.add_pos_button.clicked.connect(self._add_position)
         self.pos_gp.remove_pos_button.clicked.connect(self._remove_position)
         self.pos_gp.clear_pos_button.clicked.connect(self._clear_positions)
         self.pos_gp.grid_button.clicked.connect(self._grid_widget)
-        self.pos_gp.toggled.connect(self._calculate_total_time)
-
-        # connection for time
-        self.tm_gp = self.tm_gp
-        self.tm_gp.toggled.connect(self._calculate_total_time)
-        self.tm_gp.interval_spinBox.valueChanged.connect(self._calculate_total_time)
-        self.tm_gp.timepoints_spinBox.valueChanged.connect(self._calculate_total_time)
-        self.tm_gp.time_comboBox.currentIndexChanged.connect(self._calculate_total_time)
+        self.pos_gp.toggled.connect(self._update_total_time)
 
         # connect mmcore signals
         self._mmc.mda.events.sequenceStarted.connect(self._on_mda_started)
         self._mmc.mda.events.sequenceFinished.connect(self._on_mda_finished)
-        self._mmc.mda.events.sequencePauseToggled.connect(self._on_mda_paused)
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_cfg_loaded)
 
         self._on_sys_cfg_loaded()
@@ -134,6 +99,8 @@ class MDAWidget(_MDAWidgetGui):
     def _on_sys_cfg_loaded(self) -> None:
         if channel_group := self._mmc.getChannelGroup() or guess_channel_group():
             self._mmc.setChannelGroup(channel_group)
+        self.ch_gb._clear_channel()
+        self._clear_positions()
 
     def _set_enabled(self, enabled: bool) -> None:
         self.tm_gp.setEnabled(enabled)
@@ -151,89 +118,6 @@ class MDAWidget(_MDAWidgetGui):
             self.z_gp.setEnabled(False)
         else:
             self.z_gp.setEnabled(enabled)
-
-    def _add_channel(self) -> bool:
-        """Add, remove or clear channel table.  Return True if anyting was changed."""
-        if len(self._mmc.getLoadedDevices()) <= 1:
-            return False
-
-        channel_group = self._mmc.getChannelGroup()
-        if not channel_group:
-            return False
-
-        idx = self.ch_gb.channel_tableWidget.rowCount()
-        self.ch_gb.channel_tableWidget.insertRow(idx)
-
-        # create a combo_box for channels in the table
-        channel_comboBox = QtW.QComboBox(self)
-        channel_exp_spinBox = QtW.QSpinBox(self)
-        channel_exp_spinBox.setRange(0, 10000)
-        channel_exp_spinBox.setValue(100)
-        channel_exp_spinBox.valueChanged.connect(self._calculate_total_time)
-
-        if channel_group := self._mmc.getChannelGroup():
-            channel_list = list(self._mmc.getAvailableConfigs(channel_group))
-            channel_comboBox.addItems(channel_list)
-
-        self.ch_gb.channel_tableWidget.setCellWidget(idx, 0, channel_comboBox)
-        self.ch_gb.channel_tableWidget.setCellWidget(idx, 1, channel_exp_spinBox)
-
-        self._calculate_total_time()
-
-        return True
-
-    def _remove_channel(self) -> None:
-        # remove selected position
-        rows = {r.row() for r in self.ch_gb.channel_tableWidget.selectedIndexes()}
-        for idx in sorted(rows, reverse=True):
-            self.ch_gb.channel_tableWidget.removeRow(idx)
-
-        self._calculate_total_time()
-
-    def _clear_channel(self) -> None:
-        # clear all positions
-        self.ch_gb.channel_tableWidget.clearContents()
-        self.ch_gb.channel_tableWidget.setRowCount(0)
-
-        self._calculate_total_time()
-
-    def _set_top(self) -> None:
-        self.z_gp.z_top_doubleSpinBox.setValue(self._mmc.getZPosition())
-
-    def _set_bottom(self) -> None:
-        self.z_gp.z_bottom_doubleSpinBox.setValue(self._mmc.getZPosition())
-
-    def _update_topbottom_range(self) -> None:
-        self.z_gp.z_range_topbottom_doubleSpinBox.setValue(
-            abs(
-                self.z_gp.z_top_doubleSpinBox.value()
-                - self.z_gp.z_bottom_doubleSpinBox.value()
-            )
-        )
-
-    def _update_rangearound_label(self, value: int) -> None:
-        self.z_gp.range_around_label.setText(f"-{value/2} µm <- z -> +{value/2} µm")
-
-    def _update_abovebelow_range(self) -> None:
-        self.z_gp.z_range_abovebelow_doubleSpinBox.setValue(
-            self.z_gp.above_doubleSpinBox.value()
-            + self.z_gp.below_doubleSpinBox.value()
-        )
-
-    def _update_n_images(self) -> None:
-        step = self.z_gp.step_size_doubleSpinBox.value()
-        # set what is the range to consider depending on the z_stack mode
-        if self.z_gp.z_tabWidget.currentIndex() == 0:
-            _range = self.z_gp.z_range_topbottom_doubleSpinBox.value()
-        if self.z_gp.z_tabWidget.currentIndex() == 1:
-            _range = self.z_gp.zrange_spinBox.value()
-        if self.z_gp.z_tabWidget.currentIndex() == 2:
-            _range = self.z_gp.z_range_abovebelow_doubleSpinBox.value()
-
-        self.z_gp.n_images_label.setText(
-            f"Number of Images: {round((_range / step) + 1)}"
-        )
-        self._calculate_total_time()
 
     # add, remove, clear, move_to positions table
     def _add_position(self) -> None:
@@ -265,7 +149,7 @@ class MDAWidget(_MDAWidgetGui):
                 )
                 self.pos_gp.stage_tableWidget.setItem(idx, c, item)
 
-            self._calculate_total_time()
+            self._update_total_time()
 
     def _add_position_row(self) -> int:
         idx = self.pos_gp.stage_tableWidget.rowCount()
@@ -285,7 +169,7 @@ class MDAWidget(_MDAWidgetGui):
                 removed.append(name)
             self.pos_gp.stage_tableWidget.removeRow(idx)
         self._rename_positions(removed)
-        self._calculate_total_time()
+        self._update_total_time()
 
     def _rename_positions(self, names: list) -> None:
         for name in names:
@@ -311,7 +195,7 @@ class MDAWidget(_MDAWidgetGui):
         # clear all positions
         self.pos_gp.stage_tableWidget.clearContents()
         self.pos_gp.stage_tableWidget.setRowCount(0)
-        self._calculate_total_time()
+        self._update_total_time()
 
     def _grid_widget(self) -> None:
         if not self._mmc.getXYStageDevice():
@@ -364,7 +248,7 @@ class MDAWidget(_MDAWidgetGui):
             self.pos_gp.stage_tableWidget.setItem(rows, 2, y)
             self.pos_gp.stage_tableWidget.setItem(rows, 3, z)
 
-    def _calculate_total_time(self) -> None:
+    def _update_total_time(self) -> None:
 
         # channel
         exp: list = []

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
@@ -16,12 +16,12 @@ from qtpy.QtWidgets import (
 from superqt import QCollapsible
 
 from pymmcore_widgets._general_mda_widgets import (
-    MDAChannelTable,
-    MDAControlButtons,
-    MDAPositionTable,
-    MDAStackWidget,
-    MDATimeLabel,
-    MDATimeWidget,
+    _MDAChannelTable,
+    _MDAControlButtons,
+    _MDAPositionTable,
+    _MDAStackWidget,
+    _MDATimeLabel,
+    _MDATimeWidget,
 )
 
 LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
@@ -45,10 +45,10 @@ class SampleExplorerGui(QWidget):
         self._scroll.setWidget(self.explorer_wdg)
         self.layout().addWidget(self._scroll)
 
-        self.time_lbl = MDATimeLabel()
+        self.time_lbl = _MDATimeLabel()
         self.layout().addWidget(self.time_lbl)
 
-        self.buttons_wdg = MDAControlButtons()
+        self.buttons_wdg = _MDAControlButtons()
         self.layout().addWidget(self.buttons_wdg)
 
     def _create_gui(self) -> QWidget:
@@ -62,7 +62,7 @@ class SampleExplorerGui(QWidget):
         self.scan_props = self._create_row_cols_overlap_group()
         wdg_layout.addWidget(self.scan_props)
 
-        self.channel_groupbox = MDAChannelTable()
+        self.channel_groupbox = _MDAChannelTable()
         wdg_layout.addWidget(self.channel_groupbox)
         self.channel_groupbox.channel_tableWidget.model().rowsInserted.connect(
             self._enable_run_btn
@@ -173,7 +173,7 @@ class SampleExplorerGui(QWidget):
         self.time_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.time_coll.addWidget(spacer)
-        self.time_groupBox = MDATimeWidget()
+        self.time_groupBox = _MDATimeWidget()
         self.time_groupBox.setTitle("")
         self.time_coll.addWidget(self.time_groupBox)
 
@@ -185,7 +185,7 @@ class SampleExplorerGui(QWidget):
         self.stack_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.stack_coll.addWidget(spacer)
-        self.stack_groupBox = MDAStackWidget()
+        self.stack_groupBox = _MDAStackWidget()
         self.stack_groupBox.setTitle("")
         self.stack_coll.addWidget(self.stack_groupBox)
 
@@ -197,7 +197,7 @@ class SampleExplorerGui(QWidget):
         self.pos_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.pos_coll.addWidget(spacer)
-        self.stage_pos_groupBox = MDAPositionTable(["Grid #", "X", "Y", "Z"])
+        self.stage_pos_groupBox = _MDAPositionTable(["Grid #", "X", "Y", "Z"])
         self.stage_pos_groupBox.setTitle("")
         self.stage_pos_groupBox.grid_button.hide()
         self.pos_coll.addWidget(self.stage_pos_groupBox)

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
@@ -1,28 +1,28 @@
 from typing import Optional
 
-from fonticon_mdi6 import MDI6
-from qtpy.QtCore import QSize, Qt
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
-    QAbstractItemView,
-    QAbstractSpinBox,
-    QComboBox,
-    QDoubleSpinBox,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
-    QPushButton,
     QScrollArea,
     QSizePolicy,
     QSpacerItem,
     QSpinBox,
-    QTableWidget,
-    QTabWidget,
     QVBoxLayout,
     QWidget,
 )
 from superqt import QCollapsible
-from superqt.fonticon import icon
+
+from pymmcore_widgets._general_mda_widgets import (
+    MDAChannelTable,
+    MDAControlButtons,
+    MDAPositionTable,
+    MDAStackWidget,
+    MDATimeLabel,
+    MDATimeWidget,
+)
 
 LBL_SIZEPOLICY = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
@@ -45,11 +45,11 @@ class SampleExplorerGui(QWidget):
         self._scroll.setWidget(self.explorer_wdg)
         self.layout().addWidget(self._scroll)
 
-        lbl = self._create_label()
-        self.layout().addWidget(lbl)
+        self.time_lbl = MDATimeLabel()
+        self.layout().addWidget(self.time_lbl)
 
-        self.btns = self._create_start_stop_buttons()
-        self.layout().addWidget(self.btns)
+        self.buttons_wdg = MDAControlButtons()
+        self.layout().addWidget(self.buttons_wdg)
 
     def _create_gui(self) -> QWidget:
 
@@ -62,8 +62,14 @@ class SampleExplorerGui(QWidget):
         self.scan_props = self._create_row_cols_overlap_group()
         wdg_layout.addWidget(self.scan_props)
 
-        self.channel_explorer_groupBox = self._create_channel_group()
-        wdg_layout.addWidget(self.channel_explorer_groupBox)
+        self.channel_groupbox = MDAChannelTable()
+        wdg_layout.addWidget(self.channel_groupbox)
+        self.channel_groupbox.channel_tableWidget.model().rowsInserted.connect(
+            self._enable_run_btn
+        )
+        self.channel_groupbox.channel_tableWidget.model().rowsRemoved.connect(
+            self._enable_run_btn
+        )
 
         mda_options = self._create_mda_options()
         wdg_layout.addWidget(mda_options)
@@ -74,6 +80,11 @@ class SampleExplorerGui(QWidget):
         wdg_layout.addItem(spacer)
 
         return wdg
+
+    def _enable_run_btn(self) -> None:
+        self.buttons_wdg.run_Button.setEnabled(
+            self.channel_groupbox.channel_tableWidget.rowCount() > 0
+        )
 
     def _create_row_cols_overlap_group(self) -> QGroupBox:
 
@@ -138,60 +149,6 @@ class SampleExplorerGui(QWidget):
         group_layout.addWidget(self.ovl_wdg, 0, 1)
         return group
 
-    def _create_channel_group(self) -> QGroupBox:
-
-        group = QGroupBox(title="Channels")
-        group.setMinimumHeight(230)
-        group_layout = QGridLayout()
-        group_layout.setHorizontalSpacing(15)
-        group_layout.setVerticalSpacing(0)
-        group_layout.setContentsMargins(10, 0, 10, 0)
-        group.setLayout(group_layout)
-
-        # table
-        self.channel_explorer_tableWidget = QTableWidget()
-        self.channel_explorer_tableWidget.model().rowsInserted.connect(
-            self._enable_run_btn
-        )
-        self.channel_explorer_tableWidget.model().rowsRemoved.connect(
-            self._enable_run_btn
-        )
-        self.channel_explorer_tableWidget.setMinimumHeight(90)
-        hdr = self.channel_explorer_tableWidget.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        self.channel_explorer_tableWidget.verticalHeader().setVisible(False)
-        self.channel_explorer_tableWidget.setTabKeyNavigation(True)
-        self.channel_explorer_tableWidget.setColumnCount(2)
-        self.channel_explorer_tableWidget.setRowCount(0)
-        self.channel_explorer_tableWidget.setHorizontalHeaderLabels(
-            ["Channel", "Exposure Time (ms)"]
-        )
-        group_layout.addWidget(self.channel_explorer_tableWidget, 0, 0, 3, 1)
-
-        # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        min_size = 100
-        self.add_ch_explorer_Button = QPushButton(text="Add")
-        self.add_ch_explorer_Button.setMinimumWidth(min_size)
-        self.add_ch_explorer_Button.setSizePolicy(btn_sizepolicy)
-        self.remove_ch_explorer_Button = QPushButton(text="Remove")
-        self.remove_ch_explorer_Button.setMinimumWidth(min_size)
-        self.remove_ch_explorer_Button.setSizePolicy(btn_sizepolicy)
-        self.clear_ch_explorer_Button = QPushButton(text="Clear")
-        self.clear_ch_explorer_Button.setMinimumWidth(min_size)
-        self.clear_ch_explorer_Button.setSizePolicy(btn_sizepolicy)
-
-        group_layout.addWidget(self.add_ch_explorer_Button, 0, 1, 1, 1)
-        group_layout.addWidget(self.remove_ch_explorer_Button, 1, 1, 1, 2)
-        group_layout.addWidget(self.clear_ch_explorer_Button, 2, 1, 1, 2)
-
-        return group
-
-    def _enable_run_btn(self) -> None:
-        self.start_scan_Button.setEnabled(
-            self.channel_explorer_tableWidget.rowCount() > 0
-        )
-
     def _spacer(self) -> QLabel:
         spacer = QLabel()
         spacer.setMinimumHeight(0)
@@ -216,7 +173,8 @@ class SampleExplorerGui(QWidget):
         self.time_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.time_coll.addWidget(spacer)
-        self.time_groupBox = self._create_time_group()
+        self.time_groupBox = MDATimeWidget()
+        self.time_groupBox.setTitle("")
         self.time_coll.addWidget(self.time_groupBox)
 
         group_layout.addWidget(self.time_coll)
@@ -227,7 +185,8 @@ class SampleExplorerGui(QWidget):
         self.stack_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.stack_coll.addWidget(spacer)
-        self.stack_groupBox = self._create_stack_groupBox()
+        self.stack_groupBox = MDAStackWidget()
+        self.stack_groupBox.setTitle("")
         self.stack_coll.addWidget(self.stack_groupBox)
 
         group_layout.addWidget(self.stack_coll)
@@ -238,380 +197,14 @@ class SampleExplorerGui(QWidget):
         self.pos_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.pos_coll.addWidget(spacer)
-        self.stage_pos_groupBox = self._create_stage_pos_groupBox()
+        self.stage_pos_groupBox = MDAPositionTable(["Grid #", "X", "Y", "Z"])
+        self.stage_pos_groupBox.setTitle("")
+        self.stage_pos_groupBox.grid_Button.hide()
         self.pos_coll.addWidget(self.stage_pos_groupBox)
 
         group_layout.addWidget(self.pos_coll)
 
         return group
-
-    def _create_time_group(self) -> QGroupBox:
-
-        group = QGroupBox()
-        group.setCheckable(True)
-        group.setChecked(False)
-        group.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        )
-        group_layout = QGridLayout()
-        group_layout.setHorizontalSpacing(20)
-        group_layout.setVerticalSpacing(5)
-        group_layout.setContentsMargins(10, 10, 10, 10)
-        group.setLayout(group_layout)
-
-        # Timepoints
-        wdg = QWidget()
-        wdg_lay = QHBoxLayout()
-        wdg_lay.setSpacing(5)
-        wdg_lay.setContentsMargins(0, 0, 0, 0)
-        wdg.setLayout(wdg_lay)
-        lbl = QLabel(text="Timepoints:")
-        lbl.setSizePolicy(LBL_SIZEPOLICY)
-        self.timepoints_spinBox = QSpinBox()
-        self.timepoints_spinBox.setMinimum(1)
-        self.timepoints_spinBox.setMaximum(10000)
-        self.timepoints_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        wdg_lay.addWidget(lbl)
-        wdg_lay.addWidget(self.timepoints_spinBox)
-        group_layout.addWidget(wdg, 0, 0)
-
-        # Interval
-        wdg1 = QWidget()
-        wdg1_lay = QHBoxLayout()
-        wdg1_lay.setSpacing(5)
-        wdg1_lay.setContentsMargins(0, 0, 0, 0)
-        wdg1.setLayout(wdg1_lay)
-        lbl1 = QLabel(text="Interval:")
-        lbl1.setSizePolicy(LBL_SIZEPOLICY)
-        self.interval_spinBox = QSpinBox()
-        self.interval_spinBox.setMinimum(0)
-        self.interval_spinBox.setMaximum(10000)
-        self.interval_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        wdg1_lay.addWidget(lbl1)
-        wdg1_lay.addWidget(self.interval_spinBox)
-        group_layout.addWidget(wdg1, 0, 1)
-
-        self.time_comboBox = QComboBox()
-        self.time_comboBox.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        )
-        self.time_comboBox.addItems(["ms", "sec", "min", "hours"])
-        group_layout.addWidget(self.time_comboBox, 0, 2)
-
-        wdg2 = QWidget()
-        wdg2_lay = QHBoxLayout()
-        wdg2_lay.setSpacing(5)
-        wdg2_lay.setContentsMargins(0, 0, 0, 0)
-        wdg2.setLayout(wdg2_lay)
-        self._icon_lbl = QLabel()
-        self._icon_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._icon_lbl.setSizePolicy(LBL_SIZEPOLICY)
-        wdg2_lay.addWidget(self._icon_lbl)
-        self._time_lbl = QLabel()
-        self._time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._time_lbl.setSizePolicy(LBL_SIZEPOLICY)
-        wdg2_lay.addWidget(self._time_lbl)
-        spacer = QSpacerItem(
-            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
-        wdg2_lay.addItem(spacer)
-        group_layout.addWidget(wdg2, 1, 0, 1, 2)
-
-        self._time_lbl.hide()
-        self._icon_lbl.hide()
-
-        return group
-
-    def _create_stack_groupBox(self) -> QGroupBox:
-
-        group = QGroupBox()
-        group.setCheckable(True)
-        group.setChecked(False)
-        group.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        )
-        group_layout = QVBoxLayout()
-        group_layout.setSpacing(10)
-        group_layout.setContentsMargins(10, 10, 10, 10)
-        group.setLayout(group_layout)
-
-        # tab
-        self.z_tabWidget = QTabWidget()
-        z_tab_layout = QVBoxLayout()
-        z_tab_layout.setSpacing(0)
-        z_tab_layout.setContentsMargins(0, 0, 0, 0)
-        self.z_tabWidget.setLayout(z_tab_layout)
-        group_layout.addWidget(self.z_tabWidget)
-
-        # top bottom
-        tb = QWidget()
-        tb_layout = QGridLayout()
-        tb_layout.setContentsMargins(10, 10, 10, 10)
-        tb.setLayout(tb_layout)
-
-        self.set_top_Button = QPushButton(text="Set Top")
-        self.set_bottom_Button = QPushButton(text="Set Bottom")
-
-        lbl_range_tb = QLabel(text="Range (µm):")
-        lbl_range_tb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.z_top_doubleSpinBox = QDoubleSpinBox()
-        self.z_top_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_top_doubleSpinBox.setMinimum(0.0)
-        self.z_top_doubleSpinBox.setMaximum(100000)
-        self.z_top_doubleSpinBox.setDecimals(2)
-
-        self.z_bottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_bottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_bottom_doubleSpinBox.setMinimum(0.0)
-        self.z_bottom_doubleSpinBox.setMaximum(100000)
-        self.z_bottom_doubleSpinBox.setDecimals(2)
-
-        self.z_range_topbottom_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_topbottom_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_range_topbottom_doubleSpinBox.setMaximum(10000000)
-        self.z_range_topbottom_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.ButtonSymbols.NoButtons
-        )
-        self.z_range_topbottom_doubleSpinBox.setReadOnly(True)
-
-        tb_layout.addWidget(self.set_top_Button, 0, 0)
-        tb_layout.addWidget(self.z_top_doubleSpinBox, 1, 0)
-        tb_layout.addWidget(self.set_bottom_Button, 0, 1)
-        tb_layout.addWidget(self.z_bottom_doubleSpinBox, 1, 1)
-        tb_layout.addWidget(lbl_range_tb, 0, 2)
-        tb_layout.addWidget(self.z_range_topbottom_doubleSpinBox, 1, 2)
-
-        self.z_tabWidget.addTab(tb, "TopBottom")
-
-        # range around
-        ra = QWidget()
-        ra_layout = QHBoxLayout()
-        ra_layout.setSpacing(10)
-        ra_layout.setContentsMargins(10, 10, 10, 10)
-        ra.setLayout(ra_layout)
-
-        lbl_range_ra = QLabel(text="Range (µm):")
-        lbl_range_ra.setSizePolicy(LBL_SIZEPOLICY)
-
-        self.zrange_spinBox = QSpinBox()
-        self.zrange_spinBox.setValue(5)
-        self.zrange_spinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.zrange_spinBox.setMaximum(100000)
-
-        self.range_around_label = QLabel(text="-2.5 µm <- z -> +2.5 µm")
-        self.range_around_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        ra_layout.addWidget(lbl_range_ra)
-        ra_layout.addWidget(self.zrange_spinBox)
-        ra_layout.addWidget(self.range_around_label)
-
-        self.z_tabWidget.addTab(ra, "RangeAround")
-
-        # above below wdg
-        ab = QWidget()
-        ab_layout = QGridLayout()
-        ab_layout.setContentsMargins(10, 0, 10, 15)
-        ab.setLayout(ab_layout)
-
-        lbl_above = QLabel(text="Above (µm):")
-        lbl_above.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.above_doubleSpinBox = QDoubleSpinBox()
-        self.above_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.above_doubleSpinBox.setMinimum(0.05)
-        self.above_doubleSpinBox.setMaximum(10000)
-        self.above_doubleSpinBox.setSingleStep(0.5)
-        self.above_doubleSpinBox.setDecimals(2)
-
-        lbl_below = QLabel(text="Below (µm):")
-        lbl_below.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.below_doubleSpinBox = QDoubleSpinBox()
-        self.below_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.below_doubleSpinBox.setMinimum(0.05)
-        self.below_doubleSpinBox.setMaximum(10000)
-        self.below_doubleSpinBox.setSingleStep(0.5)
-        self.below_doubleSpinBox.setDecimals(2)
-
-        lbl_range = QLabel(text="Range (µm):")
-        lbl_range.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_range_abovebelow_doubleSpinBox = QDoubleSpinBox()
-        self.z_range_abovebelow_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_range_abovebelow_doubleSpinBox.setMaximum(10000000)
-        self.z_range_abovebelow_doubleSpinBox.setButtonSymbols(
-            QAbstractSpinBox.ButtonSymbols.NoButtons
-        )
-        self.z_range_abovebelow_doubleSpinBox.setReadOnly(True)
-
-        ab_layout.addWidget(lbl_above, 0, 0)
-        ab_layout.addWidget(self.above_doubleSpinBox, 1, 0)
-        ab_layout.addWidget(lbl_below, 0, 1)
-        ab_layout.addWidget(self.below_doubleSpinBox, 1, 1)
-        ab_layout.addWidget(lbl_range, 0, 2)
-        ab_layout.addWidget(self.z_range_abovebelow_doubleSpinBox, 1, 2)
-
-        self.z_tabWidget.addTab(ab, "AboveBelow")
-
-        # step size wdg
-        step_wdg = QWidget()
-        step_wdg_layout = QHBoxLayout()
-        step_wdg_layout.setSpacing(15)
-        step_wdg_layout.setContentsMargins(0, 10, 0, 0)
-        step_wdg.setLayout(step_wdg_layout)
-
-        s = QWidget()
-        s_layout = QHBoxLayout()
-        s_layout.setSpacing(0)
-        s_layout.setContentsMargins(0, 0, 0, 0)
-        s.setLayout(s_layout)
-        lbl = QLabel(text="Step Size (µm):")
-        lbl.setSizePolicy(LBL_SIZEPOLICY)
-        self.step_size_doubleSpinBox = QDoubleSpinBox()
-        self.step_size_doubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.step_size_doubleSpinBox.setMinimum(0.05)
-        self.step_size_doubleSpinBox.setMaximum(10000)
-        self.step_size_doubleSpinBox.setSingleStep(0.5)
-        self.step_size_doubleSpinBox.setDecimals(2)
-        s_layout.addWidget(lbl)
-        s_layout.addWidget(self.step_size_doubleSpinBox)
-
-        self.n_images_label = QLabel(text="Number of Images:")
-
-        step_wdg_layout.addWidget(s)
-        step_wdg_layout.addWidget(self.n_images_label)
-        group_layout.addWidget(step_wdg)
-
-        return group
-
-    def _create_stage_pos_groupBox(self) -> QGroupBox:
-
-        group = QGroupBox(title="(double-click to move to position)")
-        group.setCheckable(True)
-        group.setChecked(False)
-        group.setMinimumHeight(230)
-        group_layout = QGridLayout()
-        group_layout.setHorizontalSpacing(15)
-        group_layout.setVerticalSpacing(0)
-        group_layout.setContentsMargins(10, 0, 10, 0)
-        group.setLayout(group_layout)
-
-        # table
-        self.stage_tableWidget = QTableWidget()
-        self.stage_tableWidget.setSelectionBehavior(
-            QAbstractItemView.SelectionBehavior.SelectRows
-        )
-        hdr = self.stage_tableWidget.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        self.stage_tableWidget.verticalHeader().setVisible(False)
-        self.stage_tableWidget.setTabKeyNavigation(True)
-        self.stage_tableWidget.setColumnCount(4)
-        self.stage_tableWidget.setRowCount(0)
-        self.stage_tableWidget.setHorizontalHeaderLabels(["Grid #", "X", "Y", "Z"])
-        group_layout.addWidget(self.stage_tableWidget, 0, 0, 4, 1)
-
-        # buttons
-        btn_sizepolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        min_size = 100
-        self.add_pos_Button = QPushButton(text="Add")
-        self.add_pos_Button.setMinimumWidth(min_size)
-        self.add_pos_Button.setSizePolicy(btn_sizepolicy)
-        self.remove_pos_Button = QPushButton(text="Remove")
-        self.remove_pos_Button.setMinimumWidth(min_size)
-        self.remove_pos_Button.setSizePolicy(btn_sizepolicy)
-        self.clear_pos_Button = QPushButton(text="Clear")
-        self.clear_pos_Button.setMinimumWidth(min_size)
-        self.clear_pos_Button.setSizePolicy(btn_sizepolicy)
-        self.go = QPushButton(text="Go")
-        self.go.setMinimumWidth(min_size)
-        self.go.setSizePolicy(btn_sizepolicy)
-
-        group_layout.addWidget(self.add_pos_Button, 0, 1, 1, 1)
-        group_layout.addWidget(self.remove_pos_Button, 1, 1, 1, 2)
-        group_layout.addWidget(self.clear_pos_Button, 2, 1, 1, 2)
-        group_layout.addWidget(self.go, 3, 1, 1, 2)
-
-        return group
-
-    def _create_start_stop_buttons(self) -> QWidget:
-
-        wdg = QWidget()
-        wdg.setSizePolicy(
-            QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        )
-        wdg_layout = QHBoxLayout()
-        wdg_layout.setSpacing(10)
-        wdg_layout.setContentsMargins(10, 5, 10, 10)
-        wdg.setLayout(wdg_layout)
-
-        acq_wdg = QWidget()
-        acq_wdg_layout = QHBoxLayout()
-        acq_wdg_layout.setSpacing(0)
-        acq_wdg_layout.setContentsMargins(0, 0, 0, 0)
-        acq_wdg.setLayout(acq_wdg_layout)
-        acquisition_order_label = QLabel(text="Acquisition Order:")
-        acquisition_order_label.setSizePolicy(LBL_SIZEPOLICY)
-        self.acquisition_order_comboBox = QComboBox()
-        self.acquisition_order_comboBox.setMinimumWidth(100)
-        self.acquisition_order_comboBox.addItems(["tpcz", "tpzc", "ptzc", "ptcz"])
-        acq_wdg_layout.addWidget(acquisition_order_label)
-        acq_wdg_layout.addWidget(self.acquisition_order_comboBox)
-        wdg_layout.addWidget(acq_wdg)
-
-        spacer = QSpacerItem(
-            10, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
-        )
-        wdg_layout.addItem(spacer)
-
-        btn_sizepolicy = QSizePolicy(
-            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
-        )
-        min_width = 100
-        icon_size = 40
-        self.start_scan_Button = QPushButton(text="Run")
-        self.start_scan_Button.setEnabled(False)
-        self.start_scan_Button.setMinimumWidth(min_width)
-        self.start_scan_Button.setStyleSheet("QPushButton { text-align: center; }")
-        self.start_scan_Button.setSizePolicy(btn_sizepolicy)
-        self.start_scan_Button.setIcon(
-            icon(MDI6.play_circle_outline, color=(0, 255, 0))
-        )
-        self.start_scan_Button.setIconSize(QSize(icon_size, icon_size))
-
-        self.pause_scan_Button = QPushButton(text="Pause")
-        self.pause_scan_Button.setMinimumWidth(min_width)
-        self.pause_scan_Button.setStyleSheet("QPushButton { text-align: center; }")
-        self.pause_scan_Button.setSizePolicy(btn_sizepolicy)
-        self.pause_scan_Button.setIcon(icon(MDI6.pause_circle_outline, color="green"))
-        self.pause_scan_Button.setIconSize(QSize(icon_size, icon_size))
-
-        self.cancel_scan_Button = QPushButton(text="Cancel")
-        self.cancel_scan_Button.setMinimumWidth(min_width)
-        self.cancel_scan_Button.setStyleSheet("QPushButton { text-align: center; }")
-        self.cancel_scan_Button.setSizePolicy(btn_sizepolicy)
-        self.cancel_scan_Button.setIcon(icon(MDI6.stop_circle_outline, color="magenta"))
-        self.cancel_scan_Button.setIconSize(QSize(icon_size, icon_size))
-
-        wdg_layout.addWidget(self.start_scan_Button)
-        wdg_layout.addWidget(self.pause_scan_Button)
-        wdg_layout.addWidget(self.cancel_scan_Button)
-
-        return wdg
-
-    def _create_label(self) -> QWidget:
-
-        # wdg = QGroupBox()
-        wdg = QWidget()
-        wdg_lay = QHBoxLayout()
-        wdg_lay.setSpacing(3)
-        wdg_lay.setContentsMargins(10, 5, 10, 5)
-        wdg_lay.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        wdg.setLayout(wdg_lay)
-
-        self._total_time_lbl = QLabel()
-        self._total_time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._total_time_lbl.setSizePolicy(LBL_SIZEPOLICY)
-        wdg_lay.addWidget(self._total_time_lbl)
-
-        return wdg
 
 
 if __name__ == "__main__":

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
@@ -82,7 +82,7 @@ class SampleExplorerGui(QWidget):
         return wdg
 
     def _enable_run_btn(self) -> None:
-        self.buttons_wdg.run_Button.setEnabled(
+        self.buttons_wdg.run_button.setEnabled(
             self.channel_groupbox.channel_tableWidget.rowCount() > 0
         )
 
@@ -199,7 +199,7 @@ class SampleExplorerGui(QWidget):
         self.pos_coll.addWidget(spacer)
         self.stage_pos_groupBox = MDAPositionTable(["Grid #", "X", "Y", "Z"])
         self.stage_pos_groupBox.setTitle("")
-        self.stage_pos_groupBox.grid_Button.hide()
+        self.stage_pos_groupBox.grid_button.hide()
         self.pos_coll.addWidget(self.stage_pos_groupBox)
 
         group_layout.addWidget(self.pos_coll)

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
@@ -173,9 +173,9 @@ class SampleExplorerGui(QWidget):
         self.time_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.time_coll.addWidget(spacer)
-        self.time_groupBox = _MDATimeWidget()
-        self.time_groupBox.setTitle("")
-        self.time_coll.addWidget(self.time_groupBox)
+        self.time_groupbox = _MDATimeWidget()
+        self.time_groupbox.setTitle("")
+        self.time_coll.addWidget(self.time_groupbox)
 
         group_layout.addWidget(self.time_coll)
 
@@ -185,9 +185,9 @@ class SampleExplorerGui(QWidget):
         self.stack_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.stack_coll.addWidget(spacer)
-        self.stack_groupBox = _MDAStackWidget()
-        self.stack_groupBox.setTitle("")
-        self.stack_coll.addWidget(self.stack_groupBox)
+        self.stack_groupbox = _MDAStackWidget()
+        self.stack_groupbox.setTitle("")
+        self.stack_coll.addWidget(self.stack_groupbox)
 
         group_layout.addWidget(self.stack_coll)
 
@@ -197,10 +197,10 @@ class SampleExplorerGui(QWidget):
         self.pos_coll.layout().setContentsMargins(0, 0, 0, 0)
         spacer = self._spacer()
         self.pos_coll.addWidget(spacer)
-        self.stage_pos_groupBox = _MDAPositionTable(["Grid #", "X", "Y", "Z"])
-        self.stage_pos_groupBox.setTitle("")
-        self.stage_pos_groupBox.grid_button.hide()
-        self.pos_coll.addWidget(self.stage_pos_groupBox)
+        self.stage_pos_groupbox = _MDAPositionTable(["Grid #", "X", "Y", "Z"])
+        self.stage_pos_groupbox.setTitle("")
+        self.stage_pos_groupbox.grid_button.hide()
+        self.pos_coll.addWidget(self.stage_pos_groupbox)
 
         group_layout.addWidget(self.pos_coll)
 

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -85,8 +85,8 @@ class SampleExplorerWidget(SampleExplorerGui):
         self.ch_gb.clear_ch_button.clicked.connect(self._clear_channel)
 
         # connection for z stack
-        self.z_gp.set_top_Button.clicked.connect(self._set_top)
-        self.z_gp.set_bottom_Button.clicked.connect(self._set_bottom)
+        self.z_gp.set_top_button.clicked.connect(self._set_top)
+        self.z_gp.set_bottom_button.clicked.connect(self._set_bottom)
         self.z_gp.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
         self.z_gp.z_bottom_doubleSpinBox.valueChanged.connect(
             self._update_topbottom_range
@@ -117,7 +117,6 @@ class SampleExplorerWidget(SampleExplorerGui):
         self.pos_gp.add_pos_button.clicked.connect(self._add_position)
         self.pos_gp.remove_pos_button.clicked.connect(self._remove_position)
         self.pos_gp.clear_pos_button.clicked.connect(self._clear_positions)
-        self.pos_gp.go.clicked.connect(self._move_to_position)
         self.pos_gp.toggled.connect(self._calculate_total_time)
 
         # connection for time
@@ -300,7 +299,7 @@ class SampleExplorerWidget(SampleExplorerGui):
         self._calculate_total_time()
 
     def _rename_positions(self) -> None:
-        for grid_count, r in enumerate(range(self.stage_tableWidget.rowCount())):
+        for grid_count, r in enumerate(range(self.pos_gp.stage_tableWidget.rowCount())):
             item = self.pos_gp.stage_tableWidget.item(r, 0)
             item_text = item.text()
             item_whatisthis = item.whatsThis()
@@ -316,16 +315,6 @@ class SampleExplorerWidget(SampleExplorerGui):
             )
             item.setWhatsThis(new_whatisthis)
             self.pos_gp.stage_tableWidget.setItem(r, 0, item)
-
-    def _move_to_position(self) -> None:
-        if not self._mmc.getXYStageDevice():
-            return
-        curr_row = self.pos_gp.stage_tableWidget.currentRow()
-        x_val = self.pos_gp.stage_tableWidget.item(curr_row, 1).text()
-        y_val = self.pos_gp.stage_tableWidget.item(curr_row, 2).text()
-        z_val = self.pos_gp.stage_tableWidget.item(curr_row, 3).text()
-        self._mmc.setXYPosition(float(x_val), float(y_val))
-        self._mmc.setPosition(self._mmc.getFocusDevice(), float(z_val))
 
     def _get_pos_name(self, row: int) -> str:
         item = self.pos_gp.stage_tableWidget.item(row, 0)

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -51,68 +51,83 @@ class SampleExplorerWidget(SampleExplorerGui):
     ) -> None:
         super().__init__(parent=parent)
 
+        self._mmc = mmcore or CMMCorePlus.instance()
+
         self._include_run_button = include_run_button
 
-        self.cancel_scan_Button.hide()
-        self.pause_scan_Button.hide()
+        self.buttons_wdg.cancel_button.hide()
+        self.buttons_wdg.pause_button.hide()
         if not self._include_run_button:
-            self.start_scan_Button.hide()
+            self.buttons_wdg.run_button.hide()
 
-        self._mmc = mmcore or CMMCorePlus.instance()
+        self.buttons_wdg.pause_button.released.connect(
+            lambda: self._mmc.mda.toggle_pause()
+        )
+        self.buttons_wdg.cancel_button.released.connect(lambda: self._mmc.mda.cancel())
 
         self.pixel_size = self._mmc.getPixelSizeUm()
 
         self.return_to_position_x = None
         self.return_to_position_y = None
 
-        # connect for channel
-        self.add_ch_explorer_Button.clicked.connect(self._add_channel)
-        self.remove_ch_explorer_Button.clicked.connect(self._remove_channel)
-        self.clear_ch_explorer_Button.clicked.connect(self._clear_channel)
+        self.ch_gb = self.channel_groupbox
+        self.tm_gp = self.time_groupBox
+        self.z_gp = self.stack_groupBox
+        self.pos_gp = self.stage_pos_groupBox
 
-        # connect for z stack
-        self.set_top_Button.clicked.connect(self._set_top)
-        self.set_bottom_Button.clicked.connect(self._set_bottom)
-        self.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
-        self.z_bottom_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
+        # connect run button
+        if self._include_run_button:
+            self.buttons_wdg.run_button.clicked.connect(self._start_scan)
 
-        self.zrange_spinBox.valueChanged.connect(self._update_rangearound_label)
+        # connection for channel
+        self.ch_gb.add_ch_button.clicked.connect(self._add_channel)
+        self.ch_gb.remove_ch_button.clicked.connect(self._remove_channel)
+        self.ch_gb.clear_ch_button.clicked.connect(self._clear_channel)
 
-        self.above_doubleSpinBox.valueChanged.connect(self._update_abovebelow_range)
-        self.below_doubleSpinBox.valueChanged.connect(self._update_abovebelow_range)
+        # connection for z stack
+        self.z_gp.set_top_Button.clicked.connect(self._set_top)
+        self.z_gp.set_bottom_Button.clicked.connect(self._set_bottom)
+        self.z_gp.z_top_doubleSpinBox.valueChanged.connect(self._update_topbottom_range)
+        self.z_gp.z_bottom_doubleSpinBox.valueChanged.connect(
+            self._update_topbottom_range
+        )
 
-        self.z_range_abovebelow_doubleSpinBox.valueChanged.connect(
+        self.z_gp.zrange_spinBox.valueChanged.connect(self._update_rangearound_label)
+
+        self.z_gp.above_doubleSpinBox.valueChanged.connect(
+            self._update_abovebelow_range
+        )
+        self.z_gp.below_doubleSpinBox.valueChanged.connect(
+            self._update_abovebelow_range
+        )
+
+        self.z_gp.z_range_abovebelow_doubleSpinBox.valueChanged.connect(
             self._update_n_images
         )
-        self.zrange_spinBox.valueChanged.connect(self._update_n_images)
-        self.z_range_topbottom_doubleSpinBox.valueChanged.connect(self._update_n_images)
-        self.step_size_doubleSpinBox.valueChanged.connect(self._update_n_images)
-        self.z_tabWidget.currentChanged.connect(self._update_n_images)
-        self.stack_groupBox.toggled.connect(self._update_n_images)
+        self.z_gp.zrange_spinBox.valueChanged.connect(self._update_n_images)
+        self.z_gp.z_range_topbottom_doubleSpinBox.valueChanged.connect(
+            self._update_n_images
+        )
+        self.z_gp.step_size_doubleSpinBox.valueChanged.connect(self._update_n_images)
+        self.z_gp.z_tabWidget.currentChanged.connect(self._update_n_images)
+        self.z_gp.toggled.connect(self._update_n_images)
+        self.z_gp.toggled.connect(self._calculate_total_time)
 
-        # connect for positions
-        self.add_pos_Button.clicked.connect(self._add_position)
-        self.remove_pos_Button.clicked.connect(self._remove_position)
-        self.clear_pos_Button.clicked.connect(self._clear_positions)
-        self.go.clicked.connect(self._move_to_position)
+        # connection for positions
+        self.pos_gp.add_pos_Button.clicked.connect(self._add_position)
+        self.pos_gp.remove_pos_Button.clicked.connect(self._remove_position)
+        self.pos_gp.clear_pos_Button.clicked.connect(self._clear_positions)
+        self.pos_gp.go.clicked.connect(self._move_to_position)
+        self.pos_gp.toggled.connect(self._calculate_total_time)
 
-        # connect buttons
-        if self._include_run_button:
-            self.start_scan_Button.clicked.connect(self._start_scan)
-        self.cancel_scan_Button.clicked.connect(self._mmc.mda.cancel)
-        self.pause_scan_Button.clicked.connect(lambda: self._mmc.mda.toggle_pause())
-
-        # connect toggle
-        self.time_groupBox.toggled.connect(self._calculate_total_time)
-        self.interval_spinBox.valueChanged.connect(self._calculate_total_time)
-        self.timepoints_spinBox.valueChanged.connect(self._calculate_total_time)
-        self.stack_groupBox.toggled.connect(self._calculate_total_time)
-        self.stage_pos_groupBox.toggled.connect(self._calculate_total_time)
+        # connection for time
+        self.tm_gp.toggled.connect(self._calculate_total_time)
+        self.tm_gp.interval_spinBox.valueChanged.connect(self._calculate_total_time)
+        self.tm_gp.timepoints_spinBox.valueChanged.connect(self._calculate_total_time)
 
         self.scan_size_spinBox_r.valueChanged.connect(self._calculate_total_time)
         self.scan_size_spinBox_c.valueChanged.connect(self._calculate_total_time)
-
-        self.time_comboBox.currentIndexChanged.connect(self._calculate_total_time)
+        self.tm_gp.time_comboBox.currentIndexChanged.connect(self._calculate_total_time)
 
         # connect mmcore signals
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_cfg_loaded)
@@ -132,12 +147,12 @@ class SampleExplorerWidget(SampleExplorerGui):
         """Block gui when mda starts."""
         self._set_enabled(False)
         if self._include_run_button:
-            self.cancel_scan_Button.show()
-            self.pause_scan_Button.show()
-        self.start_scan_Button.hide()
+            self.buttons_wdg.cancel_button.show()
+            self.buttons_wdg.pause_button.show()
+        self.buttons_wdg.run_button.hide()
 
     def _on_mda_paused(self, paused: bool) -> None:
-        self.pause_scan_Button.setText("Go" if paused else "Pause")
+        self.buttons_wdg.pause_button.setText("Go" if paused else "Pause")
 
     def _on_mda_finished(self) -> None:
 
@@ -155,30 +170,30 @@ class SampleExplorerWidget(SampleExplorerGui):
             self.return_to_position_y = None
 
         self._set_enabled(True)
-        self.cancel_scan_Button.hide()
-        self.pause_scan_Button.hide()
+        self.buttons_wdg.cancel_button.hide()
+        self.buttons_wdg.pause_button.hide()
         if self._include_run_button:
-            self.start_scan_Button.show()
+            self.buttons_wdg.run_button.show()
 
     def _set_enabled(self, enabled: bool) -> None:
         self.scan_size_spinBox_r.setEnabled(enabled)
         self.scan_size_spinBox_c.setEnabled(enabled)
         self.ovelap_spinBox.setEnabled(enabled)
-        self.channel_explorer_groupBox.setEnabled(enabled)
-        self.time_groupBox.setEnabled(enabled)
-        self.acquisition_order_comboBox.setEnabled(enabled)
+        self.ch_gb.setEnabled(enabled)
+        self.tm_gp.setEnabled(enabled)
+        self.buttons_wdg.acquisition_order_comboBox.setEnabled(enabled)
 
         if not self._mmc.getXYStageDevice():
-            self.stage_pos_groupBox.setChecked(False)
-            self.stage_pos_groupBox.setEnabled(False)
+            self.pos_gp.setChecked(False)
+            self.pos_gp.setEnabled(False)
         else:
-            self.stage_pos_groupBox.setEnabled(enabled)
+            self.pos_gp.setEnabled(enabled)
 
         if not self._mmc.getFocusDevice():
-            self.stack_groupBox.setChecked(False)
-            self.stack_groupBox.setEnabled(False)
+            self.z_gp.setChecked(False)
+            self.z_gp.setEnabled(False)
         else:
-            self.stack_groupBox.setEnabled(enabled)
+            self.z_gp.setEnabled(enabled)
 
     def _add_channel(self) -> bool:
         """Add, remove or clear channel table.  Return True if anyting was changed."""
@@ -189,28 +204,22 @@ class SampleExplorerWidget(SampleExplorerGui):
         if not channel_group:
             return False
 
-        idx = self.channel_explorer_tableWidget.rowCount()
-        self.channel_explorer_tableWidget.insertRow(idx)
+        idx = self.ch_gb.channel_tableWidget.rowCount()
+        self.ch_gb.channel_tableWidget.insertRow(idx)
 
         # create a combo_box for channels in the table
-        self.channel_explorer_comboBox = QtW.QComboBox(self)
-        self.channel_explorer_exp_spinBox = QtW.QSpinBox(self)
-        self.channel_explorer_exp_spinBox.setRange(0, 10000)
-        self.channel_explorer_exp_spinBox.setValue(100)
-        self.channel_explorer_exp_spinBox.valueChanged.connect(
-            self._calculate_total_time
-        )
+        channel_comboBox = QtW.QComboBox(self)
+        channel_exp_spinBox = QtW.QSpinBox(self)
+        channel_exp_spinBox.setRange(0, 10000)
+        channel_exp_spinBox.setValue(100)
+        channel_exp_spinBox.valueChanged.connect(self._calculate_total_time)
 
         if channel_group := self._mmc.getChannelGroup():
             channel_list = list(self._mmc.getAvailableConfigs(channel_group))
-            self.channel_explorer_comboBox.addItems(channel_list)
+            channel_comboBox.addItems(channel_list)
 
-        self.channel_explorer_tableWidget.setCellWidget(
-            idx, 0, self.channel_explorer_comboBox
-        )
-        self.channel_explorer_tableWidget.setCellWidget(
-            idx, 1, self.channel_explorer_exp_spinBox
-        )
+        self.ch_gb.channel_tableWidget.setCellWidget(idx, 0, channel_comboBox)
+        self.ch_gb.channel_tableWidget.setCellWidget(idx, 1, channel_exp_spinBox)
 
         self._calculate_total_time()
 
@@ -218,49 +227,55 @@ class SampleExplorerWidget(SampleExplorerGui):
 
     def _remove_channel(self) -> None:
         # remove selected position
-        rows = {r.row() for r in self.channel_explorer_tableWidget.selectedIndexes()}
+        rows = {r.row() for r in self.ch_gb.channel_tableWidget.selectedIndexes()}
         for idx in sorted(rows, reverse=True):
-            self.channel_explorer_tableWidget.removeRow(idx)
+            self.ch_gb.channel_tableWidget.removeRow(idx)
 
         self._calculate_total_time()
 
     def _clear_channel(self) -> None:
         # clear all positions
-        self.channel_explorer_tableWidget.clearContents()
-        self.channel_explorer_tableWidget.setRowCount(0)
+        self.ch_gb.channel_tableWidget.clearContents()
+        self.ch_gb.channel_tableWidget.setRowCount(0)
 
         self._calculate_total_time()
 
     def _set_top(self) -> None:
-        self.z_top_doubleSpinBox.setValue(self._mmc.getZPosition())
+        self.z_gp.z_top_doubleSpinBox.setValue(self._mmc.getZPosition())
 
     def _set_bottom(self) -> None:
-        self.z_bottom_doubleSpinBox.setValue(self._mmc.getZPosition())
+        self.z_gp.z_bottom_doubleSpinBox.setValue(self._mmc.getZPosition())
 
     def _update_topbottom_range(self) -> None:
-        self.z_range_topbottom_doubleSpinBox.setValue(
-            abs(self.z_top_doubleSpinBox.value() - self.z_bottom_doubleSpinBox.value())
+        self.z_gp.z_range_topbottom_doubleSpinBox.setValue(
+            abs(
+                self.z_gp.z_top_doubleSpinBox.value()
+                - self.z_gp.z_bottom_doubleSpinBox.value()
+            )
         )
 
     def _update_rangearound_label(self, value: int) -> None:
-        self.range_around_label.setText(f"-{value/2} µm <- z -> +{value/2} µm")
+        self.z_gp.range_around_label.setText(f"-{value/2} µm <- z -> +{value/2} µm")
 
     def _update_abovebelow_range(self) -> None:
-        self.z_range_abovebelow_doubleSpinBox.setValue(
-            self.above_doubleSpinBox.value() + self.below_doubleSpinBox.value()
+        self.z_gp.z_range_abovebelow_doubleSpinBox.setValue(
+            self.z_gp.above_doubleSpinBox.value()
+            + self.z_gp.below_doubleSpinBox.value()
         )
 
     def _update_n_images(self) -> None:
-        step = self.step_size_doubleSpinBox.value()
+        step = self.z_gp.step_size_doubleSpinBox.value()
         # set what is the range to consider depending on the z_stack mode
-        if self.z_tabWidget.currentIndex() == 0:
-            _range = self.z_range_topbottom_doubleSpinBox.value()
-        if self.z_tabWidget.currentIndex() == 1:
+        if self.z_gp.z_tabWidget.currentIndex() == 0:
+            _range = self.z_gp.z_range_topbottom_doubleSpinBox.value()
+        if self.z_gp.z_tabWidget.currentIndex() == 1:
             _range = self.zrange_spinBox.value()
-        if self.z_tabWidget.currentIndex() == 2:
-            _range = self.z_range_abovebelow_doubleSpinBox.value()
+        if self.z_gp.z_tabWidget.currentIndex() == 2:
+            _range = self.z_gp.z_range_abovebelow_doubleSpinBox.value()
 
-        self.n_images_label.setText(f"Number of Images: {round((_range / step) + 1)}")
+        self.z_gp.n_images_label.setText(
+            f"Number of Images: {round((_range / step) + 1)}"
+        )
 
         self._calculate_total_time()
 
@@ -275,13 +290,13 @@ class SampleExplorerWidget(SampleExplorerGui):
 
             for c, ax in enumerate("GXYZ"):
                 if ax == "G":
-                    count = self.stage_tableWidget.rowCount()
+                    count = self.pos_gp.stage_tableWidget.rowCount()
                     item = QtW.QTableWidgetItem(f"Grid_{count:03d}")
                     item.setWhatsThis(f"Grid_{count:03d}")
                     item.setTextAlignment(
                         Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                     )
-                    self.stage_tableWidget.setItem(idx, c, item)
+                    self.pos_gp.stage_tableWidget.setItem(idx, c, item)
                     self._rename_positions()
                     continue
 
@@ -293,32 +308,32 @@ class SampleExplorerWidget(SampleExplorerGui):
                 item.setTextAlignment(
                     Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
                 )
-                self.stage_tableWidget.setItem(idx, c, item)
+                self.pos_gp.stage_tableWidget.setItem(idx, c, item)
 
         self._calculate_total_time()
 
     def _add_position_row(self) -> int:
-        idx = int(self.stage_tableWidget.rowCount())
-        self.stage_tableWidget.insertRow(idx)
+        idx = int(self.pos_gp.stage_tableWidget.rowCount())
+        self.pos_gp.stage_tableWidget.insertRow(idx)
         return idx
 
     def _remove_position(self) -> None:
         # remove selected position
-        rows = {r.row() for r in self.stage_tableWidget.selectedIndexes()}
+        rows = {r.row() for r in self.pos_gp.stage_tableWidget.selectedIndexes()}
         for idx in sorted(rows, reverse=True):
-            self.stage_tableWidget.removeRow(idx)
+            self.pos_gp.stage_tableWidget.removeRow(idx)
         self._rename_positions()
         self._calculate_total_time()
 
     def _clear_positions(self) -> None:
         # clear all positions
-        self.stage_tableWidget.clearContents()
-        self.stage_tableWidget.setRowCount(0)
+        self.pos_gp.stage_tableWidget.clearContents()
+        self.pos_gp.stage_tableWidget.setRowCount(0)
         self._calculate_total_time()
 
     def _rename_positions(self) -> None:
         for grid_count, r in enumerate(range(self.stage_tableWidget.rowCount())):
-            item = self.stage_tableWidget.item(r, 0)
+            item = self.pos_gp.stage_tableWidget.item(r, 0)
             item_text = item.text()
             item_whatisthis = item.whatsThis()
             if item_text == item_whatisthis:
@@ -332,15 +347,15 @@ class SampleExplorerWidget(SampleExplorerGui):
                 Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
             )
             item.setWhatsThis(new_whatisthis)
-            self.stage_tableWidget.setItem(r, 0, item)
+            self.pos_gp.stage_tableWidget.setItem(r, 0, item)
 
     def _move_to_position(self) -> None:
         if not self._mmc.getXYStageDevice():
             return
-        curr_row = self.stage_tableWidget.currentRow()
-        x_val = self.stage_tableWidget.item(curr_row, 1).text()
-        y_val = self.stage_tableWidget.item(curr_row, 2).text()
-        z_val = self.stage_tableWidget.item(curr_row, 3).text()
+        curr_row = self.pos_gp.stage_tableWidget.currentRow()
+        x_val = self.pos_gp.stage_tableWidget.item(curr_row, 1).text()
+        y_val = self.pos_gp.stage_tableWidget.item(curr_row, 2).text()
+        z_val = self.pos_gp.stage_tableWidget.item(curr_row, 3).text()
         self._mmc.setXYPosition(float(x_val), float(y_val))
         self._mmc.setPosition(self._mmc.getFocusDevice(), float(z_val))
 
@@ -350,20 +365,20 @@ class SampleExplorerWidget(SampleExplorerGui):
 
         # channel
         exp: list = []
-        ch = self.channel_explorer_tableWidget.rowCount()
+        ch = self.ch_gb.channel_tableWidget.rowCount()
         if ch > 0:
             exp.extend(
-                self.channel_explorer_tableWidget.cellWidget(r, 1).value()
+                self.ch_gb.channel_tableWidget.cellWidget(r, 1).value()
                 for r in range(ch)
             )
         else:
             exp = []
 
         # time
-        if self.time_groupBox.isChecked():
-            timepoints = self.timepoints_spinBox.value()
-            interval = self.interval_spinBox.value()
-            int_unit = self.time_comboBox.currentText()
+        if self.tm_gp.isChecked():
+            timepoints = self.tm_gp.timepoints_spinBox.value()
+            interval = self.tm_gp.interval_spinBox.value()
+            int_unit = self.tm_gp.time_comboBox.currentText()
             if int_unit != "sec":
                 interval = _time_in_sec(interval, int_unit)
         else:
@@ -371,14 +386,14 @@ class SampleExplorerWidget(SampleExplorerGui):
             interval = -1.0
 
         # z stack
-        if self.stack_groupBox.isChecked():
-            n_z_images = int(self.n_images_label.text()[18:])
+        if self.z_gp.isChecked():
+            n_z_images = int(self.z_gp.n_images_label.text()[18:])
         else:
             n_z_images = 1
 
         # positions
-        if self.stage_pos_groupBox.isChecked():
-            n_pos = self.stage_tableWidget.rowCount() or 1
+        if self.pos_gp.isChecked():
+            n_pos = self.pos_gp.stage_tableWidget.rowCount() or 1
         else:
             n_pos = 1
         n_pos = n_pos
@@ -415,26 +430,26 @@ class SampleExplorerWidget(SampleExplorerGui):
             (time_chs * timepoints) + addition_time - effective_interval
         )
 
-        self._icon_lbl.clear()
-        self._time_lbl.clear()
-        self._time_lbl.setStyleSheet(stylesheet)
+        self.tm_gp._icon_lbl.clear()
+        self.tm_gp._time_lbl.clear()
+        self.tm_gp._time_lbl.setStyleSheet(stylesheet)
         if _icon:
-            self._icon_lbl.show()
-            self._icon_lbl.setPixmap(_icon)
-            self._time_lbl.show()
-            self._time_lbl.setText(f"{warning_msg}")
-            self._time_lbl.adjustSize()
+            self.tm_gp._icon_lbl.show()
+            self.tm_gp._icon_lbl.setPixmap(_icon)
+            self.tm_gp._time_lbl.show()
+            self.tm_gp._time_lbl.setText(f"{warning_msg}")
+            self.tm_gp._time_lbl.adjustSize()
         else:
-            self._time_lbl.hide()
-            self._icon_lbl.hide()
+            self.tm_gp._time_lbl.hide()
+            self.tm_gp._icon_lbl.hide()
 
         t_per_tp_msg = ""
         tot_acq_msg = f"Minimum total acquisition time: {min_tot_time:.4f} {unit_4}.\n"
-        if self.time_groupBox.isChecked():
+        if self.tm_gp.isChecked():
             t_per_tp_msg = (
                 f"Minimum acquisition time per timepoint: {min_aq_tp:.4f} {unit_1}."
             )
-        self._total_time_lbl.setText(f"{tot_acq_msg}{t_per_tp_msg}")
+        self.time_lbl._total_time_lbl.setText(f"{tot_acq_msg}{t_per_tp_msg}")
 
     def get_state(self) -> MDASequence:  # sourcery skip: merge-dict-assign
         """Get current state of widget and build a useq.MDASequence.
@@ -443,7 +458,7 @@ class SampleExplorerWidget(SampleExplorerGui):
         -------
         useq.MDASequence
         """
-        table = self.channel_explorer_tableWidget
+        table = self.ch_gb.channel_tableWidget
 
         channels: list[dict] = [
             {
@@ -455,34 +470,34 @@ class SampleExplorerWidget(SampleExplorerGui):
         ]
 
         z_plan: dict | None = None
-        if self.stack_groupBox.isChecked():
+        if self.z_gp.isChecked():
 
-            if self.z_tabWidget.currentIndex() == 0:
+            if self.z_gp.z_tabWidget.currentIndex() == 0:
                 z_plan = {
-                    "top": self.z_top_doubleSpinBox.value(),
-                    "bottom": self.z_bottom_doubleSpinBox.value(),
-                    "step": self.step_size_doubleSpinBox.value(),
+                    "top": self.z_gp.z_top_doubleSpinBox.value(),
+                    "bottom": self.z_gp.z_bottom_doubleSpinBox.value(),
+                    "step": self.z_gp.step_size_doubleSpinBox.value(),
                 }
 
-            elif self.z_tabWidget.currentIndex() == 1:
+            elif self.z_gp.z_tabWidget.currentIndex() == 1:
                 z_plan = {
-                    "range": self.zrange_spinBox.value(),
-                    "step": self.step_size_doubleSpinBox.value(),
+                    "range": self.z_gp.zrange_spinBox.value(),
+                    "step": self.z_gp.step_size_doubleSpinBox.value(),
                 }
-            elif self.z_tabWidget.currentIndex() == 2:
+            elif self.z_gp.z_tabWidget.currentIndex() == 2:
                 z_plan = {
-                    "above": self.above_doubleSpinBox.value(),
-                    "below": self.below_doubleSpinBox.value(),
-                    "step": self.step_size_doubleSpinBox.value(),
+                    "above": self.z_gp.above_doubleSpinBox.value(),
+                    "below": self.z_gp.below_doubleSpinBox.value(),
+                    "step": self.z_gp.step_size_doubleSpinBox.value(),
                 }
 
         time_plan: dict | None = None
-        if self.time_groupBox.isChecked():
+        if self.tm_gp.isChecked():
             units = {"min": "minutes", "sec": "seconds", "ms": "milliseconds"}
-            unit = units[self.time_comboBox.currentText()]
+            unit = units[self.tm_gp.time_comboBox.currentText()]
             time_plan = {
-                "interval": {unit: self.interval_spinBox.value()},
-                "loops": self.timepoints_spinBox.value(),
+                "interval": {unit: self.tm_gp.interval_spinBox.value()},
+                "loops": self.tm_gp.timepoints_spinBox.value(),
             }
 
         stage_positions: list[dict] = []
@@ -493,7 +508,7 @@ class SampleExplorerWidget(SampleExplorerGui):
             stage_positions.append(pos)
 
         return MDASequence(
-            axis_order=self.acquisition_order_comboBox.currentText(),
+            axis_order=self.buttons_wdg.acquisition_order_comboBox.currentText(),
             channels=channels,
             stage_positions=stage_positions,
             z_plan=z_plan,
@@ -501,7 +516,7 @@ class SampleExplorerWidget(SampleExplorerGui):
         )
 
     def _get_pos_name(self, row: int) -> str:
-        item = self.stage_tableWidget.item(row, 0)
+        item = self.pos_gp.stage_tableWidget.item(row, 0)
         name = item.text()
         whatsthis = item.whatsThis()
         new_name = f"{name}_{whatsthis}" if whatsthis not in name else name
@@ -514,15 +529,12 @@ class SampleExplorerWidget(SampleExplorerGui):
         self.pixel_size = self._mmc.getPixelSizeUm()
 
         explorer_starting_positions = []
-        if (
-            self.stage_pos_groupBox.isChecked()
-            and self.stage_tableWidget.rowCount() > 0
-        ):
-            for r in range(self.stage_tableWidget.rowCount()):
+        if self.pos_gp.isChecked() and self.pos_gp.stage_tableWidget.rowCount() > 0:
+            for r in range(self.pos_gp.stage_tableWidget.rowCount()):
                 name = self._get_pos_name(r)
-                x = float(self.stage_tableWidget.item(r, 1).text())
-                y = float(self.stage_tableWidget.item(r, 2).text())
-                z = float(self.stage_tableWidget.item(r, 3).text())
+                x = float(self.pos_gp.stage_tableWidget.item(r, 1).text())
+                y = float(self.pos_gp.stage_tableWidget.item(r, 2).text())
+                z = float(self.pos_gp.stage_tableWidget.item(r, 3).text())
                 pos_info = (
                     (name, x, y, z) if self._mmc.getFocusDevice() else (name, x, y)
                 )

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -71,9 +71,9 @@ class SampleExplorerWidget(SampleExplorerGui):
         self.return_to_position_y = None
 
         self.ch_gb = self.channel_groupbox
-        self.tm_gp = self.time_groupBox
-        self.z_gp = self.stack_groupBox
-        self.pos_gp = self.stage_pos_groupBox
+        self.tm_gp = self.time_groupbox
+        self.z_gp = self.stack_groupbox
+        self.pos_gp = self.stage_pos_groupbox
 
         # connect run button
         if self._include_run_button:

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -114,9 +114,9 @@ class SampleExplorerWidget(SampleExplorerGui):
         self.z_gp.toggled.connect(self._calculate_total_time)
 
         # connection for positions
-        self.pos_gp.add_pos_Button.clicked.connect(self._add_position)
-        self.pos_gp.remove_pos_Button.clicked.connect(self._remove_position)
-        self.pos_gp.clear_pos_Button.clicked.connect(self._clear_positions)
+        self.pos_gp.add_pos_button.clicked.connect(self._add_position)
+        self.pos_gp.remove_pos_button.clicked.connect(self._remove_position)
+        self.pos_gp.clear_pos_button.clicked.connect(self._clear_positions)
         self.pos_gp.go.clicked.connect(self._move_to_position)
         self.pos_gp.toggled.connect(self._calculate_total_time)
 

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -16,16 +16,16 @@ if TYPE_CHECKING:
 def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg = MDAWidget(include_run_button=True)
     qtbot.addWidget(wdg)
-    assert wdg.stage_tableWidget.rowCount() == 0
-    assert wdg.channel_tableWidget.rowCount() == 0
-    assert not wdg.time_groupBox.isChecked()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    assert not wdg.time_groupbox.isChecked()
 
     wdg._set_enabled(False)
-    assert not wdg.time_groupBox.isEnabled()
-    assert not wdg.acquisition_order_comboBox.isEnabled()
-    assert not wdg.channel_groupBox.isEnabled()
-    assert not wdg.stage_pos_groupBox.isEnabled()
-    assert not wdg.stack_groupBox.isEnabled()
+    assert not wdg.time_groupbox.isEnabled()
+    assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    assert not wdg.channel_groupbox.isEnabled()
+    assert not wdg.stage_pos_groupbox.isEnabled()
+    assert not wdg.stack_groupbox.isEnabled()
     wdg._set_enabled(True)
 
     sequence = MDASequence(
@@ -42,48 +42,48 @@ def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
         ),
     )
     wdg.set_state(sequence)
-    assert wdg.stage_tableWidget.rowCount() == 2
-    assert wdg.channel_tableWidget.rowCount() == 2
-    assert wdg.time_groupBox.isChecked()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
+    assert wdg.time_groupbox.isChecked()
 
     # round trip
     assert wdg.get_state() == sequence
 
     # test add grid positions
-    wdg.stage_pos_groupBox.setChecked(True)
+    wdg.stage_pos_groupbox.setChecked(True)
     wdg._clear_positions()
-    assert wdg.stage_tableWidget.rowCount() == 0
-    wdg.grid_Button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    wdg.stage_pos_groupbox.grid_button.click()
     wdg._grid_wdg.scan_size_spinBox_r.setValue(2)
     wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
     wdg._grid_wdg.generate_position_btn.click()
-    assert wdg.stage_tableWidget.rowCount() == 4
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
 
 
 def test_mda_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg = MDAWidget(include_run_button=True)
     qtbot.addWidget(wdg)
 
-    assert wdg.channel_tableWidget.rowCount() == 0
-    wdg.add_ch_button.click()
-    wdg.add_ch_button.click()
-    assert wdg.channel_tableWidget.rowCount() == 2
-    wdg.channel_tableWidget.selectRow(0)
-    wdg.remove_ch_button.click()
-    assert wdg.channel_tableWidget.rowCount() == 1
-    wdg.clear_ch_button.click()
-    assert wdg.channel_tableWidget.rowCount() == 0
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    wdg.channel_groupbox.add_ch_button.click()
+    wdg.channel_groupbox.add_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
+    wdg.channel_groupbox.channel_tableWidget.selectRow(0)
+    wdg.channel_groupbox.remove_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 1
+    wdg.channel_groupbox.clear_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
 
-    assert wdg.stage_tableWidget.rowCount() == 0
-    wdg.stage_pos_groupBox.setChecked(True)
-    wdg.add_pos_Button.click()
-    wdg.add_pos_Button.click()
-    assert wdg.stage_tableWidget.rowCount() == 2
-    wdg.stage_tableWidget.selectRow(0)
-    wdg.remove_pos_Button.click()
-    assert wdg.stage_tableWidget.rowCount() == 1
-    wdg.clear_pos_Button.click()
-    assert wdg.stage_tableWidget.rowCount() == 0
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    wdg.stage_pos_groupbox.setChecked(True)
+    wdg.stage_pos_groupbox.add_pos_button.click()
+    wdg.stage_pos_groupbox.add_pos_button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
+    wdg.stage_pos_groupbox.stage_tableWidget.selectRow(0)
+    wdg.stage_pos_groupbox.remove_pos_button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 1
+    wdg.stage_pos_groupbox.clear_pos_button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
 
 
 def test_mda_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
@@ -91,24 +91,24 @@ def test_mda_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
     qtbot.addWidget(wdg)
 
     wdg._on_mda_started()
-    assert not wdg.time_groupBox.isEnabled()
-    assert not wdg.acquisition_order_comboBox.isEnabled()
-    assert not wdg.channel_groupBox.isEnabled()
-    assert not wdg.stage_pos_groupBox.isEnabled()
-    assert not wdg.stack_groupBox.isEnabled()
-    assert wdg.run_Button.isHidden()
-    assert not wdg.pause_Button.isHidden()
-    assert not wdg.cancel_Button.isHidden()
+    assert not wdg.time_groupbox.isEnabled()
+    assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    assert not wdg.channel_groupbox.isEnabled()
+    assert not wdg.stage_pos_groupbox.isEnabled()
+    assert not wdg.stack_groupbox.isEnabled()
+    assert wdg.buttons_wdg.run_button.isHidden()
+    assert not wdg.buttons_wdg.pause_button.isHidden()
+    assert not wdg.buttons_wdg.cancel_button.isHidden()
 
     wdg._on_mda_finished()
-    assert wdg.time_groupBox.isEnabled()
-    assert wdg.acquisition_order_comboBox.isEnabled()
-    assert wdg.channel_groupBox.isEnabled()
-    assert wdg.stage_pos_groupBox.isEnabled()
-    assert wdg.stack_groupBox.isEnabled()
-    assert not wdg.run_Button.isHidden()
-    assert wdg.pause_Button.isHidden()
-    assert wdg.cancel_Button.isHidden()
+    assert wdg.time_groupbox.isEnabled()
+    assert wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    assert wdg.channel_groupbox.isEnabled()
+    assert wdg.stage_pos_groupbox.isEnabled()
+    assert wdg.stack_groupbox.isEnabled()
+    assert not wdg.buttons_wdg.run_button.isHidden()
+    assert wdg.buttons_wdg.pause_button.isHidden()
+    assert wdg.buttons_wdg.cancel_button.isHidden()
 
 
 def test_mda_grid(qtbot: QtBot, global_mmcore: CMMCorePlus):
@@ -184,44 +184,44 @@ def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg = MDAWidget(include_run_button=True)
     qtbot.addWidget(wdg)
 
-    assert wdg.channel_tableWidget.rowCount() == 0
-    wdg.add_ch_button.click()
-    assert wdg.channel_tableWidget.rowCount() == 1
-    assert wdg.channel_tableWidget.cellWidget(0, 1).value() == 100.0
-    assert not wdg.time_groupBox.isChecked()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    wdg.channel_groupbox.add_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 1
+    assert wdg.channel_groupbox.channel_tableWidget.cellWidget(0, 1).value() == 100.0
+    assert not wdg.time_groupbox.isChecked()
 
     txt = "Minimum total acquisition time: 100.0000 ms.\n"
-    assert wdg._total_time_lbl.text() == txt
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
-    assert not wdg.time_groupBox.isChecked()
-    wdg.time_groupBox.setChecked(True)
-    wdg.time_comboBox.setCurrentText("ms")
+    assert not wdg.time_groupbox.isChecked()
+    wdg.time_groupbox.setChecked(True)
+    wdg.time_groupbox.time_comboBox.setCurrentText("ms")
 
     txt = (
         "Minimum total acquisition time: 100.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
-    assert wdg._total_time_lbl.text() == txt
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
-    wdg.timepoints_spinBox.setValue(3)
+    wdg.time_groupbox.timepoints_spinBox.setValue(3)
     txt = (
         "Minimum total acquisition time: 300.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
-    assert wdg._total_time_lbl.text() == txt
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
-    wdg.interval_spinBox.setValue(10)
+    wdg.time_groupbox.interval_spinBox.setValue(10)
     txt1 = (
         "Minimum total acquisition time: 300.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
     txt2 = "Interval shorter than acquisition time per timepoint."
-    assert wdg._total_time_lbl.text() == txt1
-    assert wdg._time_lbl.text() == txt2
+    assert wdg.time_lbl._total_time_lbl.text() == txt1
+    assert wdg.time_groupbox._time_lbl.text() == txt2
 
-    wdg.interval_spinBox.setValue(200)
+    wdg.time_groupbox.interval_spinBox.setValue(200)
     txt1 = (
         "Minimum total acquisition time: 500.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
-    assert wdg._total_time_lbl.text() == txt1
+    assert wdg.time_lbl._total_time_lbl.text() == txt1

--- a/tests/test_sample_explorer_widget.py
+++ b/tests/test_sample_explorer_widget.py
@@ -25,27 +25,27 @@ def test_explorer_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     s_exp.scan_size_spinBox_r.setValue(2)
     s_exp.ovelap_spinBox.setValue(10)
 
-    s_exp.add_ch_explorer_Button.click()
-    assert s_exp.channel_explorer_tableWidget.rowCount() == 1
+    s_exp.channel_groupbox.add_ch_button.click()
+    assert s_exp.channel_groupbox.channel_tableWidget.rowCount() == 1
 
-    s_exp.time_groupBox.setChecked(True)
-    s_exp.timepoints_spinBox.setValue(2)
-    s_exp.interval_spinBox.setValue(0)
+    s_exp.time_groupbox.setChecked(True)
+    s_exp.time_groupbox.timepoints_spinBox.setValue(2)
+    s_exp.time_groupbox.interval_spinBox.setValue(0)
 
-    s_exp.stack_groupBox.setChecked(True)
-    s_exp.z_tabWidget.setCurrentIndex(1)
-    s_exp.zrange_spinBox.setValue(2)
-    s_exp.step_size_doubleSpinBox.setValue(1.0)
-    assert s_exp.n_images_label.text() == "Number of Images: 3"
+    s_exp.stack_groupbox.setChecked(True)
+    s_exp.stack_groupbox.z_tabWidget.setCurrentIndex(1)
+    s_exp.stack_groupbox.zrange_spinBox.setValue(2)
+    s_exp.stack_groupbox.step_size_doubleSpinBox.setValue(1.0)
+    assert s_exp.stack_groupbox.n_images_label.text() == "Number of Images: 3"
 
-    s_exp.stage_pos_groupBox.setChecked(True)
-    s_exp.add_pos_Button.click()
-    assert s_exp.stage_tableWidget.rowCount() == 1
+    s_exp.stage_pos_groupbox.setChecked(True)
+    s_exp.stage_pos_groupbox.add_pos_button.click()
+    assert s_exp.stage_pos_groupbox.stage_tableWidget.rowCount() == 1
     mmc.setXYPosition(2000.0, 2000.0)
     mmc.waitForSystem()
-    s_exp.add_pos_Button.click()
+    s_exp.stage_pos_groupbox.add_pos_button.click()
 
-    assert s_exp.stage_tableWidget.rowCount() == 2
+    assert s_exp.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
 
     state = s_exp.get_state()
 
@@ -116,26 +116,26 @@ def test_explorer_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert wdg.scan_size_spinBox_c.value() == 1
     assert wdg.scan_size_spinBox_r.value() == 1
 
-    assert wdg.channel_explorer_tableWidget.rowCount() == 0
-    wdg.add_ch_explorer_Button.click()
-    wdg.add_ch_explorer_Button.click()
-    assert wdg.channel_explorer_tableWidget.rowCount() == 2
-    wdg.channel_explorer_tableWidget.selectRow(0)
-    wdg.remove_ch_explorer_Button.click()
-    assert wdg.channel_explorer_tableWidget.rowCount() == 1
-    wdg.clear_ch_explorer_Button.click()
-    assert wdg.channel_explorer_tableWidget.rowCount() == 0
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    wdg.channel_groupbox.add_ch_button.click()
+    wdg.channel_groupbox.add_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
+    wdg.channel_groupbox.channel_tableWidget.selectRow(0)
+    wdg.channel_groupbox.remove_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 1
+    wdg.channel_groupbox.clear_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
 
-    assert wdg.stage_tableWidget.rowCount() == 0
-    wdg.stage_pos_groupBox.setChecked(True)
-    wdg.add_pos_Button.click()
-    wdg.add_pos_Button.click()
-    assert wdg.stage_tableWidget.rowCount() == 2
-    wdg.stage_tableWidget.selectRow(0)
-    wdg.remove_pos_Button.click()
-    assert wdg.stage_tableWidget.rowCount() == 1
-    wdg.clear_pos_Button.click()
-    assert wdg.stage_tableWidget.rowCount() == 0
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    wdg.stage_pos_groupbox.setChecked(True)
+    wdg.stage_pos_groupbox.add_pos_button.click()
+    wdg.stage_pos_groupbox.add_pos_button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
+    wdg.stage_pos_groupbox.stage_tableWidget.selectRow(0)
+    wdg.stage_pos_groupbox.remove_pos_button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 1
+    wdg.stage_pos_groupbox.clear_pos_button.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
 
 
 def test_explorer_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
@@ -143,67 +143,68 @@ def test_explorer_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
     qtbot.addWidget(wdg)
 
     wdg._on_mda_started()
-    assert not wdg.time_groupBox.isEnabled()
-    assert not wdg.acquisition_order_comboBox.isEnabled()
-    assert not wdg.channel_explorer_groupBox.isEnabled()
-    assert not wdg.stage_pos_groupBox.isEnabled()
-    assert not wdg.stack_groupBox.isEnabled()
-    assert wdg.start_scan_Button.isHidden()
-    assert not wdg.pause_scan_Button.isHidden()
-    assert not wdg.cancel_scan_Button.isHidden()
+    assert not wdg.time_groupbox.isEnabled()
+    assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    assert not wdg.channel_groupbox.isEnabled()
+    assert not wdg.stage_pos_groupbox.isEnabled()
+    assert not wdg.stack_groupbox.isEnabled()
+    assert wdg.buttons_wdg.run_button.isHidden()
+    assert not wdg.buttons_wdg.pause_button.isHidden()
+    assert not wdg.buttons_wdg.cancel_button.isHidden()
 
     wdg._on_mda_finished()
-    assert wdg.time_groupBox.isEnabled()
-    assert wdg.acquisition_order_comboBox.isEnabled()
-    assert wdg.channel_explorer_groupBox.isEnabled()
-    assert wdg.stage_pos_groupBox.isEnabled()
-    assert wdg.stack_groupBox.isEnabled()
-    assert not wdg.start_scan_Button.isHidden()
-    assert wdg.pause_scan_Button.isHidden()
-    assert wdg.cancel_scan_Button.isHidden()
+    assert wdg.time_groupbox.isEnabled()
+    assert wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    assert wdg.channel_groupbox.isEnabled()
+    assert wdg.stage_pos_groupbox.isEnabled()
+    assert wdg.stack_groupbox.isEnabled()
+    assert not wdg.buttons_wdg.run_button.isHidden()
+    assert wdg.buttons_wdg.pause_button.isHidden()
+    assert wdg.buttons_wdg.cancel_button.isHidden()
 
 
 def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg = SampleExplorerWidget(include_run_button=True)
     qtbot.addWidget(wdg)
 
-    assert wdg.channel_explorer_tableWidget.rowCount() == 0
-    wdg.add_ch_explorer_Button.click()
-    assert wdg.channel_explorer_tableWidget.rowCount() == 1
-    assert wdg.channel_explorer_tableWidget.cellWidget(0, 1).value() == 100.0
-    assert not wdg.time_groupBox.isChecked()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    wdg.channel_groupbox.add_ch_button.click()
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 1
+    assert wdg.channel_groupbox.channel_tableWidget.cellWidget(0, 1).value() == 100.0
+    assert not wdg.time_groupbox.isChecked()
+    wdg.time_groupbox.time_comboBox.setCurrentText("ms")
 
     txt = "Minimum total acquisition time: 100.0000 ms.\n"
-    assert wdg._total_time_lbl.text() == txt
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
-    assert not wdg.time_groupBox.isChecked()
-    wdg.time_groupBox.setChecked(True)
+    assert not wdg.time_groupbox.isChecked()
+    wdg.time_groupbox.setChecked(True)
 
     txt = (
         "Minimum total acquisition time: 100.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
-    assert wdg._total_time_lbl.text() == txt
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
-    wdg.timepoints_spinBox.setValue(3)
+    wdg.time_groupbox.timepoints_spinBox.setValue(3)
     txt = (
         "Minimum total acquisition time: 300.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
-    assert wdg._total_time_lbl.text() == txt
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
-    wdg.interval_spinBox.setValue(10)
+    wdg.time_groupbox.interval_spinBox.setValue(10)
     txt1 = (
         "Minimum total acquisition time: 300.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
     txt2 = "Interval shorter than acquisition time per timepoint."
-    assert wdg._total_time_lbl.text() == txt1
-    assert wdg._time_lbl.text() == txt2
+    assert wdg.time_lbl._total_time_lbl.text() == txt1
+    assert wdg.time_groupbox._time_lbl.text() == txt2
 
-    wdg.interval_spinBox.setValue(200)
+    wdg.time_groupbox.interval_spinBox.setValue(200)
     txt1 = (
         "Minimum total acquisition time: 500.0000 ms.\n"
         "Minimum acquisition time per timepoint: 100.0000 ms."
     )
-    assert wdg._total_time_lbl.text() == txt1
+    assert wdg.time_lbl._total_time_lbl.text() == txt1


### PR DESCRIPTION
This PR removes duplicated code between mda and sample explorer.

It creates single widgets for channels, z-stacks, time and positions.

Closes #76 