### PR TITLE
fix: don't calculate time before subclasses have been inited

### DIFF
--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -17,7 +17,7 @@ from qtpy.QtWidgets import (
 )
 from useq import MDASequence
 
-from .._util import fmt_timedelta, guess_channel_group
+from .._util import fmt_timedelta
 from ._channel_table_widget import ChannelTable
 from ._checkable_tabwidget_widget import CheckableTabWidget
 from ._general_mda_widgets import (
@@ -213,10 +213,7 @@ class MDAWidget(QWidget):
         self.destroyed.connect(self._disconnect)
 
     def _on_sys_cfg_loaded(self) -> None:
-        if channel_group := self._mmc.getChannelGroup() or guess_channel_group():
-            self._mmc.setChannelGroup(channel_group)
         self._enable_run_btn()
-        self._update_total_time()
 
     def _on_config_set(self, group: str, preset: str) -> None:
         if group != self._mmc.getChannelGroup():


### PR DESCRIPTION
This fixes the bug that lead to #158. 

this was causing the calc time function to be called before subclasses finished their `init` which could lead to errors. It's also not obvious that we need to call this every time the config is reloaded.


I also removed the setting of the channel group as I'm pretty sure that that does not belong this deep in a widget, and it also seems to violate the spirit of https://github.com/pymmcore-plus/pymmcore-widgets/issues/122. But @fdrgsp I would really appreciate you taking a look to make sure I'm not messing up something else somewhere by removing that.