### PR TITLE
fix: fix style of ZPlanWidget

### DIFF
--- a/src/pymmcore_widgets/mda/_xy_bounds.py
+++ b/src/pymmcore_widgets/mda/_xy_bounds.py
@@ -80,7 +80,7 @@ SS = """
 QPushButton {{
     border-top-{side}-radius: {radius}px;
     border-bottom-{side}-radius: {radius}px;
-    border: 1px solid #8A8A8A;
+    border: 1px solid #A3A3A3;
     padding: 2px 6px;
 }}
 QPushButton:hover {{

--- a/src/pymmcore_widgets/mda/_xy_bounds.py
+++ b/src/pymmcore_widgets/mda/_xy_bounds.py
@@ -80,15 +80,14 @@ SS = """
 QPushButton {{
     border-top-{side}-radius: {radius}px;
     border-bottom-{side}-radius: {radius}px;
-    border: 0.5px solid #DCDCDC;
-    background-color: #FFF;
+    border: 1px solid #8A8A8A;
     padding: 2px 6px;
 }}
 QPushButton:hover {{
-    background-color: #EEE;
+    background-color: #ABABAB;
 }}
 QPushButton:pressed {{
-    background-color: #AAA;
+    background-color: #8C8C8C;
 }}
 """
 

--- a/src/pymmcore_widgets/useq_widgets/_z.py
+++ b/src/pymmcore_widgets/useq_widgets/_z.py
@@ -68,7 +68,7 @@ class ZPlanWidget(QWidget):
         self._suggested: float | None = None
 
         # #################### Mode Buttons ####################
-        color = "#555"
+        color = "#363636"
 
         # ------------------- actions ----------
 

--- a/src/pymmcore_widgets/useq_widgets/_z.py
+++ b/src/pymmcore_widgets/useq_widgets/_z.py
@@ -43,7 +43,6 @@ ROW_TOP_BOTTOM = 4
 ROW_ABOVE_BELOW = 6
 
 UM = "\u00B5m"  # MICRO SIGN
-L_ARR = "\u2B05"  # LEFTWARDS BLACK ARROW
 
 
 class ZPlanWidget(QWidget):
@@ -183,6 +182,7 @@ class ZPlanWidget(QWidget):
         # #################### Other Widgets ####################
 
         self._use_suggested_btn = QPushButton()
+        self._use_suggested_btn.setIcon(icon(MDI6.arrow_left_thick))
         self._use_suggested_btn.clicked.connect(self.useSuggestedStep)
         self._use_suggested_btn.hide()
 
@@ -323,7 +323,7 @@ class ZPlanWidget(QWidget):
         """Set the suggested step size and update the button text."""
         self._suggested = value
         if value:
-            self._use_suggested_btn.setText(f"{L_ARR} {value} {UM}")
+            self._use_suggested_btn.setText(f"{value} {UM}")
             self._use_suggested_btn.show()
         else:
             self._use_suggested_btn.setText("")


### PR DESCRIPTION
fix the style of the ZPlanWidget that is currently not working very well when switching between a light and dark mode.

BEFORE
<img width="539" alt="Screenshot 2023-10-31 at 9 53 07 AM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/d7a57717-9b81-48fa-8aea-585dad69b0da">

<img width="539" alt="Screenshot 2023-10-31 at 9 53 14 AM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/87a45a63-aed5-4ef5-ac2e-2c01e8f6fae2">

---
AFTER
<img width="539" alt="Screenshot 2023-10-31 at 9 48 15 AM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/34dfd5e5-aa5f-4248-ae19-c476069b15e4">

<img width="539" alt="Screenshot 2023-10-31 at 9 48 08 AM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/439a95bd-8b16-4734-be77-c723f1f4bd3c">

---

also removing `L_ARR = "\u2B05"  # LEFTWARDS BLACK ARROW` and using a `MDI6.arrow_left_thick` icon for the `_use_suggested_btn` because on windows it looks quite weird.

BEFORE -> AFTER

![Untitled](https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/2a2f451c-1e05-4528-8295-47d3e36412cb)






