### PR TITLE
test: fix tests for pymmcore 11.1.1.71.0

### DIFF
--- a/tests/test_prop_widget.py
+++ b/tests/test_prop_widget.py
@@ -61,7 +61,11 @@ def test_property_widget(dev, prop, qtbot):
 
     before = wdg.value()
     wdg.setValue(val)
-    if CORE.isPropertyPreInit(dev, prop):
+
+    strict_init = hasattr(CORE, "isFeatureEnabled") and CORE.isFeatureEnabled(
+        "StrictInitializationChecks"
+    )
+    if CORE.isPropertyPreInit(dev, prop) and strict_init:
         # as of pymmcore 10.7.0.71.0, setting pre-init properties
         # after the device has been initialized does nothing.
         _assert_equal(wdg.value(), before)


### PR DESCRIPTION
This fixes tests after the release of 11.1.1.71.0, which reverted the strict feature flag added in the previous version (that makes setting pre-init properties after initialization a no-op)