### PR TITLE
test: fix test logging warning

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -109,7 +109,7 @@ class MDAWidget(MDASequenceWidget):
     def value(self) -> MDASequence:
         """Set the current state of the widget from a [`useq.MDASequence`][]."""
         val = super().value()
-        replace = {}
+        replace: dict = {}
 
         # if the z plan is relative, and there are no stage positions, add the current
         # stage position as the relative starting one.

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -448,8 +448,8 @@ def test_run_mda_af_warning(qtbot: QtBot):
     with patch.object(QMessageBox, "warning", _ok):
         with qtbot.waitSignal(wdg._mmc.mda.events.sequenceStarted):
             wdg.control_btns.run_btn.click()
-
-    assert wdg._mmc.mda.is_running()
+        with qtbot.waitSignal(wdg._mmc.mda.events.sequenceFinished):
+            assert wdg._mmc.mda.is_running()
 
 
 def test_core_connected_channel_wdg(qtbot: QtBot):


### PR DESCRIPTION
fixes a threading issue with mda running (and logging) after test has finished