### PR TITLE
test: add test for core state modification

### DIFF
--- a/tests/test_core_state.py
+++ b/tests/test_core_state.py
@@ -38,16 +38,22 @@ ALL_WIDGETS: dict[type[QWidget], dict[str, Any]] = {
 }
 
 
+def _full_state(core: CMMCorePlus) -> dict:
+    state: dict = dict(core.state())
+    state.pop("Datetime", None)
+    for prop in core.iterProperties():
+        state[(prop.device, prop.name)] = prop.value
+    return state
+
+
 @pytest.mark.parametrize("widget", ALL_WIDGETS, ids=lambda x: x.__name__)
 def test_core_state_unchanged(
     global_mmcore: CMMCorePlus, widget: type[QWidget], qapp: Any
 ) -> None:
-    before = global_mmcore.state()
+    before = _full_state(global_mmcore)
     kwargs = {**ALL_WIDGETS[widget]}
     widget(**kwargs)
-    after = global_mmcore.state()
-    before.pop("Datetime", None)
-    after.pop("Datetime", None)
+    after = _full_state(global_mmcore)
     assert before == after
 
 

--- a/tests/test_core_state.py
+++ b/tests/test_core_state.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QWidget
+
+import pymmcore_widgets as pmmw
+
+ALL_WIDGETS: dict[type[QWidget], dict[str, Any]] = {
+    pmmw.CameraRoiWidget: {},
+    pmmw.ChannelGroupWidget: {},
+    pmmw.ChannelTable: {},
+    pmmw.ChannelWidget: {},
+    pmmw.ConfigurationWidget: {},
+    pmmw.DefaultCameraExposureWidget: {},
+    pmmw.DeviceWidget: {"device_label": "Camera"},
+    pmmw.ExposureWidget: {},
+    pmmw.GridWidget: {},
+    pmmw.GroupPresetTableWidget: {},
+    pmmw.ImagePreview: {},
+    pmmw.LiveButton: {},
+    pmmw.MDAWidget: {},
+    pmmw.ObjectivesWidget: {},
+    pmmw.PixelSizeWidget: {},
+    pmmw.PositionTable: {},
+    pmmw.PresetsWidget: {"group": "Camera"},
+    pmmw.PropertiesWidget: {},
+    pmmw.PropertyBrowser: {},
+    pmmw.PropertyWidget: {"device_label": "Camera", "prop_name": "Binning"},
+    pmmw.ShuttersWidget: {"shutter_device": "Shutter"},
+    pmmw.SnapButton: {},
+    pmmw.StageWidget: {"device": "XY"},
+    pmmw.StateDeviceWidget: {"device_label": "Objective"},
+    pmmw.TimePlanWidget: {},
+    pmmw.ZStackWidget: {},
+}
+
+
+@pytest.mark.parametrize("widget", ALL_WIDGETS, ids=lambda x: x.__name__)
+def test_core_state_unchanged(
+    global_mmcore: CMMCorePlus, widget: type[QWidget], qapp: Any
+) -> None:
+    before = global_mmcore.state()
+    kwargs = {**ALL_WIDGETS[widget]}
+    widget(**kwargs)
+    after = global_mmcore.state()
+    before.pop("Datetime", None)
+    after.pop("Datetime", None)
+    assert before == after
+
+
+def test_all_widgets_represented() -> None:
+    missing_widgets = {cls.__name__ for cls in ALL_WIDGETS}.difference(pmmw.__all__)
+    if missing_widgets:
+        raise AssertionError(
+            f"Some widgets are missing from the ALL_WIDGETS test dict: "
+            f"{missing_widgets}"
+        )

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -111,7 +111,8 @@ def test_mda_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
     wdg.z_cbox.setChecked(True)
     wdg.t_cbox.setChecked(True)
 
-    wdg._on_mda_started()
+    seq = MDASequence()
+    global_mmcore.mda.events.sequenceStarted.emit(seq)
     assert not wdg.time_widget.isEnabled()
     assert not wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
     assert not wdg.channel_widget.isEnabled()
@@ -122,7 +123,7 @@ def test_mda_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert not wdg.buttons_wdg.pause_button.isHidden()
     assert not wdg.buttons_wdg.cancel_button.isHidden()
 
-    wdg._on_mda_finished()
+    global_mmcore.mda.events.sequenceFinished.emit(seq)
     assert wdg.time_widget.isEnabled()
     assert wdg.buttons_wdg.acquisition_order_comboBox.isEnabled()
     assert not wdg.channel_widget.isEnabled()


### PR DESCRIPTION
closes #122

It's possible we're missing some deeper property that gets changed in core, but this PR at leasts makes a place to add those tests