### PR TITLE
perf: Improve speed of mda widget

### DIFF
--- a/src/pymmcore_widgets/_mda/_channel_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_channel_table_widget.py
@@ -224,6 +224,7 @@ class ChannelTable(QWidget):
         dspinbox.setRange(*range)
         dspinbox.setAlignment(Qt.AlignCenter)
         dspinbox.wheelEvent = lambda event: None  # block mouse scroll
+        dspinbox.setKeyboardTracking(False)
         dspinbox.valueChanged.connect(self.valueChanged)
         return dspinbox
 

--- a/src/pymmcore_widgets/_mda/_channel_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_channel_table_widget.py
@@ -354,9 +354,9 @@ class ChannelTable(QWidget):
             A list of dictionaries following the [useq-schema Channel specifications](
             https://pymmcore-plus.github.io/useq-schema/schema/axes/#useq.Channel).
         """
-        self.clear()
         _advanced_bool = False
         with signals_blocked(self):
+            self.clear()
             for channel in channels:
                 ch = channel.get("config")
                 group = channel.get("group")

--- a/src/pymmcore_widgets/_mda/_grid_widget.py
+++ b/src/pymmcore_widgets/_mda/_grid_widget.py
@@ -24,6 +24,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt.utils import signals_blocked
 from useq import AnyGridPlan, GridFromEdges, GridRelative
 from useq._grid import OrderMode, RelativeTo
 
@@ -738,14 +739,16 @@ class GridWidget(QWidget):
 
     def set_state(self, grid: dict | AnyGridPlan) -> None:
         """Set the state of the widget from a useq AnyGridPlan or dictionary."""
-        grid_plan = get_grid_type(grid) if isinstance(grid, dict) else grid
+        with signals_blocked(self):
+            grid_plan = get_grid_type(grid) if isinstance(grid, dict) else grid
 
-        self.overlap_and_mode.setValue(grid_plan.dict())  # type: ignore
-        self.tab.setValue(grid_plan.dict())  # type: ignore
-        self.tab.setCurrentIndex(0) if isinstance(
-            grid_plan, GridRelative
-        ) else self.tab.setCurrentIndex(1)
-        self._update_info()
+            self.overlap_and_mode.setValue(grid_plan.dict())  # type: ignore
+            self.tab.setValue(grid_plan.dict())  # type: ignore
+            self.tab.setCurrentIndex(0) if isinstance(
+                grid_plan, GridRelative
+            ) else self.tab.setCurrentIndex(1)
+            self._update_info()
+        self.valueChanged.emit(self.value())
 
     def _emit_grid_positions(self) -> None:
         """Emit the grid positions if the pixel size is set."""

--- a/src/pymmcore_widgets/_mda/_grid_widget.py
+++ b/src/pymmcore_widgets/_mda/_grid_widget.py
@@ -156,6 +156,7 @@ class _RowsColsWdg(QWidget):
         spin = QSpinBox()
         spin.setMinimum(1)
         spin.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        spin.setKeyboardTracking(False)
         spin.valueChanged.connect(lambda: self.valueChanged.emit())
         layout.addWidget(label)
         layout.addWidget(spin)
@@ -364,6 +365,7 @@ class _DoubleSpinboxWidget(QWidget):
         spin.setMinimum(-1000000)
         spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
         spin.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        spin.setKeyboardTracking(False)
         spin.valueChanged.connect(lambda: self.valueChanged.emit())
         return spin
 
@@ -442,6 +444,7 @@ class _OverlapAndOrderModeWdg(QGroupBox):
         spin.setMinimumWidth(100)
         spin.setMaximum(100)
         spin.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        spin.setKeyboardTracking(False)
         spin.valueChanged.connect(lambda: self.valueChanged.emit())
         return spin
 

--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -308,6 +308,9 @@ class MDAWidget(QWidget):
             MDASequence state in the form of a dict, MDASequence object, or a str or
             Path pointing to a sequence.yaml file
         """
+        # TODO: prevent _update_total_time from being called until
+        # all subcomponents have been set
+
         # sourcery skip: low-code-quality
         if isinstance(state, (str, Path)):
             state = MDASequence.parse_file(state)

--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -486,13 +486,14 @@ class MDAWidget(QWidget):
         total_time: float = 0.0
         _per_timepoints: dict[int, float] = {}
         t_per_tp_msg = ""
+        _uses_time = self._uses_time()
 
         for e in self.get_state():
             if e.exposure is None:
                 continue
 
             total_time = total_time + (e.exposure / 1000)
-            if self._uses_time():
+            if _uses_time:
                 _t = e.index["t"]
                 _exp = e.exposure / 1000
                 _per_timepoints[_t] = _per_timepoints.get(_t, 0) + _exp

--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -465,7 +465,7 @@ class MDAWidget(QWidget):
 
     def _uses_time(self) -> bool:
         """Hacky method to check whether the timebox is selected with any timepoints."""
-        has_phases = self.time_widget.value()["phases"]  # type: ignore
+        has_phases = self.time_widget._table.rowCount()
         return bool(self.t_cbox.isChecked() and has_phases)
 
     def _update_total_time(self) -> None:

--- a/src/pymmcore_widgets/_mda/_positions_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_positions_table_widget.py
@@ -277,6 +277,7 @@ class PositionTable(QWidget):
         spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
         spin.setValue(value)
         spin.wheelEvent = lambda event: None  # block mouse scroll
+        spin.setKeyboardTracking(False)
         self._table.setCellWidget(row, col, spin)
 
     def _add_grid_buttons(self, row: int | None, col: int | None) -> None:

--- a/src/pymmcore_widgets/_mda/_positions_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_positions_table_widget.py
@@ -538,35 +538,35 @@ class PositionTable(QWidget):
             By default True. If True, the current positions list is cleared before the
             specified one is added.
         """
-        if clear:
-            self.clear()
-
         if not isinstance(positions, Sequence):
             raise TypeError("The 'positions' arguments has to be a 'Sequence'.")
 
         if not self._mmc.getXYStageDevice() and not self._mmc.getFocusDevice():
             raise ValueError("No XY and Z Stage devices loaded.")
 
-        for position in positions:
-            if isinstance(position, Position):
-                position = cast("PositionDict", position.dict())
+        with signals_blocked(self):
+            if clear:
+                self.clear()
+            for position in positions:
+                if isinstance(position, Position):
+                    position = cast("PositionDict", position.dict())
 
-            if not isinstance(position, dict):
-                continue
+                if not isinstance(position, dict):
+                    continue
 
-            name = position.get("name")
-            x, y, z = (position.get("x"), position.get("y"), position.get("z"))
-            self._add_table_row(name or f"{POS}000", x, y, z)
-            if pos_seq := position.get("sequence"):
-                self._advanced_cbox.setChecked(True)
-                if isinstance(pos_seq, MDASequence):
-                    grid_plan = pos_seq.grid_plan.dict()
-                else:
-                    grid_plan = pos_seq.get("grid_plan")
-                if grid_plan:
-                    self._add_grid_plan(grid_plan, self._table.rowCount() - 1)
+                name = position.get("name")
+                x, y, z = (position.get("x"), position.get("y"), position.get("z"))
+                self._add_table_row(name or f"{POS}000", x, y, z)
+                if pos_seq := position.get("sequence"):
+                    self._advanced_cbox.setChecked(True)
+                    if isinstance(pos_seq, MDASequence):
+                        grid_plan = pos_seq.grid_plan.dict()
+                    else:
+                        grid_plan = pos_seq.get("grid_plan")
+                    if grid_plan:
+                        self._add_grid_plan(grid_plan, self._table.rowCount() - 1)
 
-            self.valueChanged.emit()
+        self.valueChanged.emit()
 
     def _save_positions(self) -> None:
         if not self._table.rowCount() or not self.value():

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -271,9 +271,11 @@ class TimePlanWidget(QWidget):
         with signals_blocked(self):
             for phase in phases:
                 if not isinstance(phase, TIntervalLoops):
-                    raise ValueError("Time dicts must have both 'interval' and 'loops'.")
+                    raise ValueError(
+                        "Time dicts must have both 'interval' and 'loops'."
+                    )
                 self._create_new_row(interval=phase.interval, loops=phase.loops)
-        self.valueChanged()
+        self.valueChanged.emit()
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._clear)

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -271,13 +271,12 @@ class TimePlanWidget(QWidget):
         with signals_blocked(self):
             self._clear()
             phases = tp.phases if isinstance(tp, MultiPhaseTimePlan) else [tp]
-            with signals_blocked(self):
-                for phase in phases:
-                    if not isinstance(phase, TIntervalLoops):
-                        raise ValueError(
-                            "Time dicts must have both 'interval' and 'loops'."
-                        )
-                    self._create_new_row(interval=phase.interval, loops=phase.loops)
+            for phase in phases:
+                if not isinstance(phase, TIntervalLoops):
+                    raise ValueError(
+                        "Time dicts must have both 'interval' and 'loops'."
+                    )
+                self._create_new_row(interval=phase.interval, loops=phase.loops)
         self.valueChanged.emit()
 
     def _disconnect(self) -> None:

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from superqt import QQuantity, fonticon
+from superqt.utils import signals_blocked
 from useq import MDASequence, MultiPhaseTimePlan, TIntervalLoops
 
 if TYPE_CHECKING:
@@ -267,10 +268,12 @@ class TimePlanWidget(QWidget):
         if tp is None:
             return
         phases = tp.phases if isinstance(tp, MultiPhaseTimePlan) else [tp]
-        for phase in phases:
-            if not isinstance(phase, TIntervalLoops):
-                raise ValueError("Time dicts must have both 'interval' and 'loops'.")
-            self._create_new_row(interval=phase.interval, loops=phase.loops)
+        with signals_blocked(self):
+            for phase in phases:
+                if not isinstance(phase, TIntervalLoops):
+                    raise ValueError("Time dicts must have both 'interval' and 'loops'.")
+                self._create_new_row(interval=phase.interval, loops=phase.loops)
+        self.valueChanged()
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(self._clear)

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -181,6 +181,7 @@ class TimePlanWidget(QWidget):
         time_spin.setValue(loops or 1)
         time_spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
         time_spin.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        time_spin.setKeyboardTracking(False)
         time_spin.valueChanged.connect(self.valueChanged)
 
         idx = self._table.rowCount()

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -263,19 +263,20 @@ class TimePlanWidget(QWidget):
             ) `interval` key is not a `timedelta` object, it will be converted to a
             timedelta object and will be considered as expressed in seconds.
         """
-        self._clear()
-
         tp = MDASequence(time_plan=t_plan).time_plan
         if tp is None:
+            # should we raise/warn here?
             return
-        phases = tp.phases if isinstance(tp, MultiPhaseTimePlan) else [tp]
         with signals_blocked(self):
-            for phase in phases:
-                if not isinstance(phase, TIntervalLoops):
-                    raise ValueError(
-                        "Time dicts must have both 'interval' and 'loops'."
-                    )
-                self._create_new_row(interval=phase.interval, loops=phase.loops)
+            self._clear()
+            phases = tp.phases if isinstance(tp, MultiPhaseTimePlan) else [tp]
+            with signals_blocked(self):
+                for phase in phases:
+                    if not isinstance(phase, TIntervalLoops):
+                        raise ValueError(
+                            "Time dicts must have both 'interval' and 'loops'."
+                        )
+                    self._create_new_row(interval=phase.interval, loops=phase.loops)
         self.valueChanged.emit()
 
     def _disconnect(self) -> None:

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -173,6 +173,7 @@ class TimePlanWidget(QWidget):
         mag_spin.wheelEvent = lambda event: None
         mag_spin.setAlignment(Qt.AlignmentFlag.AlignCenter)
         mag_spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        mag_spin.setKeyboardTracking(False)
         quant_wdg.valueChanged.connect(self.valueChanged)
 
         time_spin = QSpinBox()

--- a/src/pymmcore_widgets/_mda/_zstack_widget.py
+++ b/src/pymmcore_widgets/_mda/_zstack_widget.py
@@ -56,12 +56,14 @@ class ZTopBottomSelect(QWidget):
         self._top_spinbox = QDoubleSpinBox()
         self._top_spinbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._top_spinbox.setRange(self._MIN_Z, self._MAX_Z)
+        self._top_spinbox.setKeyboardTracking(False)
         self._top_spinbox.valueChanged.connect(self._update_zrange_and_emit)
 
         # current bottom position spinbox
         self._bottom_spinbox = QDoubleSpinBox()
         self._bottom_spinbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._bottom_spinbox.setRange(self._MIN_Z, self._MAX_Z)
+        self._bottom_spinbox.setKeyboardTracking(False)
         self._bottom_spinbox.valueChanged.connect(self._update_zrange_and_emit)
 
         # read only z range spinbox
@@ -69,6 +71,7 @@ class ZTopBottomSelect(QWidget):
         self._zrange_spinbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._zrange_spinbox.setMaximum(self._MAX_Z - self._MIN_Z)
         self._zrange_spinbox.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self._zrange_spinbox.setKeyboardTracking(False)
         self._zrange_spinbox.setReadOnly(True)
 
         grid = QGridLayout()
@@ -258,6 +261,7 @@ class ZStackWidget(QWidget):
         self._zstep_spinbox.setMinimum(0.05)
         self._zstep_spinbox.setMaximum(self._MAX_STEP)
         self._zstep_spinbox.setSingleStep(0.1)
+        self._zstep_spinbox.setKeyboardTracking(False)
         self._zstep_spinbox.valueChanged.connect(self._update_and_emit)
 
         # readout for the number of images

--- a/src/pymmcore_widgets/_mda/_zstack_widget.py
+++ b/src/pymmcore_widgets/_mda/_zstack_widget.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from superqt.utils import signals_blocked
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -321,20 +322,22 @@ class ZStackWidget(QWidget):
         """
         tabs = self._zmode_tabs
         wdg: ZPicker
-        if "top" in z_plan and "bottom" in z_plan:
-            wdg = cast(ZTopBottomSelect, tabs.findChild(ZTopBottomSelect))
-            wdg._top_spinbox.setValue(z_plan["top"])
-            wdg._bottom_spinbox.setValue(z_plan["bottom"])
-            tabs.setCurrentWidget(wdg)
-        elif "above" in z_plan and "below" in z_plan:
-            wdg = cast(ZAboveBelowSelect, tabs.findChild(ZAboveBelowSelect))
-            wdg._above_spinbox.setValue(z_plan["above"])
-            wdg._below_spinbox.setValue(z_plan["below"])
-            tabs.setCurrentWidget(wdg)
-        elif "range" in z_plan:
-            wdg = cast(ZRangeAroundSelect, tabs.findChild(ZRangeAroundSelect))
-            wdg._zrange_spinbox.setValue(z_plan["range"])
-            tabs.setCurrentWidget(wdg)
+        with signals_blocked(self):
+            if "top" in z_plan and "bottom" in z_plan:
+                wdg = cast(ZTopBottomSelect, tabs.findChild(ZTopBottomSelect))
+                wdg._top_spinbox.setValue(z_plan["top"])
+                wdg._bottom_spinbox.setValue(z_plan["bottom"])
+                tabs.setCurrentWidget(wdg)
+            elif "above" in z_plan and "below" in z_plan:
+                wdg = cast(ZAboveBelowSelect, tabs.findChild(ZAboveBelowSelect))
+                wdg._above_spinbox.setValue(z_plan["above"])
+                wdg._below_spinbox.setValue(z_plan["below"])
+                tabs.setCurrentWidget(wdg)
+            elif "range" in z_plan:
+                wdg = cast(ZRangeAroundSelect, tabs.findChild(ZRangeAroundSelect))
+                wdg._zrange_spinbox.setValue(z_plan["range"])
+                tabs.setCurrentWidget(wdg)
 
-        if "step" in z_plan:
-            self._zstep_spinbox.setValue(z_plan["step"])
+            if "step" in z_plan:
+                self._zstep_spinbox.setValue(z_plan["step"])
+        self.valueChanged.emit(self.value())

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QFileDialog
@@ -66,7 +66,19 @@ def test_mda_widget_load_state(qtbot: QtBot):
             "overlap": (0.0, 0.0),
         },
     )
+    mocks = []
+    for subcomponent in [
+        wdg.time_widget,
+        wdg.stack_widget,
+        wdg.position_widget,
+        wdg.channel_widget,
+        wdg.grid_widget,
+    ]:
+        mocks.append(MagicMock())
+        subcomponent.valueChanged.connect(mocks[-1])
     wdg.set_state(sequence)
+    for mock in mocks:
+        mock.assert_called_once()
     assert wdg.position_widget._table.rowCount() == 3
     assert wdg.channel_widget._table.rowCount() == 2
     assert wdg.t_cbox.isChecked()


### PR DESCRIPTION
This brings significant speed ups (e.g. 1 min -> 7 seconds) to the mda widget and some of it's subcomponents. The most significant thing I was running into as a user was that we were having the UI freeze as we tried to type out larger numbers for timepoints. This even resulted in us having to close everything and restart at least once. This was caused by slowness in the min total time calculation, and it being called over and over as we typed into the spinbox.