### PR TITLE
fix: remove redundant 'removeRow(row)' 

### DIFF
--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -303,8 +303,7 @@ class GroupPresetTableWidget(QGroupBox):
         msg = self._msg_box(f"Delete '{',  '.join(groups)}'?")
 
         if msg == QMessageBox.StandardButton.Ok:
-            for row, group in enumerate(groups):
-                self.table_wdg.removeRow(row)
+            for group in groups:
                 self._mmc.deleteConfigGroup(group)
 
     def _msg_box(self, msg: str) -> Any:
@@ -355,12 +354,12 @@ class GroupPresetTableWidget(QGroupBox):
             return
 
         groups_preset = [
-            (row, self.table_wdg.item(row, 0).text(), self.table_wdg.cellWidget(row, 1))
+            (self.table_wdg.item(row, 0).text(), self.table_wdg.cellWidget(row, 1))
             for row in sorted(selected_rows, reverse=True)
         ]
 
         _text = []
-        for _, group, wdg in groups_preset:
+        for group, wdg in groups_preset:
             if isinstance(wdg, PresetsWidget):
                 _text.append(f"({group},  {wdg._combo.currentText()})")
             else:
@@ -369,18 +368,16 @@ class GroupPresetTableWidget(QGroupBox):
         msg = self._msg_box(f"Delete '{',  '.join(_text)}'?")
 
         if msg == QMessageBox.StandardButton.Ok:
-            for row, group, wdg in groups_preset:
+            for group, wdg in groups_preset:
                 if isinstance(wdg, PresetsWidget):
                     preset = wdg._combo.currentText()
 
                     if len(wdg.allowedValues()) > 1:
                         self._mmc.deleteConfig(group, preset)
                     else:
-                        self.table_wdg.removeRow(row)
                         self._mmc.deleteConfigGroup(group)
 
                 elif isinstance(wdg, PropertyWidget):
-                    self.table_wdg.removeRow(row)
                     self._mmc.deleteConfigGroup(group)
 
     def _edit_preset(self) -> None:

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -187,7 +187,9 @@ def test_delete_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     groups_in_table = [
         gp.table_wdg.item(r, 0).text() for r in range(gp.table_wdg.rowCount())
     ]
+
     assert "Camera" not in groups_in_table
+    assert gp.table_wdg.rowCount() == 8
 
 
 def test_add_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):


### PR DESCRIPTION
Remove redundant `removeRow(row)` in `_delete_group` and `_delete_preset` methods and only calling `_mmc.deleteConfigGroup(group)` is sufficient.