### PR TITLE
test: fix and assert widget cleanup

### DIFF
--- a/src/pymmcore_widgets/_camera_roi_widget.py
+++ b/src/pymmcore_widgets/_camera_roi_widget.py
@@ -80,7 +80,6 @@ class CameraRoiWidget(QWidget):
         self.destroyed.connect(self._disconnect)
 
     def _disconnect(self) -> None:
-        print("disconnecting")
         self._mmc.events.systemConfigurationLoaded.disconnect(self._on_sys_cfg_loaded)
         self._mmc.events.pixelSizeChanged.disconnect(self._update_lbl_info)
         self._mmc.events.roiSet.disconnect(self._on_roi_set)

--- a/src/pymmcore_widgets/_camera_roi_widget.py
+++ b/src/pymmcore_widgets/_camera_roi_widget.py
@@ -60,7 +60,13 @@ class CameraRoiWidget(QWidget):
 
         self._mmc = mmcore or CMMCorePlus.instance()
 
-        self._create_gui()
+        layout = QVBoxLayout()
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        main_wdg = self._create_main_wdg()
+        layout.addWidget(main_wdg)
 
         self.chip_size_x = 0
         self.chip_size_y = 0
@@ -74,19 +80,10 @@ class CameraRoiWidget(QWidget):
         self.destroyed.connect(self._disconnect)
 
     def _disconnect(self) -> None:
+        print("disconnecting")
         self._mmc.events.systemConfigurationLoaded.disconnect(self._on_sys_cfg_loaded)
         self._mmc.events.pixelSizeChanged.disconnect(self._update_lbl_info)
         self._mmc.events.roiSet.disconnect(self._on_roi_set)
-
-    def _create_gui(self) -> None:  # sourcery skip: class-extract-method
-
-        layout = QVBoxLayout()
-        layout.setSpacing(0)
-        layout.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(layout)
-
-        main_wdg = self._create_main_wdg()
-        layout.addWidget(main_wdg)
 
     def _create_main_wdg(self) -> QWidget:
 

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -1,5 +1,4 @@
 import warnings
-from functools import partial
 from typing import Dict, Optional, Set, Tuple, cast
 
 from pymmcore_plus import CMMCorePlus, DeviceType
@@ -210,7 +209,8 @@ class AddGroupWidget(QDialog):
             else:
                 self._prop_table.showRow(r)
 
-    def _toggle_filter(self, label: str) -> None:
+    def _toggle_filter(self, toggled: bool) -> None:
+        label = self.sender().text()
         self._filters.symmetric_difference_update(DevTypeLabels[label])
         self._update_filter()
 
@@ -225,7 +225,7 @@ class AddGroupWidget(QDialog):
         for i, (label, devtypes) in enumerate(DevTypeLabels.items()):
             cb = QCheckBox(label)
             cb.setChecked(devtypes[0] not in self._filters)
-            cb.toggled.connect(partial(self._toggle_filter, label))
+            cb.toggled.connect(self._toggle_filter)
             dev_gb.layout().addWidget(cb, i + 1, 0, 1, 2)
 
         @all_btn.clicked.connect  # type: ignore

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Dict, List, Optional, Set, Tuple, cast
 
 from pymmcore_plus import CMMCorePlus, DeviceType
@@ -227,7 +226,8 @@ class EditGroupWidget(QDialog):
             else:
                 self._prop_table.showRow(r)
 
-    def _toggle_filter(self, label: str) -> None:
+    def _toggle_filter(self, toggled: bool) -> None:
+        label = self.sender().text()
         self._filters.symmetric_difference_update(DevTypeLabels[label])
         self._update_filter()
 
@@ -242,7 +242,7 @@ class EditGroupWidget(QDialog):
         for i, (label, devtypes) in enumerate(DevTypeLabels.items()):
             cb = QCheckBox(label)
             cb.setChecked(devtypes[0] not in self._filters)
-            cb.toggled.connect(partial(self._toggle_filter, label))
+            cb.toggled.connect(self._toggle_filter)
             dev_gb.layout().addWidget(cb, i + 1, 0, 1, 2)
 
         @all_btn.clicked.connect  # type: ignore

--- a/src/pymmcore_widgets/_mda_widget/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda_widget/_mda_widget.py
@@ -63,10 +63,8 @@ class MDAWidget(_MDAWidgetGui):
         if not self._include_run_button:
             self.buttons_wdg.run_button.hide()
 
-        self.buttons_wdg.pause_button.released.connect(
-            lambda: self._mmc.mda.toggle_pause()
-        )
-        self.buttons_wdg.cancel_button.released.connect(lambda: self._mmc.mda.cancel())
+        self.buttons_wdg.pause_button.released.connect(self._mmc.mda.toggle_pause)
+        self.buttons_wdg.cancel_button.released.connect(self._mmc.mda.cancel)
 
         self.ch_gb = self.channel_groupbox
         self.tm_gp = self.time_groupbox

--- a/src/pymmcore_widgets/_property_browser.py
+++ b/src/pymmcore_widgets/_property_browser.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Dict, Optional, Set, Tuple, cast
 
 from pymmcore_plus import CMMCorePlus, DeviceType
@@ -143,7 +142,8 @@ class PropertyBrowser(QDialog):
             else:
                 self._prop_table.showRow(r)
 
-    def _toggle_filter(self, label: str) -> None:
+    def _toggle_filter(self, toggled: bool) -> None:
+        label = self.sender().text()
         self._filters.symmetric_difference_update(DevTypeLabels[label])
         self._update_filter()
 
@@ -158,7 +158,7 @@ class PropertyBrowser(QDialog):
         for i, (label, devtypes) in enumerate(DevTypeLabels.items()):
             cb = QCheckBox(label)
             cb.setChecked(devtypes[0] not in self._filters)
-            cb.toggled.connect(partial(self._toggle_filter, label))
+            cb.toggled.connect(self._toggle_filter)
             dev_gb.layout().addWidget(cb, i + 1, 0, 1, 2)
 
         @all_btn.clicked.connect  # type: ignore

--- a/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
+++ b/src/pymmcore_widgets/_sample_explorer_widget/_sample_explorer_widget.py
@@ -60,10 +60,8 @@ class SampleExplorerWidget(SampleExplorerGui):
         if not self._include_run_button:
             self.buttons_wdg.run_button.hide()
 
-        self.buttons_wdg.pause_button.released.connect(
-            lambda: self._mmc.mda.toggle_pause()
-        )
-        self.buttons_wdg.cancel_button.released.connect(lambda: self._mmc.mda.cancel())
+        self.buttons_wdg.pause_button.released.connect(self._mmc.mda.toggle_pause)
+        self.buttons_wdg.cancel_button.released.connect(self._mmc.mda.cancel)
 
         self.pixel_size = self._mmc.getPixelSizeUm()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,42 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.core import _mmcore_plus
+
+if TYPE_CHECKING:
+    from pytest import FixtureRequest
+    from qtpy.QtWidgets import QApplication
+
+TEST_CONFIG = str(Path(__file__).parent / "test_config.cfg")
 
 
 # to create a new CMMCorePlus() for every test
-@pytest.fixture
-def core(monkeypatch):
-    new_core = CMMCorePlus()
-    monkeypatch.setattr("pymmcore_plus.core._mmcore_plus._instance", new_core)
-    return new_core
+@pytest.fixture(autouse=True)
+def global_mmcore():
+    mmc = CMMCorePlus()
+    mmc.loadSystemConfiguration(TEST_CONFIG)
+    with patch.object(_mmcore_plus, "_instance", mmc):
+        yield mmc
 
 
-@pytest.fixture()
-def global_mmcore(core):
-    mmc = CMMCorePlus.instance()
-    assert mmc == core
-    mmc.loadSystemConfiguration(str(Path(__file__).parent / "test_config.cfg"))
-    return mmc
+@pytest.fixture(autouse=True)
+def _run_after_each_test(request: "FixtureRequest", qapp: "QApplication"):
+    """Run after each test to ensure no widgets have been left around.
+
+    When this test fails, it means that a widget being tested has an issue closing
+    cleanly. Perhaps a strong reference has leaked somewhere.  Look for
+    `functools.partial(self._method)` or `lambda: self._method` being used in that
+    widget's code.
+    """
+    failures_before = request.session.testsfailed
+    yield
+    # if the test failed, don't worry about checking widgets
+    if request.session.testsfailed - failures_before:
+        return
+    remaining = qapp.topLevelWidgets()
+    if remaining:
+        test = f"{request.node.path.name}::{request.node.originalname}"
+        raise AssertionError(f"topLevelWidgets remaining after {test!r}: {remaining}")

--- a/tests/test_camera_roi_widget.py
+++ b/tests/test_camera_roi_widget.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
-import pytest
 from pymmcore_plus import CMMCorePlus
 
 from pymmcore_widgets._camera_roi_widget import CameraRoiWidget
@@ -13,15 +12,6 @@ if TYPE_CHECKING:
 
 FULL = "Full Chip"
 CUSTOM_ROI = "Custom ROI"
-
-
-@pytest.fixture()
-def camera_roi_widget(global_mmcore: CMMCorePlus, qtbot: QtBot):
-    cam = CameraRoiWidget(mmcore=global_mmcore)
-    qtbot.addWidget(cam)
-    mmc = global_mmcore
-    assert mmc.getProperty("Objective", "Label") == "Nikon 10X S Fluor"
-    return cam, mmc
 
 
 def _get_wdgs(cam_wdg: CameraRoiWidget):
@@ -35,8 +25,9 @@ def _get_wdgs(cam_wdg: CameraRoiWidget):
     return cam_x, cam_y, w, h, combo, cbox, crop
 
 
-def test_load_camera_roi_widget(camera_roi_widget):
-    cam, _ = camera_roi_widget
+def test_load_camera_roi_widget(qtbot: QtBot):
+    cam = CameraRoiWidget()
+    qtbot.addWidget(cam)
 
     cam_x, cam_y, w, h, combo, cbox, _ = _get_wdgs(cam)
 
@@ -51,8 +42,10 @@ def test_load_camera_roi_widget(camera_roi_widget):
     assert items == combo_items
 
 
-def test_camera_roi_combo(camera_roi_widget):
-    cam, mmc = camera_roi_widget
+def test_camera_roi_combo(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    cam = CameraRoiWidget()
+    qtbot.addWidget(cam)
 
     cam_x, cam_y, w, h, combo, cbox, _ = _get_wdgs(cam)
 
@@ -85,8 +78,10 @@ def test_camera_roi_combo(camera_roi_widget):
     assert mmc.getROI() == [0, 0, 512, 512]
 
 
-def test_camera_roi_combo_custom(camera_roi_widget):
-    cam, mmc = camera_roi_widget
+def test_camera_roi_combo_custom(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    cam = CameraRoiWidget()
+    qtbot.addWidget(cam)
 
     cam_x, cam_y, w, h, combo, cbox, crop = _get_wdgs(cam)
 
@@ -130,8 +125,9 @@ def test_camera_roi_combo_custom(camera_roi_widget):
     assert mmc.getROI() == [0, 0, 512, 512]
 
 
-def test_camera_roi_widget_signal(camera_roi_widget):
-    cam, _ = camera_roi_widget
+def test_camera_roi_widget_signal(qtbot: QtBot):
+    cam = CameraRoiWidget()
+    qtbot.addWidget(cam)
 
     cam_x, cam_y, w, h, combo, cbox, _ = _get_wdgs(cam)
 
@@ -177,8 +173,10 @@ def test_camera_roi_widget_signal(camera_roi_widget):
     assert h.value() == 300
 
 
-def test_core_setROI(camera_roi_widget):
-    cam, mmc = camera_roi_widget
+def test_core_setROI(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    cam = CameraRoiWidget()
+    qtbot.addWidget(cam)
 
     cam_x, cam_y, w, h, combo, cbox, _ = _get_wdgs(cam)
 

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -62,12 +62,12 @@ def test_populating_group_preset_table(global_mmcore: CMMCorePlus, qtbot: QtBot)
             assert global_mmcore.getProperty("Camera", "TestProperty1") == "0.1000"
 
 
-def test_add_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
+def test_add_group(qtbot: QtBot):
     gp = GroupPresetTableWidget()
     qtbot.addWidget(gp)
     add_gp_wdg = AddGroupWidget()
     qtbot.addWidget(add_gp_wdg)
-    mmc = global_mmcore
+    mmc = CMMCorePlus.instance()
 
     assert "NewGroup" not in mmc.getAvailableConfigGroups()
     groups_in_table = [

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
 from pymmcore_plus import CMMCorePlus
+from useq import MDASequence
 
 from pymmcore_widgets._mda_widget._grid_widget import GridWidget
 from pymmcore_widgets._mda_widget._mda_widget import MDAWidget
@@ -15,49 +16,49 @@ if TYPE_CHECKING:
 def test_mda_widget_load_state(qtbot: QtBot):
     wdg = MDAWidget(include_run_button=True)
     qtbot.addWidget(wdg)
-    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
-    # assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
-    # assert not wdg.time_groupbox.isChecked()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    assert not wdg.time_groupbox.isChecked()
 
-    # wdg._set_enabled(False)
-    # assert not wdg.time_groupbox.isEnabled()
-    # assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
-    # assert not wdg.channel_groupbox.isEnabled()
-    # assert not wdg.stage_pos_groupbox.isEnabled()
-    # assert not wdg.stack_groupbox.isEnabled()
-    # wdg._set_enabled(True)
+    wdg._set_enabled(False)
+    assert not wdg.time_groupbox.isEnabled()
+    assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    assert not wdg.channel_groupbox.isEnabled()
+    assert not wdg.stage_pos_groupbox.isEnabled()
+    assert not wdg.stack_groupbox.isEnabled()
+    wdg._set_enabled(True)
 
-    # sequence = MDASequence(
-    #     channels=[
-    #         {"config": "Cy5", "exposure": 20},
-    #         {"config": "FITC", "exposure": 50},
-    #     ],
-    #     time_plan={"interval": 2, "loops": 5},
-    #     z_plan={"range": 4, "step": 0.5},
-    #     axis_order="tpcz",
-    #     stage_positions=(
-    #         {"name": "Pos000", "x": 222, "y": 1, "z": 1},
-    #         {"name": "Pos001", "x": 111, "y": 0, "z": 0},
-    #     ),
-    # )
-    # wdg.set_state(sequence)
-    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
-    # assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
-    # assert wdg.time_groupbox.isChecked()
+    sequence = MDASequence(
+        channels=[
+            {"config": "Cy5", "exposure": 20},
+            {"config": "FITC", "exposure": 50},
+        ],
+        time_plan={"interval": 2, "loops": 5},
+        z_plan={"range": 4, "step": 0.5},
+        axis_order="tpcz",
+        stage_positions=(
+            {"name": "Pos000", "x": 222, "y": 1, "z": 1},
+            {"name": "Pos001", "x": 111, "y": 0, "z": 0},
+        ),
+    )
+    wdg.set_state(sequence)
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
+    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
+    assert wdg.time_groupbox.isChecked()
 
-    # # round trip
-    # assert wdg.get_state() == sequence
+    # round trip
+    assert wdg.get_state() == sequence
 
-    # # test add grid positions
-    # wdg.stage_pos_groupbox.setChecked(True)
-    # wdg._clear_positions()
-    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
-    # wdg.stage_pos_groupbox.grid_button.click()
-    # qtbot.addWidget(wdg._grid_wdg)
-    # wdg._grid_wdg.scan_size_spinBox_r.setValue(2)
-    # wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
-    # wdg._grid_wdg.generate_position_btn.click()
-    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
+    # test add grid positions
+    wdg.stage_pos_groupbox.setChecked(True)
+    wdg._clear_positions()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    wdg.stage_pos_groupbox.grid_button.click()
+    qtbot.addWidget(wdg._grid_wdg)
+    wdg._grid_wdg.scan_size_spinBox_r.setValue(2)
+    wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
+    wdg._grid_wdg.generate_position_btn.click()
+    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
 
 
 def test_mda_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
 from pymmcore_plus import CMMCorePlus
-from useq import MDASequence
 
 from pymmcore_widgets._mda_widget._grid_widget import GridWidget
 from pymmcore_widgets._mda_widget._mda_widget import MDAWidget
@@ -13,52 +12,52 @@ if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
 
-def test_mda_widget_load_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
+def test_mda_widget_load_state(qtbot: QtBot):
     wdg = MDAWidget(include_run_button=True)
     qtbot.addWidget(wdg)
-    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
-    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
-    assert not wdg.time_groupbox.isChecked()
+    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    # assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 0
+    # assert not wdg.time_groupbox.isChecked()
 
-    wdg._set_enabled(False)
-    assert not wdg.time_groupbox.isEnabled()
-    assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
-    assert not wdg.channel_groupbox.isEnabled()
-    assert not wdg.stage_pos_groupbox.isEnabled()
-    assert not wdg.stack_groupbox.isEnabled()
-    wdg._set_enabled(True)
+    # wdg._set_enabled(False)
+    # assert not wdg.time_groupbox.isEnabled()
+    # assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
+    # assert not wdg.channel_groupbox.isEnabled()
+    # assert not wdg.stage_pos_groupbox.isEnabled()
+    # assert not wdg.stack_groupbox.isEnabled()
+    # wdg._set_enabled(True)
 
-    sequence = MDASequence(
-        channels=[
-            {"config": "Cy5", "exposure": 20},
-            {"config": "FITC", "exposure": 50},
-        ],
-        time_plan={"interval": 2, "loops": 5},
-        z_plan={"range": 4, "step": 0.5},
-        axis_order="tpcz",
-        stage_positions=(
-            {"name": "Pos000", "x": 222, "y": 1, "z": 1},
-            {"name": "Pos001", "x": 111, "y": 0, "z": 0},
-        ),
-    )
-    wdg.set_state(sequence)
-    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
-    assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
-    assert wdg.time_groupbox.isChecked()
+    # sequence = MDASequence(
+    #     channels=[
+    #         {"config": "Cy5", "exposure": 20},
+    #         {"config": "FITC", "exposure": 50},
+    #     ],
+    #     time_plan={"interval": 2, "loops": 5},
+    #     z_plan={"range": 4, "step": 0.5},
+    #     axis_order="tpcz",
+    #     stage_positions=(
+    #         {"name": "Pos000", "x": 222, "y": 1, "z": 1},
+    #         {"name": "Pos001", "x": 111, "y": 0, "z": 0},
+    #     ),
+    # )
+    # wdg.set_state(sequence)
+    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 2
+    # assert wdg.channel_groupbox.channel_tableWidget.rowCount() == 2
+    # assert wdg.time_groupbox.isChecked()
 
-    # round trip
-    assert wdg.get_state() == sequence
+    # # round trip
+    # assert wdg.get_state() == sequence
 
-    # test add grid positions
-    wdg.stage_pos_groupbox.setChecked(True)
-    wdg._clear_positions()
-    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
-    wdg.stage_pos_groupbox.grid_button.click()
-    qtbot.addWidget(wdg._grid_wdg)
-    wdg._grid_wdg.scan_size_spinBox_r.setValue(2)
-    wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
-    wdg._grid_wdg.generate_position_btn.click()
-    assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
+    # # test add grid positions
+    # wdg.stage_pos_groupbox.setChecked(True)
+    # wdg._clear_positions()
+    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 0
+    # wdg.stage_pos_groupbox.grid_button.click()
+    # qtbot.addWidget(wdg._grid_wdg)
+    # wdg._grid_wdg.scan_size_spinBox_r.setValue(2)
+    # wdg._grid_wdg.scan_size_spinBox_c.setValue(2)
+    # wdg._grid_wdg.generate_position_btn.click()
+    # assert wdg.stage_pos_groupbox.stage_tableWidget.rowCount() == 4
 
 
 def test_mda_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):

--- a/tests/test_table_pixel_size_widget.py
+++ b/tests/test_table_pixel_size_widget.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
+from pymmcore_plus import CMMCorePlus
 
-from pymmcore_widgets._pixel_size_widget import PixelSizeWidget
+from pymmcore_widgets._pixel_size_widget import PixelSizeTable, PixelSizeWidget
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
+    from qtpy.QtWidgets import QWidget
 
 
 OBJECTIVE_LABEL = 0
@@ -18,17 +19,7 @@ IMAGE_PX_SIZE = 4
 ROW = 0  # "Nikon 40X Plan Fluor ELWD"
 
 
-@pytest.fixture()
-def px_wdg(global_mmcore, qtbot: QtBot):
-    px_size_wdg = PixelSizeWidget(mmcore=global_mmcore)
-    table = px_size_wdg.table
-    obj = px_size_wdg.objective_device
-    qtbot.addWidget(px_size_wdg)
-    mmc = global_mmcore
-    return px_size_wdg, table, obj, mmc
-
-
-def _get_wdg(table):
+def _get_wdg(table: PixelSizeTable) -> tuple[str, QWidget, QWidget, QWidget, QWidget]:
     obj = table.item(ROW, OBJECTIVE_LABEL).text()
     resID = table.cellWidget(ROW, RESOLUTION_ID)
     mag = table.cellWidget(ROW, MAGNIFICATION)
@@ -37,8 +28,12 @@ def _get_wdg(table):
     return obj, resID, mag, cam_px, img_px
 
 
-def test_pixel_size_table(px_wdg):
-    px_size_wdg, table, obj, mmc = px_wdg
+def test_pixel_size_table(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    table = px_size_wdg.table
+    obj = px_size_wdg.objective_device
+    qtbot.addWidget(px_size_wdg)
 
     assert ["Res10x", "Res20x", "Res40x"] == list(mmc.getAvailablePixelSizeConfigs())
     assert table.rowCount() == len(mmc.getStateLabels(obj))
@@ -65,8 +60,11 @@ def test_pixel_size_table(px_wdg):
         assert _cam_px == "10.00"
 
 
-def test_change_magnification(qtbot: QtBot, px_wdg):
-    _, table, _, mmc = px_wdg
+def test_change_magnification(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     _, _, mag, cam_px, img_px = _get_wdg(table)
 
@@ -80,8 +78,11 @@ def test_change_magnification(qtbot: QtBot, px_wdg):
     assert mmc.getPixelSizeUmByID("Res40x") == 10 / 50
 
 
-def test_change_cam_pixel_size(qtbot: QtBot, px_wdg):
-    _, table, _, mmc = px_wdg
+def test_change_cam_pixel_size(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     _, _, mag, cam_px, img_px = _get_wdg(table)
 
@@ -97,8 +98,11 @@ def test_change_cam_pixel_size(qtbot: QtBot, px_wdg):
     assert table.cellWidget(ROW + 1, CAMERA_PX_SIZE).text() == "6.00"
 
 
-def test_change_img_pixel_size(qtbot: QtBot, px_wdg):
-    px_size_wdg, table, _, mmc = px_wdg
+def test_change_img_pixel_size(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     _, _, mag, cam_px, img_px = _get_wdg(table)
 
@@ -121,8 +125,11 @@ def test_change_img_pixel_size(qtbot: QtBot, px_wdg):
         assert _cam_px == "10.00"
 
 
-def test_ResolutionID(qtbot: QtBot, px_wdg):
-    px_size_wdg, table, _, mmc = px_wdg
+def test_ResolutionID(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     px_size_wdg.img_px_radiobtn.setChecked(True)
     assert not px_size_wdg.mag_radiobtn.isChecked()
@@ -148,8 +155,11 @@ def test_ResolutionID(qtbot: QtBot, px_wdg):
     assert img_px.graphicsEffect().opacity() == 1.00
 
 
-def test_delete_button(qtbot: QtBot, px_wdg):
-    _, table, _, mmc = px_wdg
+def test_delete_button(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     del_btn = table.cellWidget(ROW, 5).children()[-1]
     with qtbot.waitSignal(mmc.events.pixelSizeChanged):
@@ -166,8 +176,11 @@ def test_delete_button(qtbot: QtBot, px_wdg):
     assert img_px.graphicsEffect().opacity() == 0.50
 
 
-def test_setPixelSizeUm(qtbot: QtBot, px_wdg):
-    _, table, _, mmc = px_wdg
+def test_setPixelSizeUm(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     _, _, _, _, img_px = _get_wdg(table)
     assert img_px.text() == "0.2500"
@@ -195,8 +208,11 @@ def test_setPixelSizeUm(qtbot: QtBot, px_wdg):
     assert img_px.graphicsEffect().opacity() == 1.00
 
 
-def test_deletePixelSizeConfig(qtbot: QtBot, px_wdg):
-    _, table, _, mmc = px_wdg
+def test_deletePixelSizeConfig(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     with qtbot.waitSignal(mmc.events.pixelSizeChanged):
         mmc.deletePixelSizeConfig("Res40x")
@@ -213,8 +229,11 @@ def test_deletePixelSizeConfig(qtbot: QtBot, px_wdg):
     assert img_px.graphicsEffect().opacity() == 0.50
 
 
-def test_definePixelSizeConfig(qtbot: QtBot, px_wdg):
-    _, table, _, mmc = px_wdg
+def test_definePixelSizeConfig(qtbot: QtBot):
+    mmc = CMMCorePlus.instance()
+    px_size_wdg = PixelSizeWidget()
+    qtbot.addWidget(px_size_wdg)
+    table = px_size_wdg.table
 
     del_btn = table.cellWidget(ROW, 5).children()[-1]
     with qtbot.waitSignal(mmc.events.pixelSizeChanged):


### PR DESCRIPTION
This PR adds a new fixture in conftest that is automatically used (with [autouse](https://docs.pytest.org/en/6.2.x/fixture.html#autouse-fixtures-fixtures-you-don-t-have-to-request)) that asserts that no top level widgets are remaining after the test closes.  It enforces good widget "hygiene", to make sure that we're not leaking references.

One thing I found while doing it is that the fixture pattern of 

```python
@pytest.fixture
def some_widget(qtbot):
    my_widget = Widget()
    qtbot.addWidget(my_widget)
    return my_widget
```

actually prevents good widget cleanup.  so those have been removed when found