### PR TITLE
refactor: remove time estimates from MDAWidget

### DIFF
--- a/src/pymmcore_widgets/_mda/_general_mda_widgets.py
+++ b/src/pymmcore_widgets/_mda/_general_mda_widgets.py
@@ -109,24 +109,6 @@ class _AcquisitionOrderWidget(QWidget):
         acq_wdg_layout.addWidget(self.acquisition_order_comboBox)
 
 
-class _MDATimeLabel(QWidget):
-    def __init__(self, *, parent: QWidget | None = None) -> None:
-        super().__init__(parent=parent)
-
-        wdg_lay = QHBoxLayout()
-        wdg_lay.setSpacing(5)
-        wdg_lay.setContentsMargins(10, 5, 10, 5)
-        wdg_lay.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self.setLayout(wdg_lay)
-
-        self._total_time_lbl = QLabel()
-        self._total_time_lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._total_time_lbl.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
-        wdg_lay.addWidget(self._total_time_lbl)
-
-
 class _SaveLoadSequenceWidget(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)

--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -18,14 +17,11 @@ from qtpy.QtWidgets import (
 )
 from useq import MDASequence
 
-from pymmcore_widgets._util import fmt_timedelta
-
 from ._channel_table_widget import ChannelTable
 from ._checkable_tabwidget_widget import CheckableTabWidget
 from ._general_mda_widgets import (
     _AcquisitionOrderWidget,
     _MDAControlButtons,
-    _MDATimeLabel,
     _SaveLoadSequenceWidget,
 )
 from ._grid_widget import GridWidget
@@ -118,7 +114,6 @@ class MDAWidget(QWidget):
         self.stack_widget.setFixedHeight(self.stack_widget.minimumSizeHint().height())
         self.position_widget = PositionTable()
         self.grid_widget = Grid()
-        self.grid_widget.valueChanged.connect(self._update_total_time)
         self.grid_widget.layout().itemAt(
             self.grid_widget.layout().count() - 1
         ).widget().hide()  # hide add grid button
@@ -141,9 +136,6 @@ class MDAWidget(QWidget):
         self.p_cbox = self._get_checkbox(2)
         self.t_cbox = self._get_checkbox(3)
         self.g_cbox = self._get_checkbox(4)
-
-        # info time label and buttons widgets
-        self.time_lbl = _MDATimeLabel()
 
         # savle load widget
         self._save_load = _SaveLoadSequenceWidget()
@@ -170,46 +162,28 @@ class MDAWidget(QWidget):
         self.layout().setSpacing(10)
         self.layout().setContentsMargins(10, 10, 10, 10)
         self.layout().addWidget(scroll)
-        self.layout().addWidget(self.time_lbl)
         self.layout().addLayout(acq_order_run_layout)
 
         # CONNECTIONS
-        # connect tabs changed signal
         self._tab.currentChanged.connect(self._on_tab_changed)
-        # connect Channels, Time, Z Stack, Positions and Grid widgets
         self.channel_widget.valueChanged.connect(self._enable_run_btn)
-        self.channel_widget.valueChanged.connect(self._update_total_time)
-        self.channel_widget._advanced_cbox.toggled.connect(self._update_total_time)
-        self.time_widget.valueChanged.connect(self._update_total_time)
-        self.stack_widget.valueChanged.connect(self._update_total_time)
-        self.position_widget._advanced_cbox.toggled.connect(self._update_total_time)
-        self.position_widget.valueChanged.connect(self._update_total_time)
         # below not using lambda with position_widget below because it would cause
         # problems in closing the widget (see conftest _run_after_each_test fixture)
         self.position_widget.valueChanged.connect(self._on_positions_tab_changed)
-        # connect tab checkboxes
         self.ch_cbox.toggled.connect(self._enable_run_btn)
-        self.ch_cbox.toggled.connect(self._update_total_time)
-        self.z_cbox.toggled.connect(self._update_total_time)
-        self.t_cbox.toggled.connect(self._update_total_time)
-        self.p_cbox.toggled.connect(self._update_total_time)
         # not using lambda with p_cbox below because it would cause problems in closing
         # the widget (see conftest _run_after_each_test fixture)
         self.p_cbox.toggled.connect(self._on_positions_tab_changed)
-        self.g_cbox.toggled.connect(self._update_total_time)
-        # connect mmcore signals
         self._mmc.mda.events.sequenceStarted.connect(self._on_mda_started)
         self._mmc.mda.events.sequenceFinished.connect(self._on_mda_finished)
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_cfg_loaded)
         self._mmc.events.configSet.connect(self._on_config_set)
         self._mmc.events.configGroupChanged.connect(self._on_config_set)
         self._mmc.events.channelGroupChanged.connect(self._enable_run_btn)
-        # connect run button
         if self._include_run_button:
             self.buttons_wdg = _MDAControlButtons()
             self.buttons_wdg.run_button.clicked.connect(self._on_run_clicked)
             self.buttons_wdg.run_button.show()
-            # connect buttons
             self.buttons_wdg.pause_button.released.connect(self._mmc.mda.toggle_pause)
             self.buttons_wdg.cancel_button.released.connect(self._mmc.mda.cancel)
             acq_order_run_layout.addWidget(self.buttons_wdg)
@@ -293,9 +267,6 @@ class MDAWidget(QWidget):
             MDASequence state in the form of a dict, MDASequence object, or a str or
             Path pointing to a sequence.yaml file
         """
-        # TODO: prevent _update_total_time from being called until
-        # all subcomponents have been set
-
         # sourcery skip: low-code-quality
         if isinstance(state, (str, Path)):
             state = MDASequence.parse_file(state)
@@ -459,8 +430,6 @@ class MDAWidget(QWidget):
         """Hide the warning if the time groupbox is unchecked."""
         if not checked and self.time_widget._warning_widget.isVisible():
             self.time_widget.setWarningVisible(False)
-        else:
-            self._update_total_time()
 
     def _uses_time(self) -> bool:
         """Hacky method to check whether the timebox is selected with any timepoints."""
@@ -469,94 +438,6 @@ class MDAWidget(QWidget):
 
     def _uses_autofocus(self) -> bool:
         return bool(self.p_cbox.isChecked() and self.position_widget._use_af())
-
-    def _update_total_time(self) -> None:
-        """Calculate the minimum total acquisition time info."""
-        # TODO: fix me!!!!!
-        if self._mmc.getChannelGroup() and self._mmc.getCurrentConfig(
-            self._mmc.getChannelGroup()
-        ):
-            if self.ch_cbox.isChecked() and not self.channel_widget._table.rowCount():
-                self.time_lbl._total_time_lbl.setText(
-                    "Minimum total acquisition time: 0 sec."
-                )
-                return
-
-        elif not self.ch_cbox.isChecked() or not self.channel_widget._table.rowCount():
-            self.time_lbl._total_time_lbl.setText(
-                "Minimum total acquisition time: 0 sec."
-            )
-            return
-
-        total_time: float = 0.0
-        _per_timepoints: dict[int, float] = {}
-        t_per_tp_msg = ""
-        _uses_time = self._uses_time()
-
-        for e in self.get_state():
-            if e.exposure is None:
-                continue
-
-            total_time = total_time + (e.exposure / 1000)
-            if _uses_time:
-                _t = e.index["t"]
-                _exp = e.exposure / 1000
-                _per_timepoints[_t] = _per_timepoints.get(_t, 0) + _exp
-
-        if _per_timepoints:
-            time_value = self.time_widget.value()
-
-            intervals = []
-            for phase in time_value["phases"]:  # type: ignore
-                interval = phase["interval"].total_seconds()
-                intervals.append(interval)
-                if phase.get("loops") is not None:
-                    total_time = total_time + (phase["loops"] - 1) * interval
-                else:
-                    total_time = total_time + phase["duration"].total_seconds()
-
-            # check if the interval(s) is smaller than the sum of the exposure times
-            sum_ch_exp = sum(
-                (c["exposure"] / 1000)
-                for c in self.channel_widget.value()
-                if c["exposure"] is not None
-            )
-            for i in intervals:
-                if 0 < i < sum_ch_exp:
-                    self.time_widget.setWarningVisible(True)
-                    break
-                else:
-                    self.time_widget.setWarningVisible(False)
-
-            # group by time
-            _group_by_time: dict[float, list[int]] = {
-                n: [k for k in _per_timepoints if _per_timepoints[k] == n]
-                for n in set(_per_timepoints.values())
-            }
-
-            t_per_tp_msg = "Minimum acquisition time per timepoint: "
-
-            if len(_group_by_time) == 1:
-                t_per_tp_msg = (
-                    f"\n{t_per_tp_msg}"
-                    f"{fmt_timedelta(timedelta(seconds=_per_timepoints[0]))}"
-                )
-            else:
-                acq_min = timedelta(seconds=min(_per_timepoints.values()))
-                t_per_tp_msg = (
-                    f"\n{t_per_tp_msg}{fmt_timedelta(acq_min)}"
-                    if self._uses_time()
-                    else ""
-                )
-        else:
-            t_per_tp_msg = ""
-            self.time_widget.setWarningVisible(False)
-
-        _min_tot_time = (
-            "Minimum total acquisition time: "
-            f"{fmt_timedelta(timedelta(seconds=total_time))}"
-        )
-        self.time_lbl._total_time_lbl.setText(f"{_min_tot_time}{t_per_tp_msg}")
 
     def _disconnect(self) -> None:
         self._mmc.mda.events.sequenceStarted.disconnect(self._on_mda_started)

--- a/src/pymmcore_widgets/_mda/_time_plan_widget.py
+++ b/src/pymmcore_widgets/_mda/_time_plan_widget.py
@@ -4,15 +4,12 @@ import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
-from fonticon_mdi6 import MDI6
 from pymmcore_plus import CMMCorePlus
-from qtpy.QtCore import QSize, Qt, Signal
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (
     QAbstractSpinBox,
     QDoubleSpinBox,
     QGridLayout,
-    QHBoxLayout,
-    QLabel,
     QPushButton,
     QSizePolicy,
     QSpacerItem,
@@ -21,12 +18,11 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from superqt import QQuantity, fonticon
+from superqt import QQuantity
 from superqt.utils import signals_blocked
 from useq import MDASequence, MultiPhaseTimePlan, TIntervalLoops
 
 if TYPE_CHECKING:
-    from qtpy.QtGui import QIcon
     from typing_extensions import TypedDict
 
     class TimeDict(TypedDict, total=False):
@@ -65,7 +61,6 @@ class TimePlanWidget(QWidget):
     """
 
     valueChanged = Signal()
-    _warning_widget: QWidget
 
     def __init__(
         self,
@@ -123,29 +118,6 @@ class TimePlanWidget(QWidget):
         layout_buttons.addItem(spacer)
 
         group_layout.addWidget(buttons_wdg, 0, 1)
-
-        # warning Icon (exclamation mark)
-        self._warning_icon = QLabel()
-        self.setWarningIcon(MDI6.exclamation_thick)
-        self._warning_icon.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self._warning_icon.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
-        # warning message
-        self._warning_msg = QLabel()
-        self.setWarningMessage("Interval shorter than acquisition time per timepoint.")
-        # warning widget (icon + message)
-        self._warning_widget = QWidget()
-        _warning_layout = QHBoxLayout()
-        _warning_layout.setSpacing(0)
-        _warning_layout.setContentsMargins(0, 0, 0, 0)
-        self._warning_widget.setLayout(_warning_layout)
-        _warning_layout.addWidget(self._warning_icon)
-        _warning_layout.addWidget(self._warning_msg)
-        self._warning_widget.setStyleSheet("color:magenta")
-        self._warning_widget.hide()
-
-        group_layout.addWidget(self._warning_widget, 1, 0, 1, 2)
 
         self._mmc.events.systemConfigurationLoaded.connect(self._clear)
 
@@ -206,22 +178,6 @@ class TimePlanWidget(QWidget):
             self._table.clearContents()
             self._table.setRowCount(0)
         self.valueChanged.emit()
-
-    def setWarningMessage(self, msg: str) -> None:
-        """Set the text of the warning message."""
-        self._warning_msg.setText(msg)
-
-    def setWarningIcon(self, icon: str | QIcon) -> None:
-        """Set the icon of the warning message."""
-        if isinstance(icon, str):
-            _icon: QIcon = fonticon.icon(MDI6.exclamation_thick, color="magenta")
-        else:
-            _icon = icon
-        self._warning_icon.setPixmap(_icon.pixmap(QSize(30, 30)))
-
-    def setWarningVisible(self, visible: bool = True) -> None:
-        """Set the visibility of the warning message."""
-        self._warning_widget.setVisible(visible)
 
     def value(self) -> MultiPhaseTimeDict:
         """Return the current time plan as a dictionary.

--- a/src/pymmcore_widgets/_util.py
+++ b/src/pymmcore_widgets/_util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ContextManager, Sequence
+from typing import ContextManager, Sequence
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler
@@ -14,9 +14,6 @@ from qtpy.QtWidgets import (
 )
 from superqt.utils import signals_blocked
 from useq import AnyGridPlan, MDASequence
-
-if TYPE_CHECKING:
-    from datetime import timedelta
 
 
 class ComboMessageBox(QDialog):
@@ -105,34 +102,6 @@ def block_core(mmcore_events: CMMCoreSignaler | PCoreSignaler) -> ContextManager
         return mmcore_events.blocked()  # type: ignore
     elif isinstance(mmcore_events, PCoreSignaler):
         return signals_blocked(mmcore_events)  # type: ignore
-
-
-def fmt_timedelta(time: timedelta) -> str:
-    """Take timedelta and return formatted string.
-
-    Examples
-    --------
-    >>> fmt_timedelta(timedelta(seconds=100))
-    '01 min  40 sec'
-    >>> fmt_timedelta(timedelta(minutes=320, seconds=2500))
-    '06 hours  01 min  40 sec'
-    """
-    d = "day" if time.days == 1 else "days"
-    _time = str(time).replace(f" {d}, ", ":") if time.days >= 1 else f"0:{time!s}"
-    out: list = []
-    keys = ["days", "hours", "min", "sec", "ms"]
-    for i, t in enumerate(_time.split(":")):
-        if i == 3:
-            s = t.split(".")
-            if len(s) == 2:
-                sec = f"{int(s[0]):02d} sec " if int(s[0]) > 0 else ""
-                ms = f"{int(s[1][:3]):03d} ms" if int(s[1][:3]) > 0 else ""
-                out.append(f"{sec}{ms}")
-            else:
-                out.append(f"{int(s[0]):02d} sec") if int(s[0]) > 0 else ""
-        else:
-            out.append(f"{int(float(t)):02d} {keys[i]}") if int(float(t)) > 0 else ""
-    return "  ".join(out)
 
 
 def get_grid_type(grid: dict) -> AnyGridPlan | None:

--- a/tests/test_mda_widget.py
+++ b/tests/test_mda_widget.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 from qtpy.QtWidgets import QFileDialog
@@ -13,8 +13,6 @@ from pymmcore_widgets._mda import MDAWidget
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
     from pytestqt.qtbot import QtBot
-    from qtpy.QtWidgets import QSpinBox
-    from superqt import QQuantity
 
 
 def test_mda_widget_load_state(qtbot: QtBot) -> None:
@@ -179,69 +177,6 @@ def test_mda_methods(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert not wdg.buttons_wdg.run_button.isHidden()
     assert wdg.buttons_wdg.pause_button.isHidden()
     assert wdg.buttons_wdg.cancel_button.isHidden()
-
-
-def test_gui_labels(qtbot: QtBot, global_mmcore: CMMCorePlus):
-    # sourcery skip: extract-duplicate-method
-    global_mmcore.setExposure(100)
-    wdg = MDAWidget(include_run_button=True)
-    qtbot.addWidget(wdg)
-    wdg.show()
-
-    wdg.ch_cbox.setChecked(True)
-    assert wdg.channel_widget._table.rowCount() == 0
-    wdg.channel_widget._add_button.click()
-    assert wdg.channel_widget._table.rowCount() == 1
-    assert wdg.channel_widget._table.cellWidget(0, 1).value() == 100.0
-
-    assert not wdg.t_cbox.isChecked()
-    wdg.t_cbox.setChecked(True)
-    wdg.time_widget._add_button.click()
-
-    txt = (
-        "Minimum total acquisition time: 100 ms"
-        "\nMinimum acquisition time per timepoint: 100 ms"
-    )
-    assert wdg.time_lbl._total_time_lbl.text() == txt
-    assert wdg.time_widget._warning_widget.isHidden()
-
-    assert wdg.t_cbox.isChecked()
-    interval = cast("QQuantity", wdg.time_widget._table.cellWidget(0, 0))
-    timepoint = cast("QSpinBox", wdg.time_widget._table.cellWidget(0, 1))
-    interval.setValue(1, "ms")
-    timepoint.setValue(2)
-
-    txt = (
-        "Minimum total acquisition time: 201 ms"
-        "\nMinimum acquisition time per timepoint: 100 ms"
-    )
-    assert wdg.time_lbl._total_time_lbl.text() == txt
-    assert not wdg.time_widget._warning_widget.isHidden()
-
-    wdg.channel_widget._add_button.click()
-    wdg.channel_widget._advanced_cbox.setChecked(True)
-    wdg.channel_widget._table.cellWidget(1, 4).setValue(2)
-    wdg.channel_widget._table.cellWidget(1, 1).setValue(100.0)
-    assert not wdg.time_widget._warning_widget.isHidden()
-    interval.setValue(200, "ms")
-    timepoint.setValue(4)
-    assert wdg.time_widget._warning_widget.isHidden()
-
-    txt = (
-        "Minimum total acquisition time: 01 sec 200 ms"
-        "\nMinimum acquisition time per timepoint: 100 ms"
-    )
-    assert wdg.time_lbl._total_time_lbl.text() == txt
-
-    wdg.time_widget._add_button.click()
-    timepoint = cast("QSpinBox", wdg.time_widget._table.cellWidget(1, 1))
-    timepoint.setValue(2)
-
-    txt = (
-        "Minimum total acquisition time: 02 sec 400 ms"
-        "\nMinimum acquisition time per timepoint: 100 ms"
-    )
-    assert wdg.time_lbl._total_time_lbl.text() == txt
 
 
 def test_enable_run_button(qtbot: QtBot, global_mmcore: CMMCorePlus):


### PR DESCRIPTION
This PR removes the time estimating functionality from the MDAWidget.  After #157, it became clear that that was a major slowdown.  

https://github.com/pymmcore-plus/useq-schema/pull/117 adds a mechanism to estimate the time of an experiment that is many orders of magnitude faster than the present approach.  Since it will have effectively no overlap with the current code, this PR just deletes that code, and a followup will replace it