### PR TITLE
fix: disallow setting pre-init props after device initialization

### DIFF
--- a/src/pymmcore_widgets/_device_property_table.py
+++ b/src/pymmcore_widgets/_device_property_table.py
@@ -186,6 +186,7 @@ class DevicePropertyTable(QTableWidget):
         query: str = "",
         exclude_devices: Iterable[DeviceType] = (),
         include_read_only: bool = True,
+        include_pre_init: bool = True,
         init_props_only: bool = False,
     ) -> None:
         """Update the table to only show devices that match the given query/filter."""
@@ -195,6 +196,7 @@ class DevicePropertyTable(QTableWidget):
             prop = cast(DeviceProperty, item.data(self.PROP_ROLE))
             if (
                 (prop.isReadOnly() and not include_read_only)
+                or (prop.isPreInit() and not include_pre_init)
                 or (init_props_only and not prop.isPreInit())
                 or (prop.deviceType() in exclude_devices)
                 or (query and query.lower() not in item.text().lower())

--- a/src/pymmcore_widgets/_device_type_filter.py
+++ b/src/pymmcore_widgets/_device_type_filter.py
@@ -56,9 +56,15 @@ class DeviceTypeFilters(QWidget):
         self._read_only_checkbox.toggled.connect(self.filtersChanged)
         self._read_only_checkbox.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
+        self._pre_init_checkbox = QCheckBox("Show pre-init props")
+        self._pre_init_checkbox.setChecked(True)
+        self._pre_init_checkbox.toggled.connect(self.filtersChanged)
+        self._pre_init_checkbox.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
         layout = QVBoxLayout()
         layout.addWidget(self._dev_gb)
         layout.addWidget(self._read_only_checkbox)
+        layout.addWidget(self._pre_init_checkbox)
         layout.addStretch()
         self.setLayout(layout)
 
@@ -83,4 +89,11 @@ class DeviceTypeFilters(QWidget):
 
     def setShowReadOnly(self, show: bool) -> None:
         self._read_only_checkbox.setChecked(show)
+        self.filtersChanged.emit()
+
+    def showPreInitProps(self) -> bool:
+        return self._pre_init_checkbox.isChecked()  # type: ignore
+
+    def setShowPreInitProps(self, show: bool) -> None:
+        self._pre_init_checkbox.setChecked(show)
         self.filtersChanged.emit()

--- a/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_group_widget.py
@@ -140,7 +140,10 @@ class AddGroupWidget(QDialog):
     def _update_filter(self) -> None:
         filt = self._filter_text.text().lower()
         self._prop_table.filterDevices(
-            filt, self._device_filters.filters(), self._device_filters.showReadOnly()
+            filt,
+            exclude_devices=self._device_filters.filters(),
+            include_read_only=self._device_filters.showReadOnly(),
+            include_pre_init=self._device_filters.showPreInitProps(),
         )
 
     def _add_group(self) -> None:

--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -137,7 +137,10 @@ class EditGroupWidget(QDialog):
     def _update_filter(self) -> None:
         filt = self._filter_text.text().lower()
         self._prop_table.filterDevices(
-            filt, self._device_filters.filters(), self._device_filters.showReadOnly()
+            filt,
+            exclude_devices=self._device_filters.filters(),
+            include_read_only=self._device_filters.showReadOnly(),
+            include_pre_init=self._device_filters.showPreInitProps(),
         )
 
     def _add_group(self) -> None:

--- a/src/pymmcore_widgets/_property_browser.py
+++ b/src/pymmcore_widgets/_property_browser.py
@@ -60,7 +60,10 @@ class PropertyBrowser(QDialog):
     def _update_filter(self) -> None:
         filt = self._filter_text.text().lower()
         self._prop_table.filterDevices(
-            filt, self._device_filters.filters(), self._device_filters.showReadOnly()
+            filt,
+            exclude_devices=self._device_filters.filters(),
+            include_read_only=self._device_filters.showReadOnly(),
+            include_pre_init=self._device_filters.showPreInitProps(),
         )
 
 

--- a/src/pymmcore_widgets/_property_widget.py
+++ b/src/pymmcore_widgets/_property_widget.py
@@ -336,17 +336,17 @@ class PropertyWidget(QWidget):
         self.layout().addWidget(cast(QWidget, self._value_widget))
         self.destroyed.connect(self._disconnect)
 
-        # disable for any device init state besides 0 (Uninitialized)
-        if hasattr(self._mmc, "getDeviceInitializationState") and (
-            self._mmc.isPropertyPreInit(device_label, prop_name)
-            and self._mmc.getDeviceInitializationState(device_label)
-        ):
-            self.setDisabled(True)
-
     def _try_update_from_core(self) -> None:
         # set current value from core, ignoring errors
         with contextlib.suppress(RuntimeError, ValueError):
             self._value_widget.setValue(self._mmc.getProperty(*self._dp))
+
+        # disable for any device init state besides 0 (Uninitialized)
+        if hasattr(self._mmc, "getDeviceInitializationState") and (
+            self._mmc.isPropertyPreInit(self._device_label, self._prop_name)
+            and self._mmc.getDeviceInitializationState(self._device_label)
+        ):
+            self.setDisabled(True)
 
     # connect events and queue for disconnection on widget destroyed
     def _on_core_change(self, dev_label: str, prop_name: str, new_val: Any) -> None:

--- a/src/pymmcore_widgets/_property_widget.py
+++ b/src/pymmcore_widgets/_property_widget.py
@@ -4,7 +4,11 @@ import contextlib
 from typing import Any, Callable, Protocol, TypeVar, cast
 
 import pymmcore
-from pymmcore_plus import CMMCorePlus, DeviceType, PropertyType
+from pymmcore_plus import (
+    CMMCorePlus,
+    DeviceType,
+    PropertyType,
+)
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -331,6 +335,13 @@ class PropertyWidget(QWidget):
 
         self.layout().addWidget(cast(QWidget, self._value_widget))
         self.destroyed.connect(self._disconnect)
+
+        # disable for any device init state besides 0 (Uninitialized)
+        if hasattr(self._mmc, "getDeviceInitializationState") and (
+            self._mmc.isPropertyPreInit(device_label, prop_name)
+            and self._mmc.getDeviceInitializationState(device_label)
+        ):
+            self.setDisabled(True)
 
     def _try_update_from_core(self) -> None:
         # set current value from core, ignoring errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -43,7 +42,8 @@ def _run_after_each_test(request: "FixtureRequest", qapp: "QApplication"):
         if (
             # os.name == "nt"
             # and sys.version_info[:2] <= (3, 9)
-            type(remaining[0]).__name__ in {"ImagePreview", "SnapButton"}
+            type(remaining[0]).__name__
+            in {"ImagePreview", "SnapButton"}
         ):
             # I have no idea why, but the ImagePreview widget is leaking.
             # And it only came with a seemingly unrelated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,12 +41,12 @@ def _run_after_each_test(request: "FixtureRequest", qapp: "QApplication"):
     remaining = qapp.topLevelWidgets()
     if len(remaining) > nbefore:
         if (
-            os.name == "nt"
+            # os.name == "nt"
             # and sys.version_info[:2] <= (3, 9)
-            and type(remaining[0]).__name__ in {"ImagePreview", "SnapButton"}
+            type(remaining[0]).__name__ in {"ImagePreview", "SnapButton"}
         ):
-            # I have no idea why, but the ImagePreview widget is leaking on py38
-            # on windows only. And it only came with a seemingly unrelated
+            # I have no idea why, but the ImagePreview widget is leaking.
+            # And it only came with a seemingly unrelated
             # https://github.com/pymmcore-plus/pymmcore-widgets/pull/90
             # we're just ignoring it for now.
             return

--- a/tests/test_prop_widget.py
+++ b/tests/test_prop_widget.py
@@ -16,7 +16,7 @@ dev_props = [
     (dev, prop)
     for dev in CORE.getLoadedDevices()
     for prop in CORE.getDevicePropertyNames(dev)
-    if dev != "LED" and prop != "Number of positions"
+    if dev != "LED" and prop not in {"Number of positions", "Initialize"}
 ]
 
 
@@ -59,7 +59,14 @@ def test_property_widget(dev, prop, qtbot):
     else:
         val = "some string"
 
+    before = wdg.value()
     wdg.setValue(val)
+    if CORE.isPropertyPreInit(dev, prop):
+        # as of pymmcore 10.7.0.71.0, setting pre-init properties
+        # after the device has been initialized does nothing.
+        _assert_equal(wdg.value(), before)
+        return
+
     _assert_equal(wdg.value(), val)
     _assert_equal(CORE.getProperty(dev, prop), val)
 


### PR DESCRIPTION
Pre-init properties must not be set after initialization, and this is now enforced upstream by https://github.com/micro-manager/mmCoreAndDevices/pull/376 

This PR fixes tests here resulting from that change, and makes PropertyWidgets disabled after device initialization