### PR TITLE
fix: convert MDAWidget and ChannelWidget exposure in seconds

### DIFF
--- a/src/pymmcore_widgets/_mda/_channel_table_widget.py
+++ b/src/pymmcore_widgets/_mda/_channel_table_widget.py
@@ -330,7 +330,8 @@ class ChannelTable(QWidget):
                         "group": name_widget.itemData(
                             name_widget.currentIndex(), self.CH_GROUP_ROLE
                         ),
-                        "exposure": exposure_widget.value(),
+                        "exposure": exposure_widget.value()
+                        / 1000,  # convert to seconds
                         # NOTE: the columns representing these values *may* be hidden
                         # ... but we are still using them
                         "z_offset": (
@@ -375,7 +376,11 @@ class ChannelTable(QWidget):
                     )
                     continue
 
-                exposure = channel.get("exposure") or self._mmc.getExposure()
+                # exposure input is in seconds so we convert it in millisecond since
+                # the channel table exposure is in milliseconds. self._mmc.getExposure()
+                # is instead already in ms.
+                _exp = channel.get("exposure")
+                exposure = _exp * 1000 if _exp is not None else self._mmc.getExposure()
                 z_offset = channel.get("z_offset") or 0.0
                 do_stack = channel["do_stack"] if "do_stack" in channel else True
                 acquire_every = channel.get("acquire_every") or 1

--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -356,7 +356,7 @@ class MDAWidget(QWidget):
                 {
                     "config": self._mmc.getCurrentConfig(self._mmc.getChannelGroup()),
                     "group": self._mmc.getChannelGroup(),
-                    "exposure": self._mmc.getExposure(),
+                    "exposure": self._mmc.getExposure() / 1000,  # convert to seconds
                     "z_offset": 0.0,
                     "do_stack": True,
                     "acquire_every": 1,
@@ -495,10 +495,10 @@ class MDAWidget(QWidget):
             if e.exposure is None:
                 continue
 
-            total_time = total_time + (e.exposure / 1000)
+            total_time = total_time + e.exposure
             if _uses_time:
                 _t = e.index["t"]
-                _exp = e.exposure / 1000
+                _exp = e.exposure
                 _per_timepoints[_t] = _per_timepoints.get(_t, 0) + _exp
 
         if _per_timepoints:
@@ -515,7 +515,7 @@ class MDAWidget(QWidget):
 
             # check if the interval(s) is smaller than the sum of the exposure times
             sum_ch_exp = sum(
-                (c["exposure"] / 1000)
+                c["exposure"]
                 for c in self.channel_widget.value()
                 if c["exposure"] is not None
             )

--- a/tests/test_channel_table_widget.py
+++ b/tests/test_channel_table_widget.py
@@ -65,7 +65,7 @@ def test_set_get_state(qtbot: QtBot):
         {
             "config": "Cy5",
             "group": "Channel",
-            "exposure": 100.0,
+            "exposure": 0.1,
             "z_offset": 0.0,
             "do_stack": True,
             "acquire_every": 1,
@@ -73,7 +73,7 @@ def test_set_get_state(qtbot: QtBot):
         {
             "config": "DAPI",
             "group": "Channel",
-            "exposure": 100.0,
+            "exposure": 0.1,
             "z_offset": 10.0,
             "do_stack": True,
             "acquire_every": 1,
@@ -81,7 +81,7 @@ def test_set_get_state(qtbot: QtBot):
         {
             "config": "HighRes",
             "group": "Camera",
-            "exposure": 100.0,
+            "exposure": 0.1,
             "z_offset": 0.0,
             "do_stack": False,
             "acquire_every": 1,
@@ -89,7 +89,7 @@ def test_set_get_state(qtbot: QtBot):
         {
             "config": "Cy5",
             "group": "Channel",
-            "exposure": 100.0,
+            "exposure": 0.1,
             "z_offset": 0.0,
             "do_stack": True,
             "acquire_every": 2,

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -35,8 +35,8 @@ def test_mda_widget_load_state(qtbot: QtBot):
 
     sequence = MDASequence(
         channels=[
-            {"config": "Cy5", "exposure": 20},
-            {"config": "FITC", "exposure": 50},
+            {"config": "Cy5", "exposure": 0.2},
+            {"config": "FITC", "exposure": 0.5},
         ],
         time_plan={"phases": [{"interval": 2, "loops": 5}]},
         z_plan={"range": 4, "step": 0.5},
@@ -308,10 +308,10 @@ def test_save_and_load_sequence(qtbot: QtBot):
                     },
                 ],
                 channels=[
-                    {"config": "Cy5", "exposure": 50},
+                    {"config": "Cy5", "exposure": 0.5},
                     {
                         "config": "DAPI",
-                        "exposure": 100.0,
+                        "exposure": 0.1,
                         "do_stack": False,
                         "acquire_every": 3,
                     },


### PR DESCRIPTION
In [useq.MDAEvents](https://pymmcore-plus.github.io/useq-schema/schema/event/#event) and [useq.Channel](https://pymmcore-plus.github.io/useq-schema/schema/axes/#useq.Channel), the exposure time  unit is seconds. The `MDAWidget` and the `ChannelWidget` currently use milliseconds. This PR make the widgets return an exposure time values in seconds.