### PR TITLE
fix: fix bugs in  ChannelTable

### DIFF
--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -57,16 +57,6 @@ class CoreConnectedChannelTable(ChannelTable):
         if ch_group and ch_group in self.channelGroups():
             self._group_combo.setCurrentText(ch_group)
 
-    # def _update_channel_groups(self) -> None:
-    #     ch_group = self._mmc.getChannelGroup()
-    #     # if there is no channel group available, use all available groups
-    #     names = [ch_group] if ch_group else self._mmc.getAvailableConfigGroups()
-    #     groups = {
-    #         group_name: self._mmc.getAvailableConfigs(group_name)
-    #         for group_name in names
-    #     }
-    #     self.channels.setChannelGroups(groups)
-
     def _disconnect(self) -> None:
         """Disconnect from the core instance."""
         self._mmc.events.systemConfigurationLoaded.disconnect(

--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -66,7 +66,5 @@ class CoreConnectedChannelTable(ChannelTable):
         if not self._mmc.getChannelGroup():
             return
 
-        data = {
-            self.GROUP.key: self._mmc.getChannelGroup(),
-        }
+        data = {self.GROUP.key: self._group_combo.currentText()}
         self.table().setRowData(row, data)

--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pymmcore_plus import CMMCorePlus
-from superqt.utils import signals_blocked
 
 from pymmcore_widgets.useq_widgets import ChannelTable
 
@@ -38,33 +37,15 @@ class CoreConnectedChannelTable(ChannelTable):
         super().__init__(rows, parent)
         self._mmc = mmcore or CMMCorePlus.instance()
 
-        # when a new row is inserted, call _on_rows_inserted
-        # to update the new values from the core channels
-        self.table().model().rowsInserted.connect(self._on_rows_inserted)
+        # connections
+        self._mmc.events.systemConfigurationLoaded.connect(self._update_channel_groups)
+        self._mmc.events.configGroupDeleted.connect(self._update_channel_groups)
+        self._mmc.events.configDefined.connect(self._update_channel_groups)
 
-    def _add_row(self) -> None:
-        """Add a new to the end of the table and use the current core position."""
-        # note: _add_row is only called when act_add_row is triggered
-        # (e.g. when the + button is clicked). Not when a row is added programmatically
+        self._update_channel_groups()
 
-        # block the signal that's going to be emitted until _on_rows_inserted
-        # has had a chance to update the values from the current channels
-        with signals_blocked(self):
-            super()._add_row()
-        self.valueChanged.emit()
-
-    def _on_rows_inserted(self, parent: Any, start: int, end: int) -> None:
-        # when a new row is inserted by any means, populate it
-        # this is connected above in __init_ with self.model().rowsInserted.connect
-        with signals_blocked(self):
-            for row_idx in range(start, end + 1):
-                self._set_channel_group_from_core(row_idx)
-        self.valueChanged.emit()
-
-    def _set_channel_group_from_core(self, row: int, col: int = 0) -> None:
-        """Set the current core channel group at the given row."""
-        if not self._mmc.getChannelGroup():
-            return
-
-        data = {self.GROUP.key: self._group_combo.currentText()}
-        self.table().setRowData(row, data)
+    def _update_channel_groups(self) -> None:
+        """Update the channel groups when the system configuration is loaded."""
+        gps = self._mmc.getAvailableConfigGroups()
+        GROUPS = {group: self._mmc.getAvailableConfigs(group) for group in gps}
+        self.setChannelGroups(GROUPS)

--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pymmcore_plus import CMMCorePlus
+from superqt.utils import signals_blocked
+
+from pymmcore_widgets.useq_widgets import ChannelTable
+
+if TYPE_CHECKING:
+    from qtpy.QtWidgets import QWidget
+
+DEFAULT_EXP = 100.0
+
+
+class CoreConnectedChannelTable(ChannelTable):
+    """[ChannelTable](../ChannelTable#) connected to a Micro-Manager core instance.
+
+    Parameters
+    ----------
+    rows : int
+        Number of rows to initialize the table with, by default 0.
+    mmcore : CMMCorePlus | None
+        Optional [`CMMCorePlus`][pymmcore_plus.CMMCorePlus] micromanager core.
+        By default, None. If not specified, the widget will use the active
+        (or create a new)
+        [`CMMCorePlus.instance`][pymmcore_plus.core._mmcore_plus.CMMCorePlus.instance].
+    parent : QWidget | None
+        Optional parent widget, by default None.
+    """
+
+    def __init__(
+        self,
+        rows: int = 0,
+        mmcore: CMMCorePlus | None = None,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(rows, parent)
+        self._mmc = mmcore or CMMCorePlus.instance()
+
+        # when a new row is inserted, call _on_rows_inserted
+        # to update the new values from the core channels
+        self.table().model().rowsInserted.connect(self._on_rows_inserted)
+
+    def _add_row(self) -> None:
+        """Add a new to the end of the table and use the current core position."""
+        # note: _add_row is only called when act_add_row is triggered
+        # (e.g. when the + button is clicked). Not when a row is added programmatically
+
+        # block the signal that's going to be emitted until _on_rows_inserted
+        # has had a chance to update the values from the current channels
+        with signals_blocked(self):
+            super()._add_row()
+        self.valueChanged.emit()
+
+    def _on_rows_inserted(self, parent: Any, start: int, end: int) -> None:
+        # when a new row is inserted by any means, populate it
+        # this is connected above in __init_ with self.model().rowsInserted.connect
+        with signals_blocked(self):
+            for row_idx in range(start, end + 1):
+                self._set_channel_group_from_core(row_idx)
+        self.valueChanged.emit()
+
+    def _set_channel_group_from_core(self, row: int, col: int = 0) -> None:
+        """Set the current core channel group at the given row."""
+        if not self._mmc.getChannelGroup():
+            return
+
+        data = {
+            self.GROUP.key: self._mmc.getChannelGroup(),
+        }
+        self.table().setRowData(row, data)

--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -41,6 +41,9 @@ class CoreConnectedChannelTable(ChannelTable):
         self._mmc.events.systemConfigurationLoaded.connect(self._update_channel_groups)
         self._mmc.events.configGroupDeleted.connect(self._update_channel_groups)
         self._mmc.events.configDefined.connect(self._update_channel_groups)
+        self._mmc.events.channelGroupChanged.connect(self._update_channel_groups)
+
+        self.destroyed.connect(self._disconnect)
 
         self._update_channel_groups()
 
@@ -49,3 +52,16 @@ class CoreConnectedChannelTable(ChannelTable):
         gps = self._mmc.getAvailableConfigGroups()
         GROUPS = {group: self._mmc.getAvailableConfigs(group) for group in gps}
         self.setChannelGroups(GROUPS)
+
+        ch_group = self._mmc.getChannelGroup()
+        if ch_group and ch_group in self.channelGroups():
+            self._group_combo.setCurrentText(ch_group)
+
+    def _disconnect(self) -> None:
+        """Disconnect from the core instance."""
+        self._mmc.events.systemConfigurationLoaded.disconnect(
+            self._update_channel_groups
+        )
+        self._mmc.events.configGroupDeleted.disconnect(self._update_channel_groups)
+        self._mmc.events.configDefined.disconnect(self._update_channel_groups)
+        self._mmc.events.channelGroupChanged.disconnect(self._update_channel_groups)

--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -67,7 +67,6 @@ class CoreConnectedChannelTable(ChannelTable):
     #     }
     #     self.channels.setChannelGroups(groups)
 
-
     def _disconnect(self) -> None:
         """Disconnect from the core instance."""
         self._mmc.events.systemConfigurationLoaded.disconnect(

--- a/src/pymmcore_widgets/mda/_core_channels.py
+++ b/src/pymmcore_widgets/mda/_core_channels.py
@@ -57,6 +57,17 @@ class CoreConnectedChannelTable(ChannelTable):
         if ch_group and ch_group in self.channelGroups():
             self._group_combo.setCurrentText(ch_group)
 
+    # def _update_channel_groups(self) -> None:
+    #     ch_group = self._mmc.getChannelGroup()
+    #     # if there is no channel group available, use all available groups
+    #     names = [ch_group] if ch_group else self._mmc.getAvailableConfigGroups()
+    #     groups = {
+    #         group_name: self._mmc.getAvailableConfigs(group_name)
+    #         for group_name in names
+    #     }
+    #     self.channels.setChannelGroups(groups)
+
+
     def _disconnect(self) -> None:
         """Disconnect from the core instance."""
         self._mmc.events.systemConfigurationLoaded.disconnect(

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -98,7 +98,6 @@ class MDAWidget(MDASequenceWidget):
         self.control_btns.cancel_btn.released.connect(self._mmc.mda.cancel)
         self._mmc.mda.events.sequenceStarted.connect(self._on_mda_started)
         self._mmc.mda.events.sequenceFinished.connect(self._on_mda_finished)
-        self._mmc.events.channelGroupChanged.connect(self._update_channel_groups)
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_config_loaded)
 
         self.destroyed.connect(self._disconnect)
@@ -106,7 +105,6 @@ class MDAWidget(MDASequenceWidget):
     def _on_sys_config_loaded(self) -> None:
         # TODO: connect objective change event to update suggested step
         self.z_plan.setSuggestedStep(_guess_NA(self._mmc) or 0.5)
-        self._update_channel_groups()
 
     def value(self) -> MDASequence:
         """Set the current state of the widget from a [`useq.MDASequence`][]."""
@@ -149,19 +147,6 @@ class MDAWidget(MDASequenceWidget):
         y = self._mmc.getYPosition() if self._mmc.getXYStageDevice() else None
         z = self._mmc.getPosition() if self._mmc.getFocusDevice() else None
         return Position(x=x, y=y, z=z)
-
-    def _update_channel_groups(self) -> None:
-        names = self._mmc.getAvailableConfigGroups()
-        groups = {
-            group_name: self._mmc.getAvailableConfigs(group_name)
-            for group_name in names
-        }
-        self.channels.setChannelGroups(groups)
-
-        # set the current channel group in the channel combo
-        ch_group = self._mmc.getChannelGroup()
-        if ch_group and ch_group in self.channels.channelGroups():
-            self.channels._group_combo.setCurrentText(ch_group)
 
     def _on_run_clicked(self) -> None:
         """Run the MDA sequence experiment."""
@@ -212,7 +197,6 @@ class MDAWidget(MDASequenceWidget):
         with suppress(Exception):
             self._mmc.mda.events.sequenceStarted.disconnect(self._on_mda_started)
             self._mmc.mda.events.sequenceFinished.disconnect(self._on_mda_finished)
-            self._mmc.events.channelGroupChanged.disconnect(self._update_channel_groups)
 
 
 class _SaveGroupBox(QGroupBox):

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -22,10 +22,10 @@ from superqt.fonticon import icon
 from useq import MDASequence, Position
 
 from pymmcore_widgets.useq_widgets import MDASequenceWidget
-from pymmcore_widgets.useq_widgets._channels import ChannelTable
 from pymmcore_widgets.useq_widgets._mda_sequence import MDATabs
 from pymmcore_widgets.useq_widgets._time import TimePlanWidget
 
+from ._core_channels import CoreConnectedChannelTable
 from ._core_grid import CoreConnectedGridPlanWidget
 from ._core_positions import CoreConnectedPositionTable
 from ._core_z import CoreConnectedZPlanWidget
@@ -50,7 +50,7 @@ class CoreMDATabs(MDATabs):
         self.stage_positions = CoreConnectedPositionTable(1, mmcore=self._mmc)
         self.z_plan = CoreConnectedZPlanWidget(self._mmc)
         self.grid_plan = CoreConnectedGridPlanWidget(self._mmc)
-        self.channels = ChannelTable(1)
+        self.channels = CoreConnectedChannelTable(1)
 
 
 class MDAWidget(MDASequenceWidget):

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -47,10 +47,10 @@ class CoreMDATabs(MDATabs):
 
     def create_subwidgets(self) -> None:
         self.time_plan = TimePlanWidget(1)
-        self.stage_positions = CoreConnectedPositionTable(1, mmcore=self._mmc)
+        self.stage_positions = CoreConnectedPositionTable(1, self._mmc)
         self.z_plan = CoreConnectedZPlanWidget(self._mmc)
         self.grid_plan = CoreConnectedGridPlanWidget(self._mmc)
-        self.channels = CoreConnectedChannelTable(1)
+        self.channels = CoreConnectedChannelTable(1, self._mmc)
 
 
 class MDAWidget(MDASequenceWidget):
@@ -151,14 +151,17 @@ class MDAWidget(MDASequenceWidget):
         return Position(x=x, y=y, z=z)
 
     def _update_channel_groups(self) -> None:
-        ch_group = self._mmc.getChannelGroup()
-        # if there is no channel group available, use all available groups
-        names = [ch_group] if ch_group else self._mmc.getAvailableConfigGroups()
+        names = self._mmc.getAvailableConfigGroups()
         groups = {
             group_name: self._mmc.getAvailableConfigs(group_name)
             for group_name in names
         }
         self.channels.setChannelGroups(groups)
+
+        # set the current channel group in the channel combo
+        ch_group = self._mmc.getChannelGroup()
+        if ch_group and ch_group in self.channels.channelGroups():
+            self.channels._group_combo.setCurrentText(ch_group)
 
     def _on_run_clicked(self) -> None:
         """Run the MDA sequence experiment."""

--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -74,6 +74,7 @@ class ChannelTable(DataTableWidget):
             if ngroups_before > 1:
                 toolbar.removeAction(actions[1])
         elif ngroups_before <= 1:
+            self._group_combo.show()
             toolbar.insertWidget(actions[0], self._group_combo)
 
         self._on_group_changed()

--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 import useq
 from pymmcore_plus import Keyword
-from qtpy.QtWidgets import QComboBox, QWidgetAction
+from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QWidget, QWidgetAction
 from superqt.utils import signals_blocked
 
 from ._column_info import (
@@ -17,9 +17,6 @@ from ._column_info import (
     TextColumn,
 )
 from ._data_table import DataTableWidget
-
-if TYPE_CHECKING:
-    from qtpy.QtWidgets import QWidget
 
 NAMED_CONFIG = TextColumn(key="config", default=None, is_row_selector=True)
 DEFAULT_GROUP = Keyword.Channel
@@ -40,6 +37,14 @@ class ChannelTable(DataTableWidget):
         super().__init__(rows, parent)
         self._group_combo = QComboBox()
         self._group_combo.currentTextChanged.connect(self._on_group_changed)
+
+        self._group_wdg = QWidget()
+        layout = QHBoxLayout(self._group_wdg)
+        layout.addWidget(QLabel("Group:"))
+        layout.addWidget(self._group_combo)
+        layout.addStretch()
+        layout.setContentsMargins(5, 0, 0, 0)
+
         # These will change in on_group_changed... so we store the current values.
         self._groups: Mapping[str, Sequence[str]] = {}
         self._config_column: ColumnInfo = self.CONFIG
@@ -74,8 +79,8 @@ class ChannelTable(DataTableWidget):
             if ngroups_before > 1:
                 toolbar.removeAction(actions[1])
         elif ngroups_before <= 1:
-            self._group_combo.show()
-            toolbar.insertWidget(actions[0], self._group_combo)
+            self._group_wdg.show()
+            toolbar.insertWidget(actions[0], self._group_wdg)
 
         self._on_group_changed()
 

--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -4,6 +4,7 @@ from collections import Counter
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 import useq
+from pymmcore_plus import Keyword
 from qtpy.QtWidgets import QComboBox, QWidgetAction
 from superqt.utils import signals_blocked
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget
 
 NAMED_CONFIG = TextColumn(key="config", default=None, is_row_selector=True)
-DEFAULT_GROUP = "Channel"
+DEFAULT_GROUP = Keyword.Channel
 
 
 class ChannelTable(DataTableWidget):

--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -8,6 +8,7 @@ import pint
 import pytest
 import useq
 from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QWidgetAction
 
 import pymmcore_widgets
 from pymmcore_widgets.useq_widgets import (
@@ -261,8 +262,15 @@ def test_channel_groups(qtbot: QtBot) -> None:
     qtbot.addWidget(wdg)
     wdg.show()
 
+    actions = [x for x in wdg.toolBar().children() if isinstance(x, QWidgetAction)]
+    assert len(actions) == 1
+
     GROUPS = {"Channels": ["DAPI", "FITC"], "Other": ["foo", "bar"]}
     wdg.setChannelGroups(GROUPS)
+
+    actions = [x for x in wdg.toolBar().children() if isinstance(x, QWidgetAction)]
+    assert len(actions) == 2
+
     assert wdg.channelGroups() == GROUPS
     wdg.act_add_row.trigger()
     with qtbot.waitSignal(wdg.valueChanged):

--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -8,7 +8,6 @@ import pint
 import pytest
 import useq
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtWidgets import QWidgetAction
 
 import pymmcore_widgets
 from pymmcore_widgets.useq_widgets import (
@@ -262,14 +261,8 @@ def test_channel_groups(qtbot: QtBot) -> None:
     qtbot.addWidget(wdg)
     wdg.show()
 
-    actions = [x for x in wdg.toolBar().children() if isinstance(x, QWidgetAction)]
-    assert len(actions) == 1
-
     GROUPS = {"Channels": ["DAPI", "FITC"], "Other": ["foo", "bar"]}
     wdg.setChannelGroups(GROUPS)
-
-    actions = [x for x in wdg.toolBar().children() if isinstance(x, QWidgetAction)]
-    assert len(actions) == 2
 
     assert wdg.channelGroups() == GROUPS
     wdg.act_add_row.trigger()

--- a/tests/test_useq_widgets.py
+++ b/tests/test_useq_widgets.py
@@ -261,14 +261,14 @@ def test_channel_groups(qtbot: QtBot) -> None:
     qtbot.addWidget(wdg)
     wdg.show()
 
-    GROUPS = {"Channel": ["DAPI", "FITC"], "Other": ["foo", "bar"]}
+    GROUPS = {"Channels": ["DAPI", "FITC"], "Other": ["foo", "bar"]}
     wdg.setChannelGroups(GROUPS)
     assert wdg.channelGroups() == GROUPS
     wdg.act_add_row.trigger()
     with qtbot.waitSignal(wdg.valueChanged):
         wdg.act_add_row.trigger()
     val = wdg.value()
-    assert val[0].group == "Channel"
+    assert val[0].group == "Channels"
     assert val[0].config == "DAPI"
     assert val[1].config == "FITC"
 
@@ -280,7 +280,7 @@ def test_channel_groups(qtbot: QtBot) -> None:
     wdg.setChannelGroups(None)
 
     val = wdg.value()
-    assert val[0].group == "Channel"
+    assert val[0].group == "Channel"  # default
     assert val[0].config == ""
     assert val[1].config == ""
     with qtbot.waitSignal(wdg.valueChanged):


### PR DESCRIPTION
This PR fix two bugs in the `ChannelTable` and create a `CoreConnectedChannelTable` to handle any changes when using a core.

1) the `_group_combo` is "hidden" if there is only one channel group but if you use the `setChannelGroups` method and you set more than one group, the `_group_combo` does not show up. This PR fixes this behavior.

2) before,  we did not get the channel group **from the `_group_combo`** and when adding a channel using the table button, the channel group was set to the default "Channel" even if the channel group selected in the `_group_combo` had a different name (we did not see that before because in the test config the channel group is named "Channel" as the default). This PR fixes this behavior by adding a `_on_rows_inserted` method connected to the table `model().rowsInserted` signal.

3) add a `CoreConnectedChannelTable` to handle cases when a group is deleted or created or a config is loaded.

4) add tests