### PR TITLE
fix: change property browser icons color to gray

### DIFF
--- a/src/pymmcore_widgets/_device_property_table.py
+++ b/src/pymmcore_widgets/_device_property_table.py
@@ -129,7 +129,7 @@ class DevicePropertyTable(QTableWidget):
             # TODO: make sure to add icons for all possible device types
             icon_string = ICONS.get(prop.deviceType(), None)
             if icon_string:
-                item.setIcon(icon(icon_string, opacity=0.5, color="blue"))
+                item.setIcon(icon(icon_string, color="Gray"))
             self.setItem(i, 0, item)
 
             wdg = PropertyWidget(prop.device, prop.name, mmcore=self._mmc)


### PR DESCRIPTION
This PR changes the blue color of the properties icons since it is not very visible when in dark mode. It is now gray and it seems to look good in both light and dark mode. 

---
<img width="266" alt="Screen Shot 2022-12-06 at 9 42 07 AM" src="https://user-images.githubusercontent.com/70725613/205942160-ab3540b7-d4d1-4869-992e-73e7939d978f.png">
<img width="266" alt="Screen Shot 2022-12-06 at 9 41 55 AM" src="https://user-images.githubusercontent.com/70725613/205942175-938904dc-2c47-4bed-af86-d63cf99891ad.png">
