### PR TITLE
fix: fix bug in channel widget 

### DIFF
--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -51,7 +51,9 @@ class ChannelWidget(QWidget):
 
         self._channel_group = channel_group or self._get_channel_group()
 
-        self.channel_wdg = self._create_channel_widget(self._channel_group)
+        self.channel_wdg: PresetsWidget | QComboBox
+
+        self._create_channel_widget(self._channel_group)
 
         self.setLayout(QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
@@ -79,16 +81,13 @@ class ChannelWidget(QWidget):
                 return str(dialog.currentText())
         return None  # pragma: no cover
 
-    def _create_channel_widget(
-        self, channel_group: str | None
-    ) -> PresetsWidget | QComboBox:
+    def _create_channel_widget(self, channel_group: str | None) -> None:
         if channel_group:
-            channel_wdg = PresetsWidget(channel_group, parent=self)
+            self.channel_wdg = PresetsWidget(channel_group, parent=self)
             self._mmc.setChannelGroup(channel_group)
         else:
-            channel_wdg = QComboBox()
-            channel_wdg.setEnabled(False)
-        return channel_wdg
+            self.channel_wdg = QComboBox()
+            self.channel_wdg.setEnabled(False)
 
     def _on_sys_cfg_loaded(self) -> None:
         channel_group = self._channel_group or self._get_channel_group()
@@ -131,7 +130,7 @@ class ChannelWidget(QWidget):
             self._on_channel_group_changed("")
 
     def _update_widget(self, channel_group: str) -> None:
-        self.channel_wdg = self._create_channel_widget(channel_group)
+        self._create_channel_widget(channel_group)
         self.layout().addWidget(self.channel_wdg)
 
     def _disconnect(self) -> None:


### PR DESCRIPTION
fix: define `self.channel_wdg` within the `_create_channel_widget` method

not sure how to explain it well but I'll try...

The `ChannelWidget`  `_on_channel_group_changed` method is in charge of deleting the current `self.channel_wdg` (`QComboBox` or `PresetsWidget`) to then create a new one. 
However, since within this method we call `setChannelGroup` which triggers again `_on_channel_group_changed`, we create a loop where the new `self.channel_wdg` is not yet defined. This cause a duplication of the widget (movie below).

As a solution, I moved the `QComboBox` or `PresetsWidget` assignment to the `self.channel_wdg` variable within the `ChannelWidget` `_create_channel_widget` method.

---
BEFORE

https://user-images.githubusercontent.com/70725613/205969878-829c20d4-705f-4c22-b035-9f8e63619ea6.mov

AFTER

https://user-images.githubusercontent.com/70725613/205969888-2e3e22a3-3140-417a-ba32-426f060dcc8b.mov






