### PR TITLE
fix: Stop shutter widget from accidentally closing shutter

### DIFF
--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -62,7 +62,6 @@ class ChannelWidget(QWidget):
 
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_cfg_loaded)
         self._mmc.events.channelGroupChanged.connect(self._on_channel_group_changed)
-        self._mmc.events.configSet.connect(self._on_channel_set)
 
         # presetDeleted signal is handled by the PresetsWidget
         self._mmc.events.configDefined.connect(self._on_new_group_preset)
@@ -98,17 +97,6 @@ class ChannelWidget(QWidget):
             # signal is not emitted and we get a ValueError. So we need to call:
             self._on_channel_group_changed(channel_group)
 
-    def _on_channel_set(self, group: str, preset: str) -> None:
-        ch = self._mmc.getChannelGroup()
-        if group != ch:
-            return  # pragma: no cover
-        for d in self._mmc.getConfigData(ch, preset):
-            _dev = d[0]
-            _type = self._mmc.getDeviceType(_dev)
-            if _type is DeviceType.Shutter:
-                self._mmc.setProperty("Core", "Shutter", _dev)
-                break
-
     def _on_channel_group_changed(self, new_channel_group: str) -> None:
         """When Channel group is changed, recreate combo."""
         _wdg = QWidget()
@@ -136,6 +124,5 @@ class ChannelWidget(QWidget):
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._on_sys_cfg_loaded)
         self._mmc.events.channelGroupChanged.disconnect(self._on_channel_group_changed)
-        self._mmc.events.configSet.disconnect(self._on_channel_set)
         self._mmc.events.configDefined.disconnect(self._on_new_group_preset)
         self._mmc.events.configGroupDeleted.connect(self._on_group_deleted)

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pymmcore_plus import CMMCorePlus, DeviceType
+from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
 
 from ._presets_widget import PresetsWidget

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -73,6 +73,9 @@ class ShuttersWidget(QWidget):
         self._mmc.events.autoShutterSet.connect(self._on_autoshutter_changed)
         self._mmc.events.propertyChanged.connect(self._on_prop_changed)
         self._mmc.events.configSet.connect(self._on_channel_set)
+        self._mmc.events.continuousSequenceAcquisitionStarted.connect(self._on_live_mode)
+        self._mmc.events.sequenceAcquisitionStarted.connect(self._on_live_mode)
+        self._mmc.events.sequenceAcquisitionStopped.connect(self._on_live_mode)
 
         self.destroyed.connect(self._disconnect)
 
@@ -273,6 +276,10 @@ class ShuttersWidget(QWidget):
                 if value != "Undefined":
                     self._mmc.events.propertyChanged.emit(value, "State", True)
 
+    def _on_live_mode(self) -> None:
+        if not self._mmc.getShutterOpen(self.shutter_device):
+            self._set_shutter_wdg_to_closed()
+
     def _on_channel_set(self, group: str, preset: str) -> None:
         if (self._mmc.getShutterDevice() == self.shutter_device) and self._mmc.getAutoShutter():
             self.shutter_button.setEnabled(False)
@@ -300,8 +307,6 @@ class ShuttersWidget(QWidget):
                 self.autoshutter_checkbox.setChecked(state)
         if self._mmc.getShutterDevice() == self.shutter_device:
             self.shutter_button.setEnabled(not state)
-        if state and self._mmc.isSequenceRunning():
-            self._mmc.stopSequenceAcquisition()
 
     def _close_shutter(self, shutter: str) -> None:
         self._set_shutter_wdg_to_closed()

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -243,7 +243,10 @@ class ShuttersWidget(QWidget):
                 self.autoshutter_checkbox.setChecked(self._mmc.getAutoShutter())
             else:
                 self.autoshutter_checkbox.setChecked(False)
-            self.shutter_button.setEnabled(True)
+            if self._mmc.getShutterDevice() == self.shutter_device:
+                self.shutter_button.setEnabled(not self._mmc.getAutoShutter())
+            else:
+                self.shutter_button.setEnabled(True)
             if self._mmc.getShutterOpen(self.shutter_device):
                 self._set_shutter_wdg_to_opened()
             else:

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -274,15 +274,10 @@ class ShuttersWidget(QWidget):
                     self._mmc.events.propertyChanged.emit(value, "State", True)
 
     def _on_channel_set(self, group: str, preset: str) -> None:
-        ch = self._mmc.getChannelGroup()
-        if group != ch:
-            return  # pragma: no cover
-        for d in self._mmc.getConfigData(ch, preset):
-            _dev = d[0]
-            _type = self._mmc.getDeviceType(_dev)
-            if _type is DeviceType.Shutter:
-                self._mmc.setProperty("Core", "Shutter", _dev)
-                break
+        if (self._mmc.getShutterDevice() == self.shutter_device) and self._mmc.getAutoShutter():
+            self.shutter_button.setEnabled(False)
+        else:
+            self.shutter_button.setEnabled(True)
 
     def _on_shutter_btn_clicked(self) -> None:
         if self._mmc.getShutterOpen(self.shutter_device):

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -300,8 +300,8 @@ class ShuttersWidget(QWidget):
         if self.autoshutter:
             with signals_blocked(self.autoshutter_checkbox):
                 self.autoshutter_checkbox.setChecked(state)
-        self.shutter_button.setEnabled(not state)
-
+        if self._mmc.getShutterDevice() == self.shutter_device:
+            self.shutter_button.setEnabled(not state)
         if state and self._mmc.isSequenceRunning():
             self._mmc.stopSequenceAcquisition()
 

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -73,7 +73,9 @@ class ShuttersWidget(QWidget):
         self._mmc.events.autoShutterSet.connect(self._on_autoshutter_changed)
         self._mmc.events.propertyChanged.connect(self._on_prop_changed)
         self._mmc.events.configSet.connect(self._on_channel_set)
-        self._mmc.events.continuousSequenceAcquisitionStarted.connect(self._on_live_mode)
+        self._mmc.events.continuousSequenceAcquisitionStarted.connect(
+            self._on_live_mode
+        )
         self._mmc.events.sequenceAcquisitionStarted.connect(self._on_live_mode)
         self._mmc.events.sequenceAcquisitionStopped.connect(self._on_live_mode)
 
@@ -283,7 +285,9 @@ class ShuttersWidget(QWidget):
             self._set_shutter_wdg_to_opened()
 
     def _on_channel_set(self, group: str, preset: str) -> None:
-        if (self._mmc.getShutterDevice() == self.shutter_device) and self._mmc.getAutoShutter():
+        if (
+            self._mmc.getShutterDevice() == self.shutter_device
+        ) and self._mmc.getAutoShutter():
             self.shutter_button.setEnabled(False)
         else:
             self.shutter_button.setEnabled(True)

--- a/src/pymmcore_widgets/_shutter_widget.py
+++ b/src/pymmcore_widgets/_shutter_widget.py
@@ -279,6 +279,8 @@ class ShuttersWidget(QWidget):
     def _on_live_mode(self) -> None:
         if not self._mmc.getShutterOpen(self.shutter_device):
             self._set_shutter_wdg_to_closed()
+        else:
+            self._set_shutter_wdg_to_opened()
 
     def _on_channel_set(self, group: str, preset: str) -> None:
         if (self._mmc.getShutterDevice() == self.shutter_device) and self._mmc.getAutoShutter():

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -79,7 +79,7 @@ class SnapButton(QPushButton):
     def _snap(self) -> None:
         if self._mmc.isSequenceRunning():
             self._mmc.stopSequenceAcquisition()
-        def snap_with_shutter():
+        def snap_with_shutter() -> None:
             """
             Perform a snap and ensure shutter signals are sent.
 
@@ -97,7 +97,6 @@ class SnapButton(QPushButton):
                     self._mmc.getShutterDevice(), "State", False
                 )
         create_worker(snap_with_shutter, _start_thread=True)
-
 
 
     def _on_system_cfg_loaded(self) -> None:

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -79,6 +79,7 @@ class SnapButton(QPushButton):
     def _snap(self) -> None:
         if self._mmc.isSequenceRunning():
             self._mmc.stopSequenceAcquisition()
+
         def snap_with_shutter() -> None:
             """
             Perform a snap and ensure shutter signals are sent.
@@ -96,8 +97,8 @@ class SnapButton(QPushButton):
                 self._mmc.events.propertyChanged.emit(
                     self._mmc.getShutterDevice(), "State", False
                 )
-        create_worker(snap_with_shutter, _start_thread=True)
 
+        create_worker(snap_with_shutter, _start_thread=True)
 
     def _on_system_cfg_loaded(self) -> None:
         self.setEnabled(bool(self._mmc.getCameraDevice()))

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -79,11 +79,26 @@ class SnapButton(QPushButton):
     def _snap(self) -> None:
         if self._mmc.isSequenceRunning():
             self._mmc.stopSequenceAcquisition()
-        if self._mmc.getAutoShutter():
-            self._mmc.events.propertyChanged.emit(
-                self._mmc.getShutterDevice(), "State", True
-            )
-        create_worker(self._mmc.snap, _start_thread=True)
+        def snap_with_shutter():
+            """
+            Perform a snap and ensure shutter signals are sent.
+
+            This is necessary as not all shutter devices properly
+            send signals as they are opened and closed.
+            """
+            autoshutter = self._mmc.getAutoShutter()
+            if autoshutter:
+                self._mmc.events.propertyChanged.emit(
+                    self._mmc.getShutterDevice(), "State", True
+                )
+            self._mmc.snap()
+            if autoshutter:
+                self._mmc.events.propertyChanged.emit(
+                    self._mmc.getShutterDevice(), "State", False
+                )
+        create_worker(snap_with_shutter, _start_thread=True)
+
+
 
     def _on_system_cfg_loaded(self) -> None:
         self.setEnabled(bool(self._mmc.getCameraDevice()))

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -22,12 +22,9 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
     assert isinstance(wdg.channel_wdg, PresetsWidget)
 
-    global_mmcore.setProperty("Core", "Shutter", "")
-    assert not global_mmcore.getShutterDevice()
-
     wdg.channel_wdg.setValue("DAPI")
     assert global_mmcore.getCurrentConfig("Channel") == "DAPI"
-    assert global_mmcore.getShutterDevice() == "Multi Shutter"
+    assert global_mmcore.getShutterDevice() == "Shutter"
 
     global_mmcore.setConfig("Channel", "FITC")
     assert wdg.channel_wdg.value() == "FITC"

--- a/tests/test_shutter_widget.py
+++ b/tests/test_shutter_widget.py
@@ -33,13 +33,13 @@ def test_create_shutter_widgets(qtbot: QtBot):
 
     shutter, state_dev_shutter, multi_shutter = _make_shutters(qtbot)
 
-    assert shutter.shutter_button.text() == "Shutter closed"
+    assert shutter.shutter_button.text() == "Shutter opened"
     assert not shutter.shutter_button.isEnabled()
-    assert state_dev_shutter.shutter_button.text() == "StateDev Shutter closed"
-    assert not state_dev_shutter.shutter_button.isEnabled()
+    assert state_dev_shutter.shutter_button.text() == "StateDev Shutter opened"
+    assert state_dev_shutter.shutter_button.isEnabled()
     assert multi_shutter.shutter_button.text() == "Multi Shutter closed"
     assert multi_shutter.autoshutter_checkbox.isChecked()
-    assert not multi_shutter.shutter_button.isEnabled()
+    assert multi_shutter.shutter_button.isEnabled()
 
 
 def test_shutter_widget_propertyChanged(qtbot: QtBot):
@@ -48,12 +48,12 @@ def test_shutter_widget_propertyChanged(qtbot: QtBot):
     mmc = CMMCorePlus.instance()
 
     with qtbot.waitSignal(mmc.events.propertyChanged):
-        mmc.setProperty("Shutter", "State", True)
+        mmc.setProperty("Shutter", "State", False)
     assert not shutter.shutter_button.isEnabled()
-    assert mmc.getShutterOpen("Shutter")
-    assert shutter.shutter_button.text() == "Shutter opened"
-    assert mmc.getProperty("Shutter", "State") == "1"
-    assert not multi_shutter.shutter_button.isEnabled()
+    assert not mmc.getShutterOpen("Shutter")
+    assert shutter.shutter_button.text() == "Shutter closed"
+    assert mmc.getProperty("Shutter", "State") == "0"
+    assert multi_shutter.shutter_button.isEnabled()
     assert not mmc.getShutterOpen("Multi Shutter")
     assert multi_shutter.shutter_button.text() == "Multi Shutter closed"
     assert mmc.getProperty("Multi Shutter", "State") == "0"
@@ -71,8 +71,8 @@ def test_shutter_widget_autoShutterSet(qtbot: QtBot):
     assert multi_shutter.shutter_button.isEnabled()
     mmc.setAutoShutter(True)
     assert not shutter.shutter_button.isEnabled()
-    assert not state_dev_shutter.shutter_button.isEnabled()
-    assert not multi_shutter.shutter_button.isEnabled()
+    assert state_dev_shutter.shutter_button.isEnabled()
+    assert multi_shutter.shutter_button.isEnabled()
 
 
 def test_shutter_widget_configSet(qtbot: QtBot):
@@ -109,30 +109,24 @@ def test_shutter_widget_SequenceAcquisition(qtbot: QtBot):
 
     with qtbot.waitSignal(mmc.events.continuousSequenceAcquisitionStarted):
         mmc.startContinuousSequenceAcquisition()
-        assert multi_shutter.shutter_button.text() == "Multi Shutter opened"
-        assert not multi_shutter.shutter_button.isEnabled()
-        assert shutter.shutter_button.text() == "Shutter opened"
-        assert not shutter.shutter_button.isEnabled()
-        assert state_dev_shutter.shutter_button.text() == "StateDev Shutter opened"
-        assert not state_dev_shutter.shutter_button.isEnabled()
+    assert shutter.shutter_button.text() == "Shutter opened"
+    assert not shutter.shutter_button.isEnabled()
 
     with qtbot.waitSignal(mmc.events.autoShutterSet):
         mmc.setAutoShutter(False)
     assert shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
     assert multi_shutter.shutter_button.isEnabled()
-    assert multi_shutter.shutter_button.text() == "Multi Shutter opened"
     assert shutter.shutter_button.text() == "Shutter opened"
-    assert state_dev_shutter.shutter_button.text() == "StateDev Shutter opened"
 
+    with qtbot.waitSignal(mmc.events.autoShutterSet):
+        mmc.setAutoShutter(True)
     with qtbot.waitSignal(mmc.events.sequenceAcquisitionStopped):
         mmc.stopSequenceAcquisition()
-    assert shutter.shutter_button.isEnabled()
+    assert not shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
     assert multi_shutter.shutter_button.isEnabled()
-    assert multi_shutter.shutter_button.text() == "Multi Shutter closed"
     assert shutter.shutter_button.text() == "Shutter closed"
-    assert state_dev_shutter.shutter_button.text() == "StateDev Shutter closed"
 
 
 def test_shutter_widget_autoshutter(qtbot: QtBot):
@@ -151,8 +145,8 @@ def test_shutter_widget_autoshutter(qtbot: QtBot):
     with qtbot.waitSignal(mmc.events.autoShutterSet):
         multi_shutter.autoshutter_checkbox.setChecked(True)
     assert not shutter.shutter_button.isEnabled()
-    assert not state_dev_shutter.shutter_button.isEnabled()
-    assert not multi_shutter.shutter_button.isEnabled()
+    assert state_dev_shutter.shutter_button.isEnabled()
+    assert multi_shutter.shutter_button.isEnabled()
 
 
 def test_shutter_widget_button(qtbot: QtBot):
@@ -168,15 +162,15 @@ def test_shutter_widget_button(qtbot: QtBot):
 
     with qtbot.waitSignal(mmc.events.propertyChanged):
         shutter.shutter_button.click()
-    assert shutter.shutter_button.text() == "Shutter opened"
-    assert mmc.getShutterOpen("Shutter")
-    assert mmc.getProperty("Shutter", "State") == "1"
-
-    with qtbot.waitSignal(mmc.events.propertyChanged):
-        shutter.shutter_button.click()
     assert shutter.shutter_button.text() == "Shutter closed"
     assert not mmc.getShutterOpen("Shutter")
     assert mmc.getProperty("Shutter", "State") == "0"
+
+    with qtbot.waitSignal(mmc.events.propertyChanged):
+        shutter.shutter_button.click()
+    assert shutter.shutter_button.text() == "Shutter opened"
+    assert mmc.getShutterOpen("Shutter")
+    assert mmc.getProperty("Shutter", "State") == "1"
 
     with qtbot.waitSignal(mmc.events.propertyChanged):
         state_dev_shutter.shutter_button.click()


### PR DESCRIPTION
The shutter widget should not be so eagerly modifying shutter state. It was closing all shutters it interacted with on initialization and also interfering with autoshutter behavior by closing all shutters after snapping an image. This is best left to control by the core AutoShutter mechanism. Particularly a problem as for some scopes the BF light source is defined as shutter device, so the widget was turning off a halogen lamp which could never warm up in time for a fast exposure.

This was causing a bug for @JasonYu1 and me where all our BF images had no signal. Some test code demonstrating this:

```python
import numpy as np
from pymmcore_plus import CMMCorePlus, DeviceType
from pymmcore_widgets import ShuttersWidget
from qtpy.QtWidgets import QApplication


# need a qapp for the widgets to be created
app = QApplication([])

core = CMMCorePlus.instance()
core.loadSystemConfiguration("new-camera-chan.cfg")

core.setShutterOpen("Lamp", True)

# I have three shutter devices
print(core.getLoadedDevicesOfType(DeviceType.ShutterDevice))

core.setConfig("Filter", "BF")
core.setExposure(500)

# the default shutter for autoshutter should now
# be the BF Shutter
print(core.getShutterDevice())

# expect large numbers as lamp is on
img = core.snap()
print(f"image mean: {img.mean()}")


# now add a shutter widget
lamp_shutter_wdg = ShuttersWidget("Lamp")


# The shutter widget turned the lamp off!
img = core.snap()
print(f"image mean: {img.mean()}")
```


Before this fix this results in:
```
('Lamp', 'BF Shutter', 'Fluor-Shutter')
BF Shutter
image mean: 24546.016795199524
image mean: 468.0492142022825
```

note that the second image has essentially no intensity (and also I can see that the light never hits the sample)

and after the fix gives:

```
('Lamp', 'BF Shutter', 'Fluor-Shutter')
BF Shutter
image mean: 24569.787509095437
image mean: 24581.002033787147
```

(and I can see the light turning on for both exposures.