### PR TITLE
fix: use core connected widgets for core connected  sub-sequence _MDAPopup

### DIFF
--- a/examples/mda_useq.py
+++ b/examples/mda_useq.py
@@ -1,7 +1,7 @@
 import useq
 from qtpy.QtWidgets import QApplication
 
-from pymmcore_widgets.mda._core_mda import MDASequenceWidget
+from pymmcore_widgets.useq_widgets import MDASequenceWidget
 
 app = QApplication([])
 

--- a/examples/mda_useq.py
+++ b/examples/mda_useq.py
@@ -1,7 +1,7 @@
 import useq
 from qtpy.QtWidgets import QApplication
 
-from pymmcore_widgets.useq_widgets import MDASequenceWidget
+from pymmcore_widgets.mda._core_mda import MDASequenceWidget
 
 app = QApplication([])
 

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -43,7 +43,7 @@ class MDAWidget(MDASequenceWidget):
     ) -> None:
         # create a couple core-connected variants of the tab widgets
         self._mmc = mmcore or CMMCorePlus.instance()
-        position_wdg = CoreConnectedPositionTable(1, self._mmc)
+        position_wdg = CoreConnectedPositionTable(0, self._mmc)
         z_wdg = CoreConnectedZPlanWidget(self._mmc)
         self.grid_wdg = CoreConnectedGridPlanWidget(self._mmc)
 

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -23,7 +23,7 @@ from pymmcore_widgets.useq_widgets import MDASequenceWidget
 
 from ._core_grid import CoreConnectedGridPlanWidget
 from ._core_positions import CoreConnectedPositionTable
-from ._core_z import CoreConnectedZPlanWidgert
+from ._core_z import CoreConnectedZPlanWidget
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -44,7 +44,7 @@ class MDAWidget(MDASequenceWidget):
         # create a couple core-connected variants of the tab widgets
         self._mmc = mmcore or CMMCorePlus.instance()
         position_wdg = CoreConnectedPositionTable(1, self._mmc)
-        z_wdg = CoreConnectedZPlanWidgert(self._mmc)
+        z_wdg = CoreConnectedZPlanWidget(self._mmc)
         self.grid_wdg = CoreConnectedGridPlanWidget(self._mmc)
 
         super().__init__(

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from fonticon_mdi6 import MDI6
@@ -11,9 +10,7 @@ from superqt.utils import signals_blocked
 from pymmcore_widgets.useq_widgets import PositionTable
 from pymmcore_widgets.useq_widgets._column_info import (
     ButtonColumn,
-    WdgGetSet,
 )
-from pymmcore_widgets.useq_widgets._positions import MDAButton, SubSeqColumn, _MDAPopup
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -25,36 +22,7 @@ if TYPE_CHECKING:
         should_save: bool
 
 
-class CoreConnectedMDAButton(MDAButton):
-    """MDAButton that is connected to the core."""
-
-    def __init__(self) -> None:
-        super().__init__()
-
-    def _on_click(self) -> None:
-        dialog = _MDAPopup(self._value, self, core_connected=True)
-        if dialog.exec():
-            self.setValue(dialog.mda_tabs.value())
-
-
-_CoreConnectedMDAButton = WdgGetSet(
-    CoreConnectedMDAButton,
-    CoreConnectedMDAButton.value,
-    CoreConnectedMDAButton.setValue,
-    lambda w, cb: w.valueChanged.connect(cb),
-)
-
-
-@dataclass(frozen=True)
-class CoreConnectedSubSeqColumn(SubSeqColumn):
-    """Column for editing a `useq.MDASequence`."""
-
-    data_type: WdgGetSet = _CoreConnectedMDAButton
-
-
 class CoreConnectedPositionTable(PositionTable):
-    SEQ = CoreConnectedSubSeqColumn(key="sequence", header="Sub-Sequence", default=None)
-
     def __init__(
         self,
         rows: int = 0,

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from fonticon_mdi6 import MDI6
@@ -8,7 +9,11 @@ from qtpy.QtWidgets import QCheckBox, QWidget, QWidgetAction
 from superqt.utils import signals_blocked
 
 from pymmcore_widgets.useq_widgets import PositionTable
-from pymmcore_widgets.useq_widgets._column_info import ButtonColumn
+from pymmcore_widgets.useq_widgets._column_info import (
+    ButtonColumn,
+    WdgGetSet,
+)
+from pymmcore_widgets.useq_widgets._positions import MDAButton, SubSeqColumn, _MDAPopup
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -20,7 +25,36 @@ if TYPE_CHECKING:
         should_save: bool
 
 
+class CoreConnectedMDAButton(MDAButton):
+    """MDAButton that is connected to the core."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def _on_click(self) -> None:
+        dialog = _MDAPopup(self._value, self, core_connected=True)
+        if dialog.exec():
+            self.setValue(dialog.mda_tabs.value())
+
+
+_CoreConnectedMDAButton = WdgGetSet(
+    CoreConnectedMDAButton,
+    CoreConnectedMDAButton.value,
+    CoreConnectedMDAButton.setValue,
+    lambda w, cb: w.valueChanged.connect(cb),
+)
+
+
+@dataclass(frozen=True)
+class CoreConnectedSubSeqColumn(SubSeqColumn):
+    """Column for editing a `useq.MDASequence`."""
+
+    data_type: WdgGetSet = _CoreConnectedMDAButton
+
+
 class CoreConnectedPositionTable(PositionTable):
+    SEQ = CoreConnectedSubSeqColumn(key="sequence", header="Sub-Sequence", default=None)
+
     def __init__(
         self,
         rows: int = 0,

--- a/src/pymmcore_widgets/mda/_core_z.py
+++ b/src/pymmcore_widgets/mda/_core_z.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget
 
 
-class CoreConnectedZPlanWidgert(ZPlanWidget):
+class CoreConnectedZPlanWidget(ZPlanWidget):
     def __init__(
         self, mmcore: CMMCorePlus | None = None, parent: QWidget | None = None
     ) -> None:

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (
 from superqt.fonticon import icon
 
 from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
+from pymmcore_widgets.mda._core_z import CoreConnectedZPlanWidget
 
 from ._column_info import FloatColumn, TextColumn, WdgGetSet, WidgetColumn
 from ._data_table import DataTableWidget
@@ -44,7 +45,8 @@ class _MDAPopup(QDialog):
 
         # create a new MDA tab widget without the stage positions tab
         _grid_wdg = CoreConnectedGridPlanWidget() if core_connected else None
-        self.mda_tabs = MDATabs(self, grid_wdg=_grid_wdg)
+        _z_wdg = CoreConnectedZPlanWidget() if core_connected else None
+        self.mda_tabs = MDATabs(self, grid_wdg=_grid_wdg, z_wdg=_z_wdg)
         self.mda_tabs.removeTab(self.mda_tabs.indexOf(self.mda_tabs.stage_positions))
 
         # use the parent's channel groups if possible

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -33,14 +33,18 @@ MAX = 9999999
 
 class _MDAPopup(QDialog):
     def __init__(
-        self, value: useq.MDASequence | None = None, parent: QWidget | None = None
+        self,
+        value: useq.MDASequence | None = None,
+        parent: QWidget | None = None,
+        core_connected: bool = False,
     ) -> None:
         from ._mda_sequence import MDATabs
 
         super().__init__(parent)
 
         # create a new MDA tab widget without the stage positions tab
-        self.mda_tabs = MDATabs(self, grid_wdg=CoreConnectedGridPlanWidget())
+        _grid_wdg = CoreConnectedGridPlanWidget() if core_connected else None
+        self.mda_tabs = MDATabs(self, grid_wdg=_grid_wdg)
         self.mda_tabs.removeTab(self.mda_tabs.indexOf(self.mda_tabs.stage_positions))
 
         # use the parent's channel groups if possible

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -21,6 +21,8 @@ from qtpy.QtWidgets import (
 )
 from superqt.fonticon import icon
 
+from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
+
 from ._column_info import FloatColumn, TextColumn, WdgGetSet, WidgetColumn
 from ._data_table import DataTableWidget
 
@@ -38,7 +40,7 @@ class _MDAPopup(QDialog):
         super().__init__(parent)
 
         # create a new MDA tab widget without the stage positions tab
-        self.mda_tabs = MDATabs(self)
+        self.mda_tabs = MDATabs(self, grid_wdg=CoreConnectedGridPlanWidget())
         self.mda_tabs.removeTab(self.mda_tabs.indexOf(self.mda_tabs.stage_positions))
 
         # use the parent's channel groups if possible

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -21,9 +21,6 @@ from qtpy.QtWidgets import (
 )
 from superqt.fonticon import icon
 
-from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
-from pymmcore_widgets.mda._core_z import CoreConnectedZPlanWidget
-
 from ._column_info import FloatColumn, TextColumn, WdgGetSet, WidgetColumn
 from ._data_table import DataTableWidget
 
@@ -39,6 +36,9 @@ class _MDAPopup(QDialog):
         parent: QWidget | None = None,
         core_connected: bool = False,
     ) -> None:
+        from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
+        from pymmcore_widgets.mda._core_z import CoreConnectedZPlanWidget
+
         from ._mda_sequence import MDATabs
 
         super().__init__(parent)

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -26,6 +26,7 @@ from ._data_table import DataTableWidget
 
 OK_CANCEL = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
 NULL_SEQUENCE = useq.MDASequence()
+MAX = 9999999
 
 
 class _MDAPopup(QDialog):
@@ -135,9 +136,9 @@ class PositionTable(DataTableWidget):
     """Table for editing a list of `useq.Positions`."""
 
     NAME = TextColumn(key="name", default=None, is_row_selector=True)
-    X = FloatColumn(key="x", header="X [mm]", default=0.0)
-    Y = FloatColumn(key="y", header="Y [mm]", default=0.0)
-    Z = FloatColumn(key="z", header="Z [mm]", default=0.0)
+    X = FloatColumn(key="x", header="X [mm]", default=0.0, maximum=MAX, minimum=-MAX)
+    Y = FloatColumn(key="y", header="Y [mm]", default=0.0, maximum=MAX, minimum=-MAX)
+    Z = FloatColumn(key="z", header="Z [mm]", default=0.0, maximum=MAX, minimum=-MAX)
     SEQ = SubSeqColumn(key="sequence", header="Sub-Sequence", default=None)
 
     def __init__(self, rows: int = 0, parent: QWidget | None = None):

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -5,9 +5,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 import useq
+from qtpy.QtCore import QTimer
 
 from pymmcore_widgets.mda import MDAWidget
+from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
 from pymmcore_widgets.mda._core_positions import CoreConnectedPositionTable
+from pymmcore_widgets.mda._core_z import CoreConnectedZPlanWidget
+from pymmcore_widgets.useq_widgets._positions import _MDAPopup
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -200,3 +204,28 @@ def test_core_position_table_add_position(qtbot: QtBot) -> None:
     assert round(val.x, 1) == 11
     assert round(val.y, 1) == 22
     assert round(val.z, 1) == 33
+
+
+def test_position_table_connected_popup(qtbot: QtBot):
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    wdg.setValue(MDA)
+
+    pos_table = wdg.stage_positions
+    assert isinstance(pos_table, CoreConnectedPositionTable)
+    seq_col = pos_table.table().indexOf(pos_table.SEQ)
+    btn = pos_table.table().cellWidget(0, seq_col)
+
+    def handle_dialog():
+        popup = btn.findChild(_MDAPopup)
+        mda = popup.mda_tabs
+        assert isinstance(mda.z_plan, CoreConnectedZPlanWidget)
+        assert isinstance(mda.grid_plan, CoreConnectedGridPlanWidget)
+        popup.accept()
+
+    QTimer.singleShot(100, handle_dialog)
+
+    with qtbot.waitSignal(wdg.valueChanged):
+        btn.seq_btn.click()


### PR DESCRIPTION
use the `CoreConnectedGridPlanWidget()` and `CoreConnectedZPlanWidget()` when opening sub-sequence `_MDAPopup` widget.

<img width="738" alt="Screenshot 2023-09-28 at 8 31 31 AM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/6401fdd5-5276-41a7-ad5a-f843fa071864">
