### PR TITLE
fix: disable z checkbox at startup

### DIFF
--- a/src/pymmcore_widgets/_mda_widget/_mda_gui.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_gui.py
@@ -60,6 +60,7 @@ class _MDAWidgetGui(QWidget):
         wdg_layout.addWidget(self.time_groupbox)
 
         self.stack_groupbox = ZStackWidget()
+        self.stack_groupbox.setChecked(False)
         wdg_layout.addWidget(self.stack_groupbox)
 
         self.stage_pos_groupbox = _MDAPositionTable(["Pos", "X", "Y", "Z"])

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_gui.py
@@ -186,6 +186,7 @@ class SampleExplorerGui(QWidget):
         spacer = self._spacer()
         self.stack_coll.addWidget(spacer)
         self.stack_groupbox = ZStackWidget()
+        self.stack_groupbox.setChecked(False)
         self.stack_groupbox.setTitle("")
         self.stack_coll.addWidget(self.stack_groupbox)
 

--- a/src/pymmcore_widgets/_zstack_widget.py
+++ b/src/pymmcore_widgets/_zstack_widget.py
@@ -221,6 +221,7 @@ class ZStackWidget(QGroupBox):
         super().__init__(parent=parent)
         self.setTitle(title)
         self.setCheckable(True)
+        self.setChecked(False)
         self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
 
         self._mmc = CMMCorePlus.instance()

--- a/src/pymmcore_widgets/_zstack_widget.py
+++ b/src/pymmcore_widgets/_zstack_widget.py
@@ -221,7 +221,6 @@ class ZStackWidget(QGroupBox):
         super().__init__(parent=parent)
         self.setTitle(title)
         self.setCheckable(True)
-        self.setChecked(False)
         self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
 
         self._mmc = CMMCorePlus.instance()


### PR DESCRIPTION
minor fix. This PR unckeck the z-stack `QGroupWidget` checkbox at startup.