### PR TITLE
fix: fix the test on PyQt6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
         python-version: ["3.8", "3.11"]
         backend: [pyside2, pyqt5]
         include:
+          - platform: macos-latest
+            python-version: "3.10"
+            backend: pyside6
+          - platform: macos-latest
+            python-version: "3.10"
+            backend: pyqt6
           - platform: windows-latest
             python-version: "3.10"
             backend: pyside6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
             python-version: "3.10"
             backend: pyside6
           - platform: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
             backend: pyqt6
           - platform: windows-latest
             python-version: "3.10"
             backend: pyside6
           - platform: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
             backend: pyqt6
           - platform: windows-latest
             python-version: "3.9"

--- a/src/pymmcore_widgets/hcwizard/roles_page.py
+++ b/src/pymmcore_widgets/hcwizard/roles_page.py
@@ -86,5 +86,11 @@ class RolesPage(ConfigWizardPage):
         self._model.core_device.set_property(Keyword.CoreFocus, text)
 
     def _on_auto_shutter_changed(self, state: Qt.CheckState) -> None:
-        val = "1" if state == Qt.CheckState.Checked else "0"
+        try:
+            # if PyQt6 or PySide6
+            val = "1" if state == Qt.CheckState.Checked.value else "0"
+        except AttributeError:
+            # if PyQt5 or PySide2
+            val = "1" if state == Qt.CheckState.Checked else "0"
+
         self._model.core_device.set_property(Keyword.CoreAutoShutter, val)

--- a/src/pymmcore_widgets/hcwizard/roles_page.py
+++ b/src/pymmcore_widgets/hcwizard/roles_page.py
@@ -1,6 +1,5 @@
 from pymmcore_plus import CMMCorePlus, DeviceType, Keyword
 from pymmcore_plus.model import Microscope
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QCheckBox, QComboBox, QFormLayout
 from superqt.utils import signals_blocked
 
@@ -85,12 +84,6 @@ class RolesPage(ConfigWizardPage):
     def _on_focus_changed(self, text: str) -> None:
         self._model.core_device.set_property(Keyword.CoreFocus, text)
 
-    def _on_auto_shutter_changed(self, state: Qt.CheckState) -> None:
-        try:
-            # if PyQt6 or PySide6
-            val = "1" if state == Qt.CheckState.Checked.value else "0"
-        except AttributeError:
-            # if PyQt5 or PySide2
-            val = "1" if state == Qt.CheckState.Checked else "0"
-
+    def _on_auto_shutter_changed(self, state: int) -> None:
+        val = "1" if bool(state) else "0"
         self._model.core_device.set_property(Keyword.CoreAutoShutter, val)


### PR DESCRIPTION
fix because of the test not passing  on pyqt6. 

The test fails because the `QCheckBox` `Qt.CheckState` is different in `pyqt6` and `pyside6` compared to `pyqt5` and `pyside2`.

Two possible solutions are:

- using try/except
 
```py
 def _on_auto_shutter_changed(self, state: Qt.CheckState) -> None:
        try:
            # if PyQt6 or PySide6
            val = "1" if state == Qt.CheckState.Checked.value else "0"
        except AttributeError:
            # if PyQt5 or PySide2
            val = "1" if state == Qt.CheckState.Checked else "0"

        self._model.core_device.set_property(Keyword.CoreAutoShutter, val)
```

- using bool **_(this is the one currently implemented in this PR_**):

```py
def _on_auto_shutter_changed(self, state: int) -> None:
    val = "1" if bool(state) else "0"
    self._model.core_device.set_property(Keyword.CoreAutoShutter, val)
```