### PR TITLE
fix: minor fix in PresetsWidget

### DIFF
--- a/src/pymmcore_widgets/_presets_widget.py
+++ b/src/pymmcore_widgets/_presets_widget.py
@@ -101,6 +101,8 @@ class PresetsWidget(QWidget):
         self._combo.setStyleSheet("")
 
     def _set_style_if_props_not_match_preset(self) -> None:
+        if not self._mmc.getAvailableConfigs(self._group):
+            return
         for preset in self._presets:
             _set_combo = True
             for dev, prop, value in self._mmc.getConfigData(self._group, preset):


### PR DESCRIPTION
This PR fixes an issue in the `PresetsWidget` that raises a `ValueError`.

Example:

With the current version, running the following code will generate a `ValueError`

```py
from pymmcore_widgets import PresetsWidget
from pymmcore_plus import CMMCorePlus

mmc = CMMCorePlus.instance()
mmc.loadSystemConfiguration()

p = PresetsWidget("Channel")

mmc.loadSystemConfiguration()
```

```
ValueError                                Traceback (most recent call last)
File ~/Library/CloudStorage/Dropbox/git/pymmcore-widgets/src/pymmcore_widgets/_presets_widget.py:155, in PresetsWidget._on_property_changed(self, device, property, value)
    153     if (device, "State") not in self.dev_prop:
    154         return
--> 155 self._set_style_if_props_not_match_preset()

File ~/Library/CloudStorage/Dropbox/git/pymmcore-widgets/src/pymmcore_widgets/_presets_widget.py:108, in PresetsWidget._set_style_if_props_not_match_preset(self)
    106 for preset in self._presets:
    107     _set_combo = True
--> 108     for dev, prop, value in self._mmc.getConfigData(self._group, preset):
    109         cache_value = self._mmc.getPropertyFromCache(dev, prop)
    110         if cache_value != value:

File ~/Library/CloudStorage/Dropbox/git/pymmcore-plus/src/pymmcore_plus/core/_mmcore_plus.py:361, in CMMCorePlus.getConfigData(self, configGroup, configName, native)
    352 def getConfigData(
    353     self, configGroup: str, configName: str, *, native: bool = False
    354 ) -> Configuration | pymmcore.Configuration:
    355     """Return the configuration object for a given `configGroup` and `configName`.
    356
    357     **Why Override?** The [`pymmcore_plus.Configuration`][] object returned
    358     when `native=False` (the default) provides a nicer `Mapping` interface. Pass
    359     `native=True` to get the original `pymmcore.Configuration` object.
    360     """
--> 361     cfg = super().getConfigData(configGroup, configName)
    362     return cfg if native else Configuration.from_configuration(cfg)

ValueError: Configuration group "Channel" or its preset "Cy5" does not exist
```


