### PR TITLE
feat: add "advanced" channel options to ChannelTable

### DIFF
--- a/src/pymmcore_widgets/_mda/_channel_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_channel_table_widget.py
@@ -237,6 +237,7 @@ class ChannelTable(QGroupBox):
 
         # exposure spinbox
         channel_exp_spinbox = self._create_spinbox((0, 10000), True)
+        channel_exp_spinbox.setMinimum(1)
         channel_exp_spinbox.setValue(exposure or self._mmc.getExposure() or 100)
 
         # z offset spinbox

--- a/src/pymmcore_widgets/_mda/_channel_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_channel_table_widget.py
@@ -420,14 +420,3 @@ class ChannelGroupCombo(QComboBox):
         self._mmc.events.systemConfigurationLoaded.disconnect(self._on_sys_cfg_loaded)
         self._mmc.events.configGroupDeleted.disconnect(self._update_channel_group_combo)
         self._mmc.events.configDefined.disconnect(self._update_channel_group_combo)
-
-
-if __name__ == "__main__":
-    from qtpy.QtWidgets import QApplication
-
-    CMMCorePlus.instance().loadSystemConfiguration()
-    app = QApplication([])
-    table = ChannelTable()
-    table.show()
-
-    app.exec_()

--- a/src/pymmcore_widgets/_mda/_channel_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_channel_table_widget.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (
+    QAbstractSpinBox,
     QCheckBox,
     QComboBox,
     QDoubleSpinBox,
@@ -190,6 +191,17 @@ class ChannelTable(QGroupBox):
                 return ch
         return available[0]
 
+    def _create_spinbox(
+        self, range: tuple[int, int], double: bool = False
+    ) -> QDoubleSpinBox:
+        dspinbox = QDoubleSpinBox() if double else QSpinBox()
+        dspinbox.setButtonSymbols(QAbstractSpinBox.NoButtons)
+        dspinbox.setRange(*range)
+        dspinbox.setAlignment(Qt.AlignCenter)
+        dspinbox.wheelEvent = lambda event: None  # block mouse scroll
+        dspinbox.valueChanged.connect(self.valueChanged)
+        return dspinbox
+
     def _create_new_row(
         self,
         channel: str | None = None,
@@ -224,20 +236,12 @@ class ChannelTable(QGroupBox):
         channel_combo.setCurrentText(channel)
 
         # exposure spinbox
-        channel_exp_spinbox = QDoubleSpinBox()
-        channel_exp_spinbox.setRange(0, 10000)
+        channel_exp_spinbox = self._create_spinbox((0, 10000), True)
         channel_exp_spinbox.setValue(exposure or self._mmc.getExposure() or 100)
-        channel_exp_spinbox.setAlignment(Qt.AlignCenter)
-        channel_exp_spinbox.wheelEvent = lambda event: None  # block mouse scroll
-        channel_exp_spinbox.valueChanged.connect(self.valueChanged)
 
         # z offset spinbox
-        z_offset_spinbox = QDoubleSpinBox()
-        z_offset_spinbox.setRange(-10000, 10000)
+        z_offset_spinbox = self._create_spinbox((-10000, 10000), True)
         z_offset_spinbox.setValue(z_offset)
-        z_offset_spinbox.setAlignment(Qt.AlignCenter)
-        z_offset_spinbox.wheelEvent = lambda event: None  # block mouse scroll
-        z_offset_spinbox.valueChanged.connect(self.valueChanged)
 
         # z stack checkbox
         z_stack_wdg = QWidget()
@@ -251,12 +255,8 @@ class ChannelTable(QGroupBox):
         z_stack_layout.addWidget(z_stack_checkbox)
 
         # acqire every spinbox
-        acquire_every_spinbox = QSpinBox()
-        acquire_every_spinbox.setRange(1, 10000)
+        acquire_every_spinbox = self._create_spinbox((1, 10000))
         acquire_every_spinbox.setValue(acquire_every)
-        acquire_every_spinbox.setAlignment(Qt.AlignCenter)
-        acquire_every_spinbox.wheelEvent = lambda event: None  # block mouse scroll
-        acquire_every_spinbox.valueChanged.connect(self.valueChanged)
 
         idx = self._table.rowCount()
         self._table.insertRow(idx)

--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -78,12 +78,15 @@ class MDAWidget(QWidget):
 
         self.time_groupbox = TimePlanWidget()
         self.time_groupbox.setChecked(False)
+        self.time_groupbox.toggled.connect(self._update_total_time)
 
         self.stack_groupbox = ZStackWidget()
         self.stack_groupbox.setChecked(False)
+        self.stack_groupbox.toggled.connect(self._update_total_time)
 
         self.position_groupbox = PositionTable()
         self.position_groupbox.setChecked(False)
+        self.position_groupbox.toggled.connect(self._update_total_time)
 
         # below the scroll area, some feedback widgets and buttons
         self.time_lbl = _MDATimeLabel()

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -51,7 +51,6 @@ class TimePlanWidget(QGroupBox):
         super().__init__(title, parent=parent)
         self.setCheckable(True)
         self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        # self.setChecked(False)
 
         self._mmc = mmcore or CMMCorePlus.instance()
 
@@ -98,13 +97,19 @@ class TimePlanWidget(QGroupBox):
         self.setWarningMessage("Interval shorter than acquisition time per timepoint.")
         # warning widget (icon + message)
         self._warning_widget = QWidget()
-        self._warning_widget.setLayout(QHBoxLayout())
-        self._warning_widget.layout().addWidget(self._warning_icon)
-        self._warning_widget.layout().addWidget(self._warning_msg)
+        _warning_layout = QHBoxLayout()
+        _warning_layout.setSpacing(0)
+        _warning_layout.setContentsMargins(0, 0, 0, 0)
+        self._warning_widget.setLayout(_warning_layout)
+        _warning_layout.addWidget(self._warning_icon)
+        _warning_layout.addWidget(self._warning_msg)
         self._warning_widget.setStyleSheet("color:magenta")
         self._warning_widget.hide()
 
-        self.setLayout(QVBoxLayout())
+        _main_layout = QVBoxLayout()
+        _main_layout.setSpacing(0)
+        _main_layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(_main_layout)
         top_row = QWidget()
         top_row.setLayout(QHBoxLayout())
         top_row.layout().setSpacing(5)
@@ -114,8 +119,8 @@ class TimePlanWidget(QGroupBox):
         top_row.layout().addWidget(self._interval_spinbox)
         top_row.layout().addWidget(self._units_combo)
 
-        self.layout().addWidget(top_row)
-        self.layout().addWidget(self._warning_widget)
+        _main_layout.addWidget(top_row)
+        _main_layout.addWidget(self._warning_widget)
 
     def setWarningMessage(self, msg: str) -> None:
         """Set the text of the warning message."""

--- a/tests/test_channel_table_widget.py
+++ b/tests/test_channel_table_widget.py
@@ -62,16 +62,51 @@ def test_set_get_state(qtbot: QtBot):
     qtbot.addWidget(ct)
 
     state = [
-        {"config": "Cy5", "group": "Channel", "exposure": 100.0},
-        {"config": "DAPI", "group": "Channel", "exposure": 100.0},
-        {"config": "HighRes", "group": "Camera", "exposure": 100.0},
+        {
+            "config": "Cy5",
+            "group": "Channel",
+            "exposure": 100.0,
+            "z_offset": 0.0,
+            "do_stack": True,
+            "acquire_every": 1,
+        },
+        {
+            "config": "DAPI",
+            "group": "Channel",
+            "exposure": 100.0,
+            "z_offset": 10.0,
+            "do_stack": True,
+            "acquire_every": 1,
+        },
+        {
+            "config": "HighRes",
+            "group": "Camera",
+            "exposure": 100.0,
+            "z_offset": 0.0,
+            "do_stack": False,
+            "acquire_every": 1,
+        },
+        {
+            "config": "Cy5",
+            "group": "Channel",
+            "exposure": 100.0,
+            "z_offset": 0.0,
+            "do_stack": True,
+            "acquire_every": 2,
+        },
     ]
 
     ct.set_state(state)
 
-    assert ct._table.rowCount() == 3
+    assert ct._table.rowCount() == 4
     assert ct._table.cellWidget(0, 0).currentText() == "Cy5"
     assert ct._table.cellWidget(1, 0).currentText() == "DAPI"
     assert ct._table.cellWidget(2, 0).currentText() == "HighRes"
+    assert ct._table.cellWidget(3, 0).currentText() == "Cy5"
+
+    ct._advanced_cbox.setChecked(True)
+    assert ct._table.cellWidget(1, 2).value() == 10.0
+    assert not ct._z_stack_checkbox(2).isChecked()
+    assert ct._table.cellWidget(3, 4).value() == 2
 
     assert ct.value() == state

--- a/tests/test_channel_table_widget.py
+++ b/tests/test_channel_table_widget.py
@@ -110,3 +110,11 @@ def test_set_get_state(qtbot: QtBot):
     assert ct._table.cellWidget(3, 4).value() == 2
 
     assert ct.value() == state
+    ct._advanced_cbox.setChecked(False)
+
+    for s in state:
+        s["z_offset"] = 0.0
+        s["do_stack"] = True
+        s["acquire_every"] = 1
+
+    assert ct.value() == state

--- a/tests/test_channel_table_widget.py
+++ b/tests/test_channel_table_widget.py
@@ -104,17 +104,8 @@ def test_set_get_state(qtbot: QtBot):
     assert ct._table.cellWidget(2, 0).currentText() == "HighRes"
     assert ct._table.cellWidget(3, 0).currentText() == "Cy5"
 
-    ct._advanced_cbox.setChecked(True)
     assert ct._table.cellWidget(1, 2).value() == 10.0
     assert not ct._z_stack_checkbox(2).isChecked()
     assert ct._table.cellWidget(3, 4).value() == 2
-
-    assert ct.value() == state
-    ct._advanced_cbox.setChecked(False)
-
-    for s in state:
-        s["z_offset"] = 0.0
-        s["do_stack"] = True
-        s["acquire_every"] = 1
 
     assert ct.value() == state

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -191,7 +191,7 @@ def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert wdg.channel_groupbox._table.cellWidget(0, 1).value() == 100.0
     assert not wdg.time_groupbox.isChecked()
 
-    txt = "Minimum total acquisition time: 100.0000 ms.\n"
+    txt = "Minimum total acquisition time: 100.0000 ms."
     assert wdg.time_lbl._total_time_lbl.text() == txt
     assert not wdg.time_groupbox._warning_widget.isVisible()
 
@@ -201,29 +201,40 @@ def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert wdg.time_groupbox._warning_widget.isVisible()
 
     txt = (
-        "Minimum total acquisition time: 100.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+        "Minimum total acquisition time: 100.0000 ms."
+        "\nMinimum acquisition time(s) per timepoint: 100.0000 ms."
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt
 
     wdg.time_groupbox._timepoints_spinbox.setValue(3)
     txt = (
-        "Minimum total acquisition time: 300.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+        "Minimum total acquisition time: 302.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt
 
     wdg.time_groupbox._interval_spinbox.setValue(10)
-    txt1 = (
-        "Minimum total acquisition time: 300.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+    txt = (
+        "Minimum total acquisition time: 320.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
-    assert wdg.time_lbl._total_time_lbl.text() == txt1
+    assert wdg.time_lbl._total_time_lbl.text() == txt
 
     wdg.time_groupbox._interval_spinbox.setValue(200)
-    txt1 = (
-        "Minimum total acquisition time: 500.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+    txt = (
+        "Minimum total acquisition time: 700.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
-    assert wdg.time_lbl._total_time_lbl.text() == txt1
+    assert wdg.time_lbl._total_time_lbl.text() == txt
     assert not wdg.time_groupbox._warning_widget.isVisible()
+
+    wdg.channel_groupbox._add_button.click()
+    wdg.channel_groupbox._advanced_cbox.setChecked(True)
+    wdg.channel_groupbox._table.cellWidget(1, 4).setValue(2)
+    wdg.channel_groupbox._table.cellWidget(1, 1).setValue(100.0)
+
+    txt = (
+        "Minimum total acquisition time: 900.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 200.0000 ms (100.0000 ms)."
+    )
+    assert wdg.time_lbl._total_time_lbl.text() == txt

--- a/tests/test_sample_explorer_widget.py
+++ b/tests/test_sample_explorer_widget.py
@@ -175,7 +175,7 @@ def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert not wdg.time_groupbox._warning_widget.isVisible()
     wdg.time_groupbox._units_combo.setCurrentText("ms")
 
-    txt = "Minimum total acquisition time: 100.0000 ms.\n"
+    txt = "Minimum total acquisition time: 100.0000 ms."
     assert wdg.time_lbl._total_time_lbl.text() == txt
 
     assert not wdg.time_groupbox.isChecked()
@@ -184,28 +184,28 @@ def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
     txt = (
         "Minimum total acquisition time: 100.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt
 
     wdg.time_groupbox._timepoints_spinbox.setValue(3)
     txt = (
-        "Minimum total acquisition time: 300.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+        "Minimum total acquisition time: 302.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt
 
     wdg.time_groupbox._interval_spinbox.setValue(10)
     txt1 = (
-        "Minimum total acquisition time: 300.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+        "Minimum total acquisition time: 320.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt1
 
     wdg.time_groupbox._interval_spinbox.setValue(200)
     txt1 = (
-        "Minimum total acquisition time: 500.0000 ms.\n"
-        "Minimum acquisition time per timepoint: 100.0000 ms."
+        "Minimum total acquisition time: 700.0000 ms.\n"
+        "Minimum acquisition time(s) per timepoint: 100.0000 ms."
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt1
     assert not wdg.time_groupbox._warning_widget.isVisible()


### PR DESCRIPTION
This PR adds the possibility (enabled through a `QCheckBox`) to set the `z_offset`, `do_stack` and `acquire_every` options to every channel in the `ChannelTable`.

---
<img width="614" alt="Screenshot 2023-03-10 at 9 32 51 AM" src="https://user-images.githubusercontent.com/70725613/224342514-8f2d4d79-e0bb-4c67-91c8-2fcd0b10beb5.png">
