### PR TITLE
fix: hide shutter open in sub_seq

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -53,6 +53,8 @@ class _MDAPopup(QDialog):
         # create a new MDA tab widget without the stage positions tab
         self.mda_tabs = tab_type(self)
         self.mda_tabs.removeTab(self.mda_tabs.indexOf(self.mda_tabs.stage_positions))
+        self.mda_tabs.time_plan.leave_shutter_open.hide()
+        self.mda_tabs.z_plan.leave_shutter_open.hide()
 
         # use the parent's channel groups if possible
         par = self.parent()


### PR DESCRIPTION
Since at the moment `useq-schema` does not support setting the `keep_shutter_open_across` property in `Position` sub-sequences, we hide the checkboxes (https://github.com/pymmcore-plus/useq-schema/blob/b0522c48b1fd7acb0904b0c7e54965d3791d2ffe/src/useq/_mda_sequence.py#L250-L253).


closes #227 