### PR TITLE
fix: fix napari micro tests

### DIFF
--- a/src/pymmcore_widgets/_load_system_cfg_widget.py
+++ b/src/pymmcore_widgets/_load_system_cfg_widget.py
@@ -62,3 +62,21 @@ class ConfigurationWidget(QWidget):
     def _load_cfg(self) -> None:
         """Load the config path currently in the line_edit."""
         load_system_config(self.cfg_LineEdit.text(), self._mmc)
+
+    def setTitle(self, title: str) -> None:
+        _show_deprecation("setTitle")
+
+    def title(self) -> str:
+        _show_deprecation("title")
+        return ""
+
+
+def _show_deprecation(name: str) -> None:
+    import warnings
+
+    warnings.warn(
+        "ConfigurationWidget is no longer a QGroupBox. "
+        f"Please place it in a groupbox if you need {name}",
+        DeprecationWarning,
+        stacklevel=3,
+    )


### PR DESCRIPTION
Fix napari-micromanager tests.

@fdrgsp, this is what i meant by https://github.com/pymmcore-plus/pymmcore-widgets/pull/185#issuecomment-1701567129

The upcoming fix in napari-micromanager is fine, but it won't "fix" anyone out there who is using napari-micromanager that might install pymmcore-widgets in the meantime.  The lower level libraries always need to support the current version of the   higher level libraries, or emit a deprecation warning