### PR TITLE
docs: add time and z plan widgets to docs

### DIFF
--- a/examples/time_plan_widget.py
+++ b/examples/time_plan_widget.py
@@ -1,0 +1,20 @@
+"""Example usage of the TimePlanWidget class.
+
+Check also the 'mda_widget.py' example to see the TimePlanWidget
+used in combination of other widgets.
+"""
+
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QApplication
+
+from pymmcore_widgets import TimePlanWidget
+
+app = QApplication([])
+
+mmc = CMMCorePlus().instance()
+mmc.loadSystemConfiguration()
+
+t_wdg = TimePlanWidget()
+t_wdg.show()
+
+app.exec_()

--- a/examples/z_stack_widget.py
+++ b/examples/z_stack_widget.py
@@ -1,0 +1,20 @@
+"""Example usage of the ZStackWidget class.
+
+Check also the 'mda_widget.py' example to see the ZStackWidget
+used in combination of other widgets.
+"""
+
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QApplication
+
+from pymmcore_widgets import ZStackWidget
+
+app = QApplication([])
+
+mmc = CMMCorePlus().instance()
+mmc.loadSystemConfiguration()
+
+z_wdg = ZStackWidget()
+z_wdg.show()
+
+app.exec_()

--- a/src/pymmcore_widgets/__init__.py
+++ b/src/pymmcore_widgets/__init__.py
@@ -14,7 +14,7 @@ from ._group_preset_widget._group_preset_table_widget import GroupPresetTableWid
 from ._image_widget import ImagePreview
 from ._live_button_widget import LiveButton
 from ._load_system_cfg_widget import ConfigurationWidget
-from ._mda import MDAWidget, SampleExplorerWidget
+from ._mda import MDAWidget, SampleExplorerWidget, TimePlanWidget, ZStackWidget
 from ._objective_widget import ObjectivesWidget
 from ._pixel_size_widget import PixelSizeWidget
 from ._presets_widget import PresetsWidget
@@ -47,4 +47,6 @@ __all__ = [
     "SnapButton",
     "StageWidget",
     "StateDeviceWidget",
+    "TimePlanWidget",
+    "ZStackWidget",
 ]


### PR DESCRIPTION
This PR adds `ZStackWidget` and `TimePlanWidget` to the docs and also adds examples.