### PR TITLE
fix: catch errors in property widget when building device property table

### DIFF
--- a/src/pymmcore_widgets/_device_property_table.py
+++ b/src/pymmcore_widgets/_device_property_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Iterable, cast
 
 from fonticon_mdi6 import MDI6
@@ -30,6 +31,8 @@ ICONS: dict[DeviceType, str] = {
     DeviceType.XYStage: MDI6.arrow_all,
     DeviceType.Serial: MDI6.serial_port,
 }
+
+logger = getLogger(__name__)
 
 
 class DevicePropertyTable(QTableWidget):
@@ -140,18 +143,24 @@ class DevicePropertyTable(QTableWidget):
         for i, prop in enumerate(props):
             item = QTableWidgetItem(f"{prop.device}-{prop.name}")
             item.setData(self.PROP_ROLE, prop)
-            # TODO: make sure to add icons for all possible device types
-            icon_string = ICONS.get(prop.deviceType(), None)
+            icon_string = ICONS.get(prop.deviceType())
             if icon_string:
                 item.setIcon(icon(icon_string, color="Gray"))
             self.setItem(i, 0, item)
 
-            wdg = PropertyWidget(
-                prop.device,
-                prop.name,
-                mmcore=self._mmc,
-                connect_core=self._connect_core,
-            )
+            try:
+                wdg = PropertyWidget(
+                    prop.device,
+                    prop.name,
+                    mmcore=self._mmc,
+                    connect_core=self._connect_core,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Error creating widget for {prop.device}-{prop.name}: {e}"
+                )
+                continue
+
             self.setCellWidget(i, 1, wdg)
             if not self._prop_widgets_enabled:
                 wdg.setEnabled(False)


### PR DESCRIPTION
If any widget has an exception in the DevicePropertyBrowser, the whole thing fails to load.  This PR catches individual widget errors and logs them.  So at least the whole browser won't crash (that one widget will be unavailable though)

see https://github.com/pymmcore-plus/napari-micromanager/issues/293 for the overflow issue and see #223 for the "actual" fix