### PR TITLE
fix: add position if relative z_plan

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from superqt.fonticon import icon
-from useq import AxesBasedAF, MDASequence, Position
+from useq import MDASequence, Position
 
 from pymmcore_widgets.useq_widgets import MDASequenceWidget
 
@@ -103,16 +103,7 @@ class MDAWidget(MDASequenceWidget):
         x = self._mmc.getXPosition() if self._mmc.getXYStageDevice() else None
         y = self._mmc.getYPosition() if self._mmc.getXYStageDevice() else None
         z = self._mmc.getPosition() if self._mmc.getFocusDevice() else None
-        sub_seq = (
-            MDASequence(
-                autofocus_plan=AxesBasedAF(  # type: ignore  # until useq release
-                    autofocus_motor_offset=self._mmc.getAutoFocusOffset(), axes=("p",)
-                )
-            )
-            if self._mmc.isContinuousFocusLocked()
-            else None
-        )
-        return Position(x=x, y=y, z=z, sequence=sub_seq)
+        return Position(x=x, y=y, z=z)
 
     def setValue(self, value: MDASequence) -> None:
         """Get the current state of the widget."""

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -89,7 +89,11 @@ class MDAWidget(MDASequenceWidget):
         val = super().value()
 
         # if the z plan is relative, and there are no stage positions, add the current
-        # stage position as the relative starting one
+        # stage position as the relative starting one.
+        # Note: this is not the final solution, it shiud be better to move this in
+        # pymmcore-plus runner but only after we introduce a concept of a "relative
+        # position" in useq.MDAEvent. At the moment, since the pymmcore-plus runner is
+        # not aware of the core, we cannot move it there.
         if val.z_plan and val.z_plan.is_relative and not val.stage_positions:
             val = val.replace(stage_positions=[self._get_current_stage_position()])
 

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -18,17 +18,16 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from superqt.fonticon import icon
+from useq import AxesBasedAF, MDASequence, Position
 
 from pymmcore_widgets.useq_widgets import MDASequenceWidget
 
 from ._core_grid import CoreConnectedGridPlanWidget
 from ._core_positions import CoreConnectedPositionTable
-from ._core_z import CoreConnectedZPlanWidgert
+from ._core_z import CoreConnectedZPlanWidget
 
 if TYPE_CHECKING:
     from typing import TypedDict
-
-    from useq import MDASequence
 
     class SaveInfo(TypedDict):
         save_dir: str
@@ -43,8 +42,8 @@ class MDAWidget(MDASequenceWidget):
     ) -> None:
         # create a couple core-connected variants of the tab widgets
         self._mmc = mmcore or CMMCorePlus.instance()
-        position_wdg = CoreConnectedPositionTable(1, self._mmc)
-        z_wdg = CoreConnectedZPlanWidgert(self._mmc)
+        position_wdg = CoreConnectedPositionTable(0, self._mmc)
+        z_wdg = CoreConnectedZPlanWidget(self._mmc)
         self.grid_wdg = CoreConnectedGridPlanWidget(self._mmc)
 
         super().__init__(
@@ -88,10 +87,32 @@ class MDAWidget(MDASequenceWidget):
     def value(self) -> MDASequence:
         """Set the current state of the widget."""
         val = super().value()
+
+        # if the z plan is relative, and there are no stage positions, add the current
+        # stage position as the relative starting one
+        if val.z_plan and val.z_plan.is_relative and not val.stage_positions:
+            val = val.replace(stage_positions=[self._get_current_stage_position()])
+
         meta: dict = val.metadata.setdefault("pymmcore_widgets", {})
         if self.save_info.isChecked():
             meta.update(self.save_info.value())
         return val
+
+    def _get_current_stage_position(self) -> Position:
+        """Return the current stage position."""
+        x = self._mmc.getXPosition() if self._mmc.getXYStageDevice() else None
+        y = self._mmc.getYPosition() if self._mmc.getXYStageDevice() else None
+        z = self._mmc.getPosition() if self._mmc.getFocusDevice() else None
+        sub_seq = (
+            MDASequence(
+                autofocus_plan=AxesBasedAF(  # type: ignore  # until useq release
+                    autofocus_motor_offset=self._mmc.getAutoFocusOffset(), axes=("p",)
+                )
+            )
+            if self._mmc.isContinuousFocusLocked()
+            else None
+        )
+        return Position(x=x, y=y, z=z, sequence=sub_seq)
 
     def setValue(self, value: MDASequence) -> None:
         """Get the current state of the widget."""

--- a/src/pymmcore_widgets/mda/_core_z.py
+++ b/src/pymmcore_widgets/mda/_core_z.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget
 
 
-class CoreConnectedZPlanWidgert(ZPlanWidget):
+class CoreConnectedZPlanWidget(ZPlanWidget):
     def __init__(
         self, mmcore: CMMCorePlus | None = None, parent: QWidget | None = None
     ) -> None:

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -222,4 +222,3 @@ def test_core_connected_relative_z_plan(qtbot: QtBot):
     assert round(val.x, 1) == 11
     assert round(val.y, 1) == 22
     assert round(val.z, 1) == 33
-    assert not val.sequence

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -200,3 +200,26 @@ def test_core_position_table_add_position(qtbot: QtBot) -> None:
     assert round(val.x, 1) == 11
     assert round(val.y, 1) == 22
     assert round(val.z, 1) == 33
+
+
+def test_core_connected_relative_z_plan(qtbot: QtBot):
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    wdg._mmc.setXYPosition(11, 22)
+    wdg._mmc.setZPosition(33)
+    wdg._mmc.waitForSystem()
+
+    MDA = useq.MDASequence(
+        channels=[{"config": "DAPI", "exposure": 1}],
+        z_plan=useq.ZRangeAround(range=1, step=0.3),
+        axis_order="pzc",
+    )
+    wdg.setValue(MDA)
+
+    val = wdg.value().stage_positions[-1]
+    assert round(val.x, 1) == 11
+    assert round(val.y, 1) == 22
+    assert round(val.z, 1) == 33
+    assert not val.sequence


### PR DESCRIPTION
If building an `MDASequence` with a `relative` `z_plan` without a specified `Position`, we need to specify the relative starting position. 