### PR TITLE
fix: hide invert xy checkboxes if not xy stage in StageWidget

### DIFF
--- a/src/pymmcore_widgets/_stage_widget.py
+++ b/src/pymmcore_widgets/_stage_widget.py
@@ -204,6 +204,10 @@ class StageWidget(QWidget):
         self.layout().addWidget(bottom_row_1)
         self.layout().addWidget(bottom_row_2)
 
+        if self._dtype is not DeviceType.XYStage:
+            self._invert_x.hide()
+            self._invert_y.hide()
+
     def _connect_events(self) -> None:
         self._mmc.events.propertyChanged.connect(self._on_prop_changed)
         self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg)

--- a/tests/test_stage_widget.py
+++ b/tests/test_stage_widget.py
@@ -132,6 +132,9 @@ def test_invert_axis(qtbot: QtBot, global_mmcore: CMMCorePlus):
     stage_xy = StageWidget("XY", levels=3)
     qtbot.addWidget(stage_xy)
 
+    assert not stage_xy._invert_x.isHidden()
+    assert not stage_xy._invert_y.isHidden()
+
     xy_up_3 = stage_xy._btns.layout().itemAtPosition(0, 3)
     xy_left_1 = stage_xy._btns.layout().itemAtPosition(3, 2)
 
@@ -151,3 +154,14 @@ def test_invert_axis(qtbot: QtBot, global_mmcore: CMMCorePlus):
     stage_xy._invert_y.setChecked(True)
     xy_up_3.widget().click()
     assert global_mmcore.getYPosition() == 0.0
+
+    stage_z = StageWidget("Z", levels=3)
+    qtbot.addWidget(stage_z)
+
+    assert stage_z._invert_x.isHidden()
+    assert stage_z._invert_y.isHidden()
+
+    z_up_2 = stage_z._btns.layout().itemAtPosition(1, 3)
+    z_up_2.widget().click()
+
+    assert global_mmcore.getPosition() == 20.0


### PR DESCRIPTION
This PR add a fix to PR #260. We need to hide the `invert X` and `invert Y` checkboxes if the stage is not a `XYStage` type.

test updated.

<img width="388" alt="Screenshot 2024-01-10 at 4 28 44 PM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/7772a0f4-729f-4544-8e8c-cdb6d4460482">
