### PR TITLE
fix: fix snap button shutter signal

### DIFF
--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -100,20 +100,18 @@ class SnapButton(QPushButton):
             _is_multiShutter = bool([x for x in props if "Physical Shutter" in x])
             autoshutter = self._mmc.getAutoShutter()
             if autoshutter:
+                self._mmc.events.propertyChanged.emit(
+                    self._mmc.getShutterDevice(), "State", True
+                )
                 if _is_multiShutter:
                     self._update_multishutter(True)
-                else:
-                    self._mmc.events.propertyChanged.emit(
-                        self._mmc.getShutterDevice(), "State", True
-                    )
             self._mmc.snap()
             if autoshutter:
+                self._mmc.events.propertyChanged.emit(
+                    self._mmc.getShutterDevice(), "State", False
+                )
                 if _is_multiShutter:
                     self._update_multishutter(False)
-                else:
-                    self._mmc.events.propertyChanged.emit(
-                        self._mmc.getShutterDevice(), "State", False
-                    )
 
         create_worker(snap_with_shutter, _start_thread=True)
 


### PR DESCRIPTION
When using the `SnapButton` widget, signals are emitted to open and close the shutters included in the channel config. This PR add and fix this behavior in case the shutter is a micromanager `Multi Shutter` device.