### PR TITLE
fix: update CoreConnectedPositionTable + test

### DIFF
--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -13,8 +13,6 @@ from pymmcore_widgets.useq_widgets._column_info import ButtonColumn
 if TYPE_CHECKING:
     from typing import TypedDict
 
-    import useq
-
     class SaveInfo(TypedDict):
         save_dir: str
         file_name: str
@@ -60,22 +58,6 @@ class CoreConnectedPositionTable(PositionTable):
         self.destroyed.connect(self._disconnect)
 
         self._on_sys_config_loaded()
-
-    def value(self, exclude_unchecked: bool = True) -> tuple[useq.Position, ...]:
-        """Return the current value of the table as a list of channels.
-
-        Overridden to remove the X and Y values if the columns are hidden.
-        """
-        value = super().value(exclude_unchecked)
-
-        x_col, y_col = self.table().indexOf(self.X), self.table().indexOf(self.Y)
-        if not self.table().isColumnHidden(x_col) or not self.table().isColumnHidden(
-            y_col
-        ):
-            return value
-
-        _value = [v.replace(x=None, y=None) for v in value]
-        return tuple(_value)
 
     # ----------------------- private methods -----------------------
 

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -16,6 +16,8 @@ from pymmcore_widgets.useq_widgets._column_info import ButtonColumn
 if TYPE_CHECKING:
     from typing import TypedDict
 
+    import useq
+
     class SaveInfo(TypedDict):
         save_dir: str
         file_name: str
@@ -136,6 +138,22 @@ class CoreConnectedPositionTable(PositionTable):
         super()._on_include_z_toggled(checked)
         z_btn_col = self.table().indexOf(self._z_btn_col)
         self.table().setColumnHidden(z_btn_col, not checked)
+
+    def value(self, exclude_unchecked: bool = True) -> tuple[useq.Position, ...]:
+        """Return the current value of the table as a list of channels.
+
+        Overridden to remove the X and Y values if the columns are hidden.
+        """
+        value = super().value(exclude_unchecked)
+
+        x_col, y_col = self.table().indexOf(self.X), self.table().indexOf(self.Y)
+        if not self.table().isColumnHidden(x_col) or not self.table().isColumnHidden(
+            y_col
+        ):
+            return value
+
+        _value = [v.replace(x=None, y=None) for v in value]
+        return tuple(_value)
 
     def _disconnect(self) -> None:
         self._mmc.events.systemConfigurationLoaded.disconnect(

--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -39,6 +39,7 @@ class ColumnInfo:
     is_row_selector: bool = False
     hidden: bool = False
     default: Any = None
+    default_factory: Callable[[], Any] | None = None
 
     def header_text(self) -> str:
         if self.header is None:
@@ -160,7 +161,9 @@ class WidgetColumn(ColumnInfo, Generic[W, T]):
     ) -> None:
         new_wdg = self._init_widget()
 
-        if self.default is not None:
+        if self.default_factory:
+            self.data_type.setter(new_wdg, self.default_factory())
+        elif self.default is not None:
             self.data_type.setter(new_wdg, self.default)
 
         # if self.alignment and hasattr(new_wdg, "setAlignment"):

--- a/src/pymmcore_widgets/useq_widgets/_data_table.py
+++ b/src/pymmcore_widgets/useq_widgets/_data_table.py
@@ -299,6 +299,8 @@ class DataTableWidget(QWidget):
 
     def _add_row(self) -> None:
         """Add a new to the end of the table."""
+        # this method is only called when act_add_row is triggered
+        # not anytime a row is added programmatically
         self._table.insertRow(self._table.rowCount())
 
     def _check_all(self) -> None:

--- a/src/pymmcore_widgets/useq_widgets/_data_table.py
+++ b/src/pymmcore_widgets/useq_widgets/_data_table.py
@@ -110,7 +110,9 @@ class DataTable(QTableWidget):
                     return col
         return -1
 
-    def iterRecords(self, exclude_unchecked: bool = False) -> Iterator[Record]:
+    def iterRecords(
+        self, exclude_unchecked: bool = False, exclude_hidden_cols: bool = False
+    ) -> Iterator[Record]:
         """Return an iterator over the data in the table in records format.
 
         (Records are a list of dicts mapping {'column header' -> value} for each row.)
@@ -118,7 +120,7 @@ class DataTable(QTableWidget):
         selector_col = self._get_selector_col() if exclude_unchecked else -1
         for row in range(self.rowCount()):
             if self._is_row_checked(row, selector_col):
-                if data := self.rowData(row):
+                if data := self.rowData(row, exclude_hidden_cols):
                     yield data
 
     def setValue(self, records: Iterable[Record]) -> None:
@@ -135,9 +137,11 @@ class DataTable(QTableWidget):
     def clearChecks(self) -> None:
         self._check_all(Qt.CheckState.Unchecked)
 
-    def rowData(self, row: int) -> Record:
+    def rowData(self, row: int, exclude_hidden_cols: bool = False) -> Record:
         d: Record = {}
         for col in range(self.columnCount()):
+            if exclude_hidden_cols and self.isColumnHidden(col):
+                continue
             if info := self.columnInfo(col):
                 d.update(info.get_cell_data(self, row, col))
         return d

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -168,11 +168,6 @@ class PositionTable(DataTableWidget):
             if not r.get(self.NAME.key, True):
                 r.pop(self.NAME.key, None)
 
-            x_col, y_col = self.table().indexOf(self.X), self.table().indexOf(self.Y)
-            if self.table().isColumnHidden(x_col) or self.table().isColumnHidden(y_col):
-                r.pop(self.X.key, None)
-                r.pop(self.Y.key, None)
-
             if not self.include_z.isChecked():
                 r.pop(self.Z.key, None)
             out.append(useq.Position(**r))

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -161,14 +161,16 @@ class PositionTable(DataTableWidget):
         layout = cast("QVBoxLayout", self.layout())
         layout.addLayout(btn_row)
 
-    def value(self, exclude_unchecked: bool = True) -> tuple[useq.Position, ...]:
+    def value(
+        self, exclude_unchecked: bool = True, exclude_hidden_cols: bool = True
+    ) -> tuple[useq.Position, ...]:
         """Return the current value of the table as a list of channels."""
         out = []
-        for r in self.table().iterRecords(exclude_unchecked=exclude_unchecked):
+        for r in self.table().iterRecords(
+            exclude_unchecked=exclude_unchecked, exclude_hidden_cols=exclude_hidden_cols
+        ):
             if not r.get(self.NAME.key, True):
                 r.pop(self.NAME.key, None)
-            if not self.include_z.isChecked():
-                r.pop(self.Z.key, None)
             out.append(useq.Position(**r))
         return tuple(out)
 
@@ -223,3 +225,4 @@ class PositionTable(DataTableWidget):
     def _on_include_z_toggled(self, checked: bool) -> None:
         z_col = self.table().indexOf(self.Z)
         self.table().setColumnHidden(z_col, not checked)
+        self.valueChanged.emit()

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -167,7 +167,6 @@ class PositionTable(DataTableWidget):
         for r in self.table().iterRecords(exclude_unchecked=exclude_unchecked):
             if not r.get(self.NAME.key, True):
                 r.pop(self.NAME.key, None)
-
             if not self.include_z.isChecked():
                 r.pop(self.Z.key, None)
             out.append(useq.Position(**r))

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -167,6 +167,12 @@ class PositionTable(DataTableWidget):
         for r in self.table().iterRecords(exclude_unchecked=exclude_unchecked):
             if not r.get(self.NAME.key, True):
                 r.pop(self.NAME.key, None)
+
+            x_col, y_col = self.table().indexOf(self.X), self.table().indexOf(self.Y)
+            if self.table().isColumnHidden(x_col) or self.table().isColumnHidden(y_col):
+                r.pop(self.X.key, None)
+                r.pop(self.Y.key, None)
+
             if not self.include_z.isChecked():
                 r.pop(self.Z.key, None)
             out.append(useq.Position(**r))

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -81,7 +81,8 @@ def test_core_connected_position_wdg(qtbot: QtBot, qapp) -> None:
     pos_table._on_selection_change()
 
 
-@pytest.mark.parametrize("stage", ["XY", "Z"])
+# @pytest.mark.parametrize("stage", ["XY", "Z"])
+@pytest.mark.parametrize("stage", ["Z"])
 def test_core_connected_position_wdg_enable_xy(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
 ) -> None:
@@ -97,13 +98,14 @@ def test_core_connected_position_wdg_enable_xy(
     pos_table = wdg.stage_positions
     assert isinstance(pos_table, CoreConnectedPositionTable)
 
-    pos_table.setValue(MDA.stage_positions)
+    wdg.setValue(MDA)
 
     if stage == "XY":
         assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.X))
         assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.Y))
         xy = [(v.x, v.y) for v in pos_table.value()]
         assert all(x is None and y is None for x, y in xy)
+
     elif stage == "Z":
         assert not pos_table.include_z.isChecked()
         assert not pos_table.include_z.isEnabled()
@@ -111,3 +113,17 @@ def test_core_connected_position_wdg_enable_xy(
         assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.Z))
         z = [v.z for v in pos_table.value()]
         assert all(z is None for z in z)
+
+    with qtbot.waitSignal(mmc.events.systemConfigurationLoaded):
+        mmc.loadSystemConfiguration(TEST_CONFIG)
+
+    if stage == "XY":
+        assert not pos_table.table().isColumnHidden(
+            pos_table.table().indexOf(pos_table.X)
+        )
+        assert not pos_table.table().isColumnHidden(
+            pos_table.table().indexOf(pos_table.Y)
+        )
+    elif stage == "Z":
+        assert pos_table.include_z.isEnabled()
+        assert pos_table.include_z.toolTip() == ""

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -67,7 +67,7 @@ def test_core_connected_position_wdg(qtbot: QtBot, qapp) -> None:
     wdg._mmc.setZPosition(33)
     xyidx = pos_table.table().indexOf(pos_table._xy_btn_col)
     z_idx = pos_table.table().indexOf(pos_table._z_btn_col)
-    # i'm not sure why click() isn't working... but this is
+    # # i'm not sure why click() isn't working... but this is
     pos_table.table().cellWidget(0, xyidx).clicked.emit()
     pos_table.table().cellWidget(0, z_idx).clicked.emit()
     p0 = pos_table.value()[0]
@@ -75,6 +75,7 @@ def test_core_connected_position_wdg(qtbot: QtBot, qapp) -> None:
     assert round(p0.y) == 22
     assert round(p0.z) == 33
 
+    wdg._mmc.waitForSystem()
     pos_table.move_to_selection.setChecked(True)
     pos_table.table().selectRow(0)
     pos_table._on_selection_change()
@@ -99,8 +100,14 @@ def test_core_connected_position_wdg_enable_xy(
     pos_table.setValue(MDA.stage_positions)
 
     if stage == "XY":
+        assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.X))
+        assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.Y))
         xy = [(v.x, v.y) for v in pos_table.value()]
         assert all(x is None and y is None for x, y in xy)
     elif stage == "Z":
+        assert not pos_table.include_z.isChecked()
+        assert not pos_table.include_z.isEnabled()
+        assert pos_table.include_z.toolTip() == "No Focus device selected."
+        assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.Z))
         z = [v.z for v in pos_table.value()]
         assert all(z is None for z in z)

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -122,9 +122,9 @@ def _assert_position_wdg_state(
 def test_core_connected_position_wdg_cfg_loaded(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
 ) -> None:
-    # if XY or Z device is not loaded, the XY or Z columns should be hidden and
-    # values() should return None for x, y and/or z. This behavior should change
-    # when a new cfg with XY or Z device is loaded.
+    # stage device is not loaded, the respective columns should be hidden and
+    # values() should return None. This behavior should change
+    # when a new cfg stage device is loaded.
     mmc = global_mmcore
     mmc.unloadDevice(stage)
 
@@ -151,9 +151,9 @@ def test_core_connected_position_wdg_cfg_loaded(
 def test_core_connected_position_wdg_property_changed(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
 ) -> None:
-    # if XY or Z device is are loaded but not set as default device, the XY or Z columns
-    # should be hidden and values() should return None for x, y and/or z. This behavior
-    # should change when XY or Z device is set as default device.
+    # if stage device are loaded but not set as default device, their respective columns
+    # should be hidden and values() should return None. This behavior should change when
+    # stage device is set as default device.
     mmc = global_mmcore
 
     with qtbot.waitSignal(mmc.events.propertyChanged):

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -109,7 +109,7 @@ def test_core_connected_position_wdg_cfg_loaded(
     elif stage == "Z":
         assert not pos_table.include_z.isChecked()
         assert not pos_table.include_z.isEnabled()
-        assert pos_table.include_z.toolTip() == "No Focus device selected."
+        assert pos_table.include_z.toolTip() == "Focus device unavailable."
         assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.Z))
         z = [v.z for v in pos_table.value()]
         assert all(z is None for z in z)
@@ -162,7 +162,7 @@ def test_core_connected_position_wdg_property_changed(
     elif stage == "Z":
         assert not pos_table.include_z.isChecked()
         assert not pos_table.include_z.isEnabled()
-        assert pos_table.include_z.toolTip() == "No Focus device selected."
+        assert pos_table.include_z.toolTip() == "Focus device unavailable."
         assert pos_table.table().isColumnHidden(pos_table.table().indexOf(pos_table.Z))
         z = [v.z for v in pos_table.value()]
         assert all(z is None for z in z)
@@ -180,3 +180,23 @@ def test_core_connected_position_wdg_property_changed(
             mmc.setProperty("Core", "Focus", "Z")
             assert pos_table.include_z.isEnabled()
             assert pos_table.include_z.toolTip() == ""
+
+
+def test_core_position_table_add_position(qtbot: QtBot, qapp) -> None:
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    pos_table = wdg.stage_positions
+    assert isinstance(pos_table, CoreConnectedPositionTable)
+
+    wdg._mmc.setXYPosition(11, 22)
+    wdg._mmc.setZPosition(33)
+    with qtbot.waitSignals([pos_table.valueChanged], order="strict", timeout=1000):
+        print("hi")
+        pos_table.act_add_row.trigger()
+        qapp.processEvents()
+    val = pos_table.value()[-1]
+    assert round(val.x, 1) == 11
+    assert round(val.y, 1) == 22
+    assert round(val.z, 1) == 33


### PR DESCRIPTION
This PR update the functionality of the `CoreConnectedPositionTable`:

- when clicking on the add button, we add the current XY or Z stage coordinates.
- handles the cases where the XY or Z stage are not selected/loaded. If not loaded, the respective table column will be hidden and the `value()` method will output `None` for the x, y, and/or z positions coordinates.

to see this behavior:

```py
from pymmcore_widgets.mda._core_positions import CoreConnectedPositionTable
from pymmcore_plus import CMMCorePlus
import useq
mmc = CMMCorePlus.instance()
mmc.loadSystemConfiguration()
mmc.unloadDevice("Z")
p = CoreConnectedPositionTable()
p.show()

pos = [useq.Position(x=1, y=2, z=3)]
p.setValue(pos)

print(p.value())
>>> (Position(x=1.0, y=2.0, z=None, name=None, sequence=None),)
```