### PR TITLE
feat: add the possibility to invert the axis in the stage widget

### DIFF
--- a/src/pymmcore_widgets/_stage_widget.py
+++ b/src/pymmcore_widgets/_stage_widget.py
@@ -169,6 +169,9 @@ class StageWidget(QWidget):
 
         self.snap_checkbox = QCheckBox(text="Snap on Click")
 
+        self._invert_x = QCheckBox(text="Invert X")
+        self._invert_y = QCheckBox(text="Invert Y")
+
         self.radiobutton = QRadioButton(text="Set as Default")
         self.radiobutton.toggled.connect(self._on_radiobutton_toggled)
 
@@ -183,13 +186,15 @@ class StageWidget(QWidget):
         bottom_row_1.layout().addWidget(self._readout)
 
         bottom_row_2 = QWidget()
-        bottom_row_2_layout = QHBoxLayout()
-        bottom_row_2_layout.setSpacing(10)
+        bottom_row_2_layout = QGridLayout()
+        bottom_row_2_layout.setSpacing(15)
         bottom_row_2_layout.setContentsMargins(0, 0, 0, 0)
         bottom_row_2_layout.setAlignment(AlignCenter)
         bottom_row_2.setLayout(bottom_row_2_layout)
-        bottom_row_2.layout().addWidget(self.snap_checkbox)
-        bottom_row_2.layout().addWidget(self._poll_cb)
+        bottom_row_2.layout().addWidget(self.snap_checkbox, 0, 0)
+        bottom_row_2.layout().addWidget(self._poll_cb, 0, 1)
+        bottom_row_2.layout().addWidget(self._invert_x, 1, 0)
+        bottom_row_2.layout().addWidget(self._invert_y, 1, 1)
 
         self.setLayout(QVBoxLayout())
         self.layout().setSpacing(0)
@@ -348,6 +353,12 @@ class StageWidget(QWidget):
     def _on_click(self) -> None:
         btn: QPushButton = self.sender()
         xmag, ymag = self.BTNS[f"{PREFIX}.{btn.text()}"][-2:]
+
+        if self._invert_x.isChecked():
+            xmag *= -1
+        if self._invert_y.isChecked():
+            ymag *= -1
+
         self._move_stage(self._scale(xmag), self._scale(ymag))
 
     def _move_stage(self, x: float, y: float) -> None:

--- a/tests/test_stage_widget.py
+++ b/tests/test_stage_widget.py
@@ -128,8 +128,7 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert not stage_z1.radiobutton.isChecked()
 
 
-def test_invert_xy(qtbot: QtBot, global_mmcore: CMMCorePlus):
-    # test XY stage
+def test_invert_axis(qtbot: QtBot, global_mmcore: CMMCorePlus):
     stage_xy = StageWidget("XY", levels=3)
     qtbot.addWidget(stage_xy)
 

--- a/tests/test_stage_widget.py
+++ b/tests/test_stage_widget.py
@@ -126,3 +126,29 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     global_mmcore.setProperty("Core", "Focus", "Z1")
     assert stage_z.radiobutton.isChecked()
     assert not stage_z1.radiobutton.isChecked()
+
+
+def test_invert_xy(qtbot: QtBot, global_mmcore: CMMCorePlus):
+    # test XY stage
+    stage_xy = StageWidget("XY", levels=3)
+    qtbot.addWidget(stage_xy)
+
+    xy_up_3 = stage_xy._btns.layout().itemAtPosition(0, 3)
+    xy_left_1 = stage_xy._btns.layout().itemAtPosition(3, 2)
+
+    stage_xy.setStep(15.0)
+
+    xy_left_1.widget().click()
+    assert global_mmcore.getXPosition() == -15.0
+    global_mmcore.waitForSystem()
+    stage_xy._invert_x.setChecked(True)
+    xy_left_1.widget().click()
+    assert global_mmcore.getXPosition() == 0.0
+
+    global_mmcore.waitForSystem()
+    xy_up_3.widget().click()
+    assert global_mmcore.getYPosition() == 45.0
+    global_mmcore.waitForSystem()
+    stage_xy._invert_y.setChecked(True)
+    xy_up_3.widget().click()
+    assert global_mmcore.getYPosition() == 0.0


### PR DESCRIPTION
This PR adds two checkboxes to the `StageWidget`, `invert X` and `invert Y`, to invert the direction of the stage movements when the arrow buttons are pressed. 

<img width="310" alt="Screenshot 2024-01-10 at 1 56 19 PM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/63a4bb14-64c8-4b62-b425-4a29c0a698fc">
