### PR TITLE
refactor: relax expectations of imageSnapped callback

### DIFF
--- a/src/pymmcore_widgets/_image_widget.py
+++ b/src/pymmcore_widgets/_image_widget.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from contextlib import suppress
 
 from typing import TYPE_CHECKING
 
@@ -92,10 +93,8 @@ class ImagePreview(QWidget):
         self.streaming_timer.setInterval(int(value))
 
     def _on_streaming_timeout(self) -> None:
-        try:
+        with suppress(RuntimeError, IndexError):
             self._update_image(self._mmc.getLastImage())
-        except (RuntimeError, IndexError):
-            return
 
     def _on_image_snapped(self) -> None:
         self._update_image(self._mmc.getImage())

--- a/src/pymmcore_widgets/_image_widget.py
+++ b/src/pymmcore_widgets/_image_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from pymmcore_plus import CMMCorePlus

--- a/src/pymmcore_widgets/_image_widget.py
+++ b/src/pymmcore_widgets/_image_widget.py
@@ -60,7 +60,7 @@ class ImagePreview(QWidget):
         self.streaming_timer = QTimer(parent=self)
         self.streaming_timer.setTimerType(Qt.TimerType.PreciseTimer)
         self.streaming_timer.setInterval(int(self._mmc.getExposure()) or _DEFAULT_WAIT)
-        self.streaming_timer.timeout.connect(self._on_image_snapped)
+        self.streaming_timer.timeout.connect(self._on_streaming_timeout)
 
         ev = self._mmc.events
         ev.imageSnapped.connect(self._on_image_snapped)
@@ -91,13 +91,16 @@ class ImagePreview(QWidget):
     def _on_exposure_changed(self, device: str, value: str) -> None:
         self.streaming_timer.setInterval(int(value))
 
-    def _on_image_snapped(self, img: np.ndarray | None = None) -> None:
-        if img is None:
-            try:
-                img = self._mmc.getLastImage()
-            except (RuntimeError, IndexError):
-                return
+    def _on_streaming_timeout(self) -> None:
+        try:
+            self._update_image(self._mmc.getLastImage())
+        except (RuntimeError, IndexError):
+            return
 
+    def _on_image_snapped(self) -> None:
+        self._update_image(self._mmc.getImage())
+
+    def _update_image(self, img: np.ndarray) -> None:
         clim = (img.min(), img.max()) if self._clims == "auto" else self._clims
         if self.image is None:
             self.image = self._imcls(

--- a/tests/test_stage_widget.py
+++ b/tests/test_stage_widget.py
@@ -68,7 +68,6 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     with qtbot.waitSignal(global_mmcore.events.imageSnapped) as snap:
         global_mmcore.waitForDevice("XY")
         xy_up_3.widget().click()
-        assert isinstance(snap.args[0], np.ndarray)
 
     # test Z stage
     stage_z = StageWidget("Z", levels=3)


### PR DESCRIPTION
this PR would allow https://github.com/pymmcore-plus/pymmcore-plus/pull/314 to pass downstream tests.

This relaxes the expectations of the `imageSnapped` signal coming from pymmcore-plus.  It no longer requires the callback to provide an argument, instead opting to call `getImage` manually after receiving the signal.  see details in PR above, but ultimately that allows pymmcore-plus to emit signals in a slightly less surprising way and is probably better in the long term.  