### PR TITLE
refactor: make _GridParams class for _create_row_cols_overlap_group

### DIFF
--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from pymmcore_plus import CMMCorePlus
 from qtpy import QtWidgets as QtW
@@ -204,7 +205,7 @@ class MDAWidget(QWidget):
     def _add_position_row(self) -> int:
         idx = self.position_groupbox.stage_tableWidget.rowCount()
         self.position_groupbox.stage_tableWidget.insertRow(idx)
-        return idx  # type: ignore [no-any-return]
+        return cast(int, idx)
 
     def _remove_position(self) -> None:
         # remove selected position

--- a/tests/test_sample_explorer_widget.py
+++ b/tests/test_sample_explorer_widget.py
@@ -21,9 +21,9 @@ def test_explorer_state(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert len(s_exp._mmc.getLoadedDevices()) > 2
     assert mmc.getChannelGroup() == "Channel"
 
-    s_exp.scan_size_spinBox_c.setValue(2)
-    s_exp.scan_size_spinBox_r.setValue(2)
-    s_exp.ovelap_spinBox.setValue(10)
+    s_exp.grid_params.scan_size_spinBox_c.setValue(2)
+    s_exp.grid_params.scan_size_spinBox_r.setValue(2)
+    s_exp.grid_params.overlap_spinBox.setValue(10)
 
     s_exp.channel_groupbox._add_button.click()
     assert s_exp.channel_groupbox._table.rowCount() == 1
@@ -111,8 +111,8 @@ def test_explorer_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg = SampleExplorerWidget(include_run_button=True)
     qtbot.addWidget(wdg)
 
-    assert wdg.scan_size_spinBox_c.value() == 1
-    assert wdg.scan_size_spinBox_r.value() == 1
+    assert wdg.grid_params.scan_size_spinBox_c.value() == 1
+    assert wdg.grid_params.scan_size_spinBox_r.value() == 1
 
     assert wdg.channel_groupbox._table.rowCount() == 0
     wdg.channel_groupbox._add_button.click()


### PR DESCRIPTION
This pulls the `_create_row_cols_overlap_group` off the SampleExplorer in favor of a new class.  As I was doing that, I noticed that there's also already a very similar `GridWidget` in `_mda._grid_widget`.  So in a follow up PR we should be figuring out how to deduplicate those two and only have one of them