### PR TITLE
fix: fix overlap in GridPlanWidget

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -98,7 +98,7 @@ class GridPlanWidget(QWidget):
         self.bottom.setButtonSymbols(QDoubleSpinBox.ButtonSymbols.NoButtons)
 
         self.overlap = QDoubleSpinBox()
-        self.overlap.setRange(-1000, 1000)
+        self.overlap.setRange(0, 100)
         self.overlap.setValue(0)
         self.overlap.setSuffix(" %")
 

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -226,7 +226,7 @@ class GridPlanWidget(QWidget):
             self._on_change()
 
     def value(self) -> useq.GridFromEdges | useq.GridRowsColumns | useq.GridWidthHeight:
-        over = self.overlap.value() / 100
+        over = self.overlap.value()
         _order = cast("OrderMode", self.order.currentEnum())
         common = {
             "overlap": (over, over),
@@ -284,6 +284,9 @@ class GridPlanWidget(QWidget):
                 self._fov_height = value.fov_height
             if value.fov_width:
                 self._fov_width = value.fov_width
+
+            if value.overlap:
+                self.overlap.setValue(value.overlap[0])
 
             self.order.setCurrentEnum(OrderMode(value.mode.value))
 

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -98,7 +98,7 @@ class GridPlanWidget(QWidget):
         self.bottom.setButtonSymbols(QDoubleSpinBox.ButtonSymbols.NoButtons)
 
         self.overlap = QDoubleSpinBox()
-        self.overlap.setRange(0, 100)
+        self.overlap.setRange(-1000, 1000)
         self.overlap.setValue(0)
         self.overlap.setSuffix(" %")
 

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -97,7 +97,7 @@ class GridPlanWidget(QWidget):
         self.bottom.setDecimals(3)
         self.bottom.setButtonSymbols(QDoubleSpinBox.ButtonSymbols.NoButtons)
 
-        self.overlap = QSpinBox()
+        self.overlap = QDoubleSpinBox()
         self.overlap.setRange(-1000, 1000)
         self.overlap.setValue(0)
         self.overlap.setSuffix(" %")

--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -384,13 +384,13 @@ def test_grid_plan_widget(qtbot: QtBot) -> None:
     wdg.setMode("area")
     assert isinstance(wdg.value(), useq.GridWidthHeight)
 
-    plan = useq.GridRowsColumns(rows=3, columns=3, mode="spiral")
+    plan = useq.GridRowsColumns(rows=3, columns=3, mode="spiral", overlap=10)
     with qtbot.waitSignal(wdg.valueChanged):
         wdg.setValue(plan)
     assert wdg.mode() == _grid.Mode.NUMBER
     assert wdg.value() == plan
 
-    plan = useq.GridFromEdges(left=1, right=2, top=3, bottom=4)
+    plan = useq.GridFromEdges(left=1, right=2, top=3, bottom=4, overlap=10)
     with qtbot.waitSignal(wdg.valueChanged):
         wdg.setValue(plan)
     assert wdg.mode() == _grid.Mode.BOUNDS


### PR DESCRIPTION
The `GridPlanWidget` overlap spinbox value was not correctly expressed in percentage as in `useq-schema`. This PR fixes it + update the tests.

related to (https://github.com/pymmcore-plus/useq-schema/issues/149#issuecomment-1832557352)

@tlambert03 do you want to switch it form 0-100% to 0-1? Should we change it also in `useq-schema`?