### PR TITLE
fix: fix bug when checking tabs in MDASequenceWidget on macOS Qt6

### DIFF
--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -493,4 +493,4 @@ def test_tab_check(qtbot: QtBot) -> None:
     qtbot.wait(220)
 
     with qtbot.waitSignal(mda.valueChanged):
-        mda._on_tab_checked(2, True)
+        mda.tab_wdg.setChecked(2, True)

--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -479,3 +479,18 @@ def test_parse_time() -> None:
     assert parse_timedelta("3:40:10.500") == timedelta(
         hours=3, minutes=40, seconds=10.5
     )
+
+
+def test_tab_check(qtbot: QtBot) -> None:
+    """Testing a bug on mac that occurs when checking tabs"""
+
+    mda = MDASequenceWidget()
+    qtbot.addWidget(mda)
+    mda.show()  # needed to show the bug
+    # this seems to be needed to show the bug
+    # qtbot.waitExposed(mda) and waitUntil(isVisible) don't seem to work work
+    # this may still occasionally pass, and longer wait times help...
+    qtbot.wait(220)
+
+    with qtbot.waitSignal(mda.valueChanged):
+        mda._on_tab_checked(2, True)


### PR DESCRIPTION
this PR will (eventually) fix a bug that @fdrgsp found on macos, with Qt6, that causes a hard crash when clicking a tab in the MDASequence widget.

For now, just a failing test.  it fails locally, but curious to see what happens on CI