### PR TITLE
fix: accept 0 as interval

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -391,7 +391,8 @@ class QQuantityLineEdit(QLineEdit):
     def _on_editing_finished(self) -> None:
         # When the editing is finished, check if the final text is valid
         before, final_text = self._last_val, self.text()
-        if valid_q := self._validator.text_to_quant(final_text):
+        valid_q = self._validator.text_to_quant(final_text)
+        if valid_q is not None:
             text = f"{valid_q:~P}"  # short pretty format
             if before != text:
                 self.setText(text)


### PR DESCRIPTION
we need to be able to set the time `interval` in the `TimePlanWidget` to `0` from the GUI.