### PR TITLE
fix: disable x, y, z set buttons when 'move to' is checked

### DIFF
--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from fonticon_mdi6 import MDI6
 from pymmcore_plus import CMMCorePlus
@@ -12,6 +12,12 @@ from pymmcore_widgets.useq_widgets._column_info import ButtonColumn
 
 if TYPE_CHECKING:
     from typing import TypedDict
+
+    from pymmcore_widgets.useq_widgets._column_info import (
+        FloatColumn,
+        TableDoubleSpinBox,
+        WidgetColumn,
+    )
 
     class SaveInfo(TypedDict):
         save_dir: str
@@ -63,11 +69,27 @@ class CoreConnectedPositionTable(PositionTable):
     # ----------------------- private methods -----------------------
 
     def _on_move_to_selection_toggled(self, checked: bool) -> None:
-        """Hide or show the axes "set button" when move_to_selection is toggled."""
-        xy_btn_col = self.table().indexOf(self._xy_btn_col)
-        z_btn_col = self.table().indexOf(self._z_btn_col)
-        self.table().setColumnHidden(xy_btn_col, checked)
-        self.table().setColumnHidden(z_btn_col, checked)
+        """Hide/show the axes "set button" and set table as RedaOnly."""
+        self._hide_widget_columns(
+            checked, [self._xy_btn_col, self._z_btn_col, self.SEQ]
+        )
+        self._set_read_only_float_columns(checked, [self.X, self.Y, self.Z])
+
+    def _hide_widget_columns(self, hide: bool, buttons: list[WidgetColumn]) -> None:
+        """Hide/show the given ButtonColumn."""
+        for btn in buttons:
+            col = self.table().indexOf(btn)
+            self.table().setColumnHidden(col, hide)
+
+    def _set_read_only_float_columns(
+        self, read_only: bool, columns: list[FloatColumn]
+    ) -> None:
+        """Set the read only state of the given FloatColumn."""
+        for column in columns:
+            col = self.table().indexOf(column)
+            for row in range(self.table().rowCount()):
+                wdg = cast("TableDoubleSpinBox", self.table().cellWidget(row, col))
+                wdg.lineEdit().setReadOnly(read_only)
 
     def _on_sys_config_loaded(self) -> None:
         """Update the table when the system configuration is loaded."""

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -52,6 +52,7 @@ class CoreConnectedPositionTable(PositionTable):
         self.table().itemSelectionChanged.connect(self._on_selection_change)
 
         # connect
+        self.move_to_selection.toggled.connect(self._on_move_to_selection_toggled)
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_config_loaded)
         self._mmc.events.propertyChanged.connect(self._on_property_changed)
 
@@ -60,6 +61,13 @@ class CoreConnectedPositionTable(PositionTable):
         self._on_sys_config_loaded()
 
     # ----------------------- private methods -----------------------
+
+    def _on_move_to_selection_toggled(self, checked: bool) -> None:
+        """Hide or show the axes "set button" when move_to_selection is toggled."""
+        xy_btn_col = self.table().indexOf(self._xy_btn_col)
+        z_btn_col = self.table().indexOf(self._z_btn_col)
+        self.table().setColumnHidden(xy_btn_col, checked)
+        self.table().setColumnHidden(z_btn_col, checked)
 
     def _on_sys_config_loaded(self) -> None:
         """Update the table when the system configuration is loaded."""

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -212,13 +212,31 @@ def test_core_position_table_move_toggle(qtbot: QtBot):
 
     wdg.setValue(MDA)
 
+    # set buttons
     xy_btn_col = pos_table.table().indexOf(pos_table._xy_btn_col)
     z_btn_col = pos_table.table().indexOf(pos_table._z_btn_col)
+    seq = pos_table.table().indexOf(pos_table.SEQ)
+    # x, y, z columns
+    x_col = pos_table.table().indexOf(pos_table.X)
+    y_col = pos_table.table().indexOf(pos_table.Y)
+    z_col = pos_table.table().indexOf(pos_table.Z)
 
     assert not pos_table.move_to_selection.isChecked()
+    # set buttons should be visible
     assert not pos_table.table().isColumnHidden(xy_btn_col)
     assert not pos_table.table().isColumnHidden(z_btn_col)
+    assert not pos_table.table().isColumnHidden(seq)
+    # x, y, z TableDoubleSpinBox should be editable
+    assert not pos_table.table().cellWidget(0, x_col).lineEdit().isReadOnly()
+    assert not pos_table.table().cellWidget(0, y_col).lineEdit().isReadOnly()
+    assert not pos_table.table().cellWidget(0, z_col).lineEdit().isReadOnly()
 
     pos_table.move_to_selection.setChecked(True)
+    # set buttons should be hidden
     assert pos_table.table().isColumnHidden(xy_btn_col)
     assert pos_table.table().isColumnHidden(z_btn_col)
+    assert pos_table.table().isColumnHidden(seq)
+    # x, y, z TableDoubleSpinBox should be read only
+    assert pos_table.table().cellWidget(0, x_col).lineEdit().isReadOnly()
+    assert pos_table.table().cellWidget(0, y_col).lineEdit().isReadOnly()
+    assert pos_table.table().cellWidget(0, z_col).lineEdit().isReadOnly()

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -200,3 +200,25 @@ def test_core_position_table_add_position(qtbot: QtBot) -> None:
     assert round(val.x, 1) == 11
     assert round(val.y, 1) == 22
     assert round(val.z, 1) == 33
+
+
+def test_core_position_table_move_toggle(qtbot: QtBot):
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    pos_table = wdg.stage_positions
+    assert isinstance(pos_table, CoreConnectedPositionTable)
+
+    wdg.setValue(MDA)
+
+    xy_btn_col = pos_table.table().indexOf(pos_table._xy_btn_col)
+    z_btn_col = pos_table.table().indexOf(pos_table._z_btn_col)
+
+    assert not pos_table.move_to_selection.isChecked()
+    assert not pos_table.table().isColumnHidden(xy_btn_col)
+    assert not pos_table.table().isColumnHidden(z_btn_col)
+
+    pos_table.move_to_selection.setChecked(True)
+    assert pos_table.table().isColumnHidden(xy_btn_col)
+    assert pos_table.table().isColumnHidden(z_btn_col)


### PR DESCRIPTION
@tlambert03 not sure what you think about it but I wanted to make more evident the the state of the `PositionTable` when the `move_to_selection` `QCheckBox` is toggled. As you can see in the video below, I thought it can be a good idea to hide the "set" and the "sub-sequence" buttons and set the x, y, z `TableDoubleSpinBox` to `readOnly` so that the user does not get confused between moving or setting a position.



https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/7bf55506-da65-4e4e-b738-fdc79e348215



