### PR TITLE
fix: set the sequence fov size when generating the sequence + test

### DIFF
--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -235,6 +235,8 @@ class MDAWidget(QWidget):
             self.time_groupbox.value() if self.time_groupbox.isChecked() else None
         )
 
+        _, _, width, height = self._mmc.getROI()
+        fov = (width * self._mmc.getPixelSizeUm(), height * self._mmc.getPixelSizeUm())
         stage_positions: list[PositionDict] = []
         if self.position_groupbox.isChecked():
             for p in self.position_groupbox.value():
@@ -243,6 +245,7 @@ class MDAWidget(QWidget):
                     p_sequence = p_sequence.replace(
                         axis_order=self.buttons_wdg.acquisition_order_comboBox.currentText()
                     )
+                    p_sequence.set_fov_size(fov)
                     p["sequence"] = p_sequence
 
                 stage_positions.append(p)
@@ -250,13 +253,16 @@ class MDAWidget(QWidget):
         if not stage_positions:
             stage_positions = self._get_current_position()
 
-        return MDASequence(
+        sequence = MDASequence(
             axis_order=self.buttons_wdg.acquisition_order_comboBox.currentText(),
             channels=channels,
             stage_positions=stage_positions,
             z_plan=z_plan,
             time_plan=time_plan,
         )
+        sequence.set_fov_size(fov)
+
+        return sequence
 
     def _get_current_position(self) -> list[PositionDict]:
         return [

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -175,3 +175,33 @@ def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
         "\nMinimum acquisition time per timepoint: 100 ms"
     )
     assert wdg.time_lbl._total_time_lbl.text() == txt
+
+
+def test_grid_sequence_fov(qtbot: QtBot, global_mmcore: CMMCorePlus):
+    """Test that the FOV size is updated when creating the MDASequernce."""
+    wdg = MDAWidget(include_run_button=True)
+    qtbot.addWidget(wdg)
+    mmc = global_mmcore
+
+    sequence = MDASequence(
+        channels=[
+            {"config": "FITC", "exposure": 50},
+        ],
+        stage_positions=(
+            {
+                "name": "Pos000",
+                "x": 1,
+                "y": 2,
+                "z": 3,
+                "sequence": {"grid_plan": {"rows": 2, "columns": 2}},
+            },
+        ),
+    )
+
+    wdg.set_state(sequence)
+
+    assert wdg.get_state()._fov_size == (512.0, 512.0)
+    mmc.setProperty("Objective", "Label", "Nikon 20X Plan Fluor ELWD")
+    assert wdg.get_state()._fov_size == (256.0, 256.0)
+    pos_seq = wdg.get_state().stage_positions[0].sequence
+    assert pos_seq._fov_size == (256.0, 256.0)


### PR DESCRIPTION
This PR adds the FOV size (width, height) info to the `MDASequence` that we create through the `MDAWidget`. Without this info, the `grid plan` won't work because the FOV is considered to be (1, 1).

Should it be here? in pymmcore-plus?...not sure...