### PR TITLE
feat: add AutoRepeat to stage buttons

### DIFF
--- a/src/pymmcore_widgets/_stage_widget.py
+++ b/src/pymmcore_widgets/_stage_widget.py
@@ -132,6 +132,7 @@ class StageWidget(QWidget):
         self._btns.layout().setSpacing(0)
         for glpyh, (row, col, *_) in self.BTNS.items():
             btn = QPushButton()
+            btn.setAutoRepeat(True)
             btn.setFlat(True)
             btn.setFixedSize(self.BTN_SIZE, self.BTN_SIZE)
             btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)


### PR DESCRIPTION
This PR adds the `AutoRepeat` function to the to `StageWidget` `QPushButtons` so that you can keep the buttons pressed to move the stages.