### PR TITLE
fix: fix objective widget resizing

### DIFF
--- a/src/pymmcore_widgets/_objective_widget.py
+++ b/src/pymmcore_widgets/_objective_widget.py
@@ -75,11 +75,10 @@ class ObjectivesWidget(QWidget):
         self, device_label: str | None
     ) -> StateDeviceWidget | QComboBox:
         if device_label:
-            combo = (
-                _ObjectiveStateWidget(device_label, parent=self, mmcore=self._mmc)
-                if self._mmc.getFocusDevice()
-                else StateDeviceWidget(device_label, parent=self, mmcore=self._mmc)
-            )
+            combo = _ObjectiveStateWidget(device_label, parent=self, mmcore=self._mmc)
+            combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+            self.setMinimumWidth(0)
+            combo.adjustSize()
             combo._combo.currentIndexChanged.connect(self._on_obj_changed)
         else:
             combo = QComboBox(parent=self)
@@ -103,13 +102,18 @@ class _ObjectiveStateWidget(StateDeviceWidget):
     # TODO: this should be a preference, not a requirement.
 
     def _pre_change_hook(self) -> None:
-        # drop focus motor
+        if not self._mmc.getFocusDevice():
+            # drop focus motor
+            return
+        self._mmc.waitForDevice(self._device_label)
         zdev = self._mmc.getFocusDevice()
         self._previous_z = self._mmc.getZPosition()
         self._mmc.setPosition(zdev, 0)
         self._mmc.waitForDevice(zdev)
 
     def _post_change_hook(self) -> None:
+        if not self._mmc.getFocusDevice():
+            return
         # raise focus motor
         self._mmc.waitForDevice(self._device_label)
         zdev = self._mmc.getFocusDevice()

--- a/src/pymmcore_widgets/_objective_widget.py
+++ b/src/pymmcore_widgets/_objective_widget.py
@@ -73,7 +73,7 @@ class ObjectivesWidget(QWidget):
 
     def _create_objective_combo(
         self, device_label: str | None
-    ) -> StateDeviceWidget | QComboBox:
+    ) -> _ObjectiveStateWidget | QComboBox:
         if device_label:
             combo = _ObjectiveStateWidget(device_label, parent=self, mmcore=self._mmc)
             combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)


### PR DESCRIPTION
This is related to https://github.com/pymmcore-plus/napari-micromanager/issues/288.

This PR updates the `_create_objective_combo()` method so that the objective combo size is adjusted every time a new config is loaded. It's not a major change but It should fix the issue we have in `napari-micromanager`. 

At the moment, the resizing is performed in `napari-micromanager` and this is not ideal since the combo might be deleted/replaced before the resize method is called (https://github.com/pymmcore-plus/napari-micromanager/blob/fa692dc13785629bd9ba277f5d01de8c4039925a/src/napari_micromanager/_gui_objects/_toolbar.py#L241).

This PR is linked to this `napari-micromanager` one: https://github.com/pymmcore-plus/napari-micromanager/pull/290