### PR TITLE
test: cleanup grid widget after test

### DIFF
--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -46,7 +46,6 @@ def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
     assert wdg.time_groupbox.isChecked()
 
-
     # round trip
     assert wdg.get_state() == sequence
 
@@ -60,7 +59,6 @@ def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
     wdg._grid_wdg.generate_position_btn.click()
     assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
-    
 
 
 def test_mda_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -46,6 +46,7 @@ def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
     assert wdg.time_groupbox.isChecked()
 
+
     # round trip
     assert wdg.get_state() == sequence
 
@@ -54,10 +55,12 @@ def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg._clear_positions()
     assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
     wdg.stage_pos_groupbox.grid_button.click()
+    qtbot.addWidget(wdg._grid_wdg)
     wdg._grid_wdg.scan_size_spinBox_r.setValue(2)
     wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
     wdg._grid_wdg.generate_position_btn.click()
     assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
+    
 
 
 def test_mda_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):


### PR DESCRIPTION
small change to make sure qtbot cleans up a lingering widget after a test