### PR TITLE
fix: fix MDA run_button not showing when _include_run_button=True

### DIFF
--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -78,6 +78,7 @@ class MDAWidget(QWidget):
         self.buttons_wdg = _MDAControlButtons()
         self.buttons_wdg.pause_button.hide()
         self.buttons_wdg.cancel_button.hide()
+        self.buttons_wdg.run_button.hide()
 
         # LAYOUT
 
@@ -126,7 +127,7 @@ class MDAWidget(QWidget):
         # connect run button
         if self._include_run_button:
             self.buttons_wdg.run_button.clicked.connect(self._on_run_clicked)
-            self.buttons_wdg.run_button.hide()
+            self.buttons_wdg.run_button.show()
 
         self._on_sys_cfg_loaded()
 


### PR DESCRIPTION
The MDA `run_button` is not showing when `_include_run_button` is `True`. By mistake this has been changed and this PR fixes it.