### PR TITLE
fix: minor time widget fix

### DIFF
--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -156,7 +156,11 @@ class TimePlanWidget(QWidget):
         loops: int | None = None,
     ) -> None:
         """Create a new row in the table."""
-        val, u = (interval.total_seconds(), "s") if interval is not None else (1, "s")
+        val, u = (
+            (interval.total_seconds(), "s")
+            if isinstance(interval, timedelta)
+            else (1, "s")
+        )
         quant_wdg = QQuantity(val, u)
         mag_spin = cast("QDoubleSpinBox", getattr(quant_wdg, "_mag_spinbox", None))
         if mag_spin is None:

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -156,7 +156,7 @@ class TimePlanWidget(QWidget):
         loops: int | None = None,
     ) -> None:
         """Create a new row in the table."""
-        val, u = (interval.total_seconds(), "s") if interval else (1, "s")
+        val, u = (interval.total_seconds(), "s") if interval is not None else (1, "s")
         quant_wdg = QQuantity(val, u)
         mag_spin = cast("QDoubleSpinBox", getattr(quant_wdg, "_mag_spinbox", None))
         if mag_spin is None:


### PR DESCRIPTION
Fixing the `_create_new_row` method in `TimePlanWidget` so that we can pass `0.0` as a possible `interval`: adding `if isinstance(interval, timedelta)` instead of only `if interval`.


