### PR TITLE
fix: fix correct index enablement on checkable tab widget

### DIFF
--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -408,3 +408,19 @@ def test_grid_plan_widget(qtbot: QtBot) -> None:
     assert wdg._fov_width == 4
     wdg.setFovWidth(6)
     assert wdg.fovWidth() == 6
+
+
+def test_proper_checked_index(qtbot):
+    """Testing that the proper tab is checked when setting a value
+
+    https://github.com/pymmcore-plus/pymmcore-widgets/issues/205
+    """
+    import useq
+
+    from pymmcore_widgets.useq_widgets._positions import _MDAPopup
+
+    seq = useq.MDASequence(grid_plan=useq.GridRowsColumns(rows=2, columns=3))
+    pop = _MDAPopup(seq)
+    qtbot.addWidget(pop)
+    assert pop.mda_tabs.grid_plan.isEnabled()
+    assert pop.mda_tabs.isChecked(pop.mda_tabs.grid_plan)


### PR DESCRIPTION
fixes #205 

@fdrgsp, for some reason the tab_index was not getting calculated correctly in `_on_tab_checkbox_toggled`.  Not quite sure why, it was some kind of race condition, because by the time I go into a debugger, it's fixed itself to the proper value.  I generally dislike using lambdas in connections, which is why I was trying to find the tab from the sender before, so I just simplified the logic there and passed the widget to the callback