### PR TITLE
fix: treat MDASequence.axis_order as Sequence[str] rather than str

### DIFF
--- a/src/pymmcore_widgets/_mda/_mda_widget.py
+++ b/src/pymmcore_widgets/_mda/_mda_widget.py
@@ -279,7 +279,7 @@ class MDAWidget(QWidget):
             raise TypeError("state must be an MDASequence, dict, or yaml file")
 
         self.acquisition_order_widget.acquisition_order_comboBox.setCurrentText(
-            state.axis_order
+            "".join(state.axis_order)
         )
 
         # set channel table

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -278,7 +278,7 @@ class MDASequenceWidget(QWidget):
     def setValue(self, value: useq.MDASequence) -> None:
         """Set widget value from a `useq-schema` MDASequence."""
         self.tab_wdg.setValue(value)
-        self.axis_order.setCurrentText(value.axis_order)
+        self.axis_order.setCurrentText("".join(value.axis_order))
 
         keep_shutter_open = value.keep_shutter_open_across
         self.z_plan.leave_shutter_open.setChecked("z" in keep_shutter_open)


### PR DESCRIPTION
this prepares for https://github.com/pymmcore-plus/useq-schema/pull/140, related to https://github.com/pymmcore-plus/useq-schema/issues/137

The point is that we shouldn't assume MDASequence.axis_order is a string... but rather a `Sequence[str]`  (which all strings are as well)