### PR TITLE
fix: choose to update ImagePreview when mda is running

### DIFF
--- a/src/pymmcore_widgets/_image_widget.py
+++ b/src/pymmcore_widgets/_image_widget.py
@@ -97,6 +97,8 @@ class ImagePreview(QWidget):
             self._update_image(self._mmc.getLastImage())
 
     def _on_image_snapped(self) -> None:
+        if self._mmc.mda.is_running():
+            return
         self._update_image(self._mmc.getImage())
 
     def _update_image(self, img: np.ndarray) -> None:

--- a/src/pymmcore_widgets/_image_widget.py
+++ b/src/pymmcore_widgets/_image_widget.py
@@ -31,7 +31,7 @@ class ImagePreview(QWidget):
         (or create a new)
         [`CMMCorePlus.instance`][pymmcore_plus.core._mmcore_plus.CMMCorePlus.instance].
     use_with_mda: bool
-        If True, the widget will also update when a Multi-Dimensional Acquisition is
+        If False, the widget will not update when a Multi-Dimensional Acquisition is
         running. By default, True.
     """
 

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -47,7 +47,7 @@ def test_image_preview_update_while_running_mda(qtbot: "QtBot"):
     assert widget.image is None
     assert widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.events.imageSnapped):
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
         mmc.mda.run(seq)
     assert widget.image is not None
 
@@ -62,6 +62,6 @@ def test_image_preview_no_update_while_running_mda(qtbot: "QtBot"):
     assert widget.image is None
     assert not widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.events.imageSnapped):
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
         mmc.mda.run(seq)
     assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -49,7 +49,7 @@ def test_image_preview_while_running_mda(qtbot: "QtBot"):
     assert widget.image is not None
 
     widget.image = None
-    widget.use_with_mda = True
+    widget.use_with_mda = False
 
     with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
         mmc.run_mda(seq)

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -35,22 +35,21 @@ def test_image_preview(qtbot: "QtBot"):
 
 
 def test_image_preview_while_running_mda(qtbot: "QtBot"):
-    widget = ImagePreview()
+    widget = ImagePreview(use_with_mda=False)
     qtbot.addWidget(widget)
     mmc = widget._mmc
 
     seq = useq.MDASequence(channels=["FITC"])
 
     assert widget.image is None
-    assert widget.use_with_mda
+    assert not widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
-        mmc.run_mda(seq)
-    assert widget.image is not None
-
-    widget.image = None
-    widget.use_with_mda = False
-
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+    with qtbot.waitSignals([mmc.events.imageSnapped, mmc.mda.events.sequenceFinished]):
         mmc.run_mda(seq)
     assert widget.image is None
+
+    widget.use_with_mda = True
+
+    with qtbot.waitSignals([mmc.events.imageSnapped, mmc.mda.events.sequenceFinished]):
+        mmc.run_mda(seq)
+    assert widget.image is not None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-import useq
 from pymmcore_plus import CMMCorePlus
 
 from pymmcore_widgets import ImagePreview
@@ -32,34 +31,3 @@ def test_image_preview(qtbot: "QtBot"):
     assert widget.streaming_timer.isActive()
     mmcore.stopSequenceAcquisition()
     assert not widget.streaming_timer.isActive()
-
-
-seq = useq.MDASequence(channels=["FITC"])
-
-
-def test_image_preview_update_while_running_mda(qtbot: "QtBot"):
-    widget = ImagePreview()
-    qtbot.addWidget(widget)
-    mmc = widget._mmc
-
-    assert widget.image is None
-    assert widget.use_with_mda
-
-    with qtbot.waitSignal(mmc.events.imageSnapped):
-        mmc.mda.run(seq)
-    assert widget.image is not None
-
-
-def test_image_preview_no_update_while_running_mda(qtbot: "QtBot"):
-    widget = ImagePreview()
-    qtbot.addWidget(widget)
-    mmc = widget._mmc
-
-    widget.use_with_mda = False
-
-    assert widget.image is None
-    assert not widget.use_with_mda
-
-    with qtbot.waitSignal(mmc.events.imageSnapped):
-        mmc.mda.run(seq)
-    assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -48,7 +48,7 @@ def test_image_preview_update_while_running_mda(qtbot: "QtBot"):
     assert widget.use_with_mda
 
     with qtbot.waitSignal(mmc.events.imageSnapped):
-        mmc.run_mda(seq)
+        mmc.mda.run(seq)
     assert widget.image is not None
 
 
@@ -63,5 +63,5 @@ def test_image_preview_no_update_while_running_mda(qtbot: "QtBot"):
     assert not widget.use_with_mda
 
     with qtbot.waitSignal(mmc.events.imageSnapped):
-        mmc.run_mda(seq)
+        mmc.mda.run(seq)
     assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -53,9 +53,11 @@ def test_image_preview_update_while_running_mda(qtbot: "QtBot"):
 
 
 def test_image_preview_no_update_while_running_mda(qtbot: "QtBot"):
-    widget = ImagePreview(use_with_mda=False)
+    widget = ImagePreview()
     qtbot.addWidget(widget)
     mmc = widget._mmc
+
+    widget.use_with_mda = False
 
     assert widget.image is None
     assert not widget.use_with_mda

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -47,7 +47,7 @@ def test_image_preview_update_while_running_mda(qtbot: "QtBot"):
     assert widget.image is None
     assert widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+    with qtbot.waitSignal(mmc.events.imageSnapped):
         mmc.mda.run(seq)
     assert widget.image is not None
 
@@ -62,6 +62,6 @@ def test_image_preview_no_update_while_running_mda(qtbot: "QtBot"):
     assert widget.image is None
     assert not widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+    with qtbot.waitSignal(mmc.events.imageSnapped):
         mmc.mda.run(seq)
     assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -34,9 +34,7 @@ def test_image_preview(qtbot: "QtBot"):
     assert not widget.streaming_timer.isActive()
 
 
-seq = useq.MDASequence(
-    channels=["FITC"], time_plan=useq.TIntervalLoops(interval=0.1, loops=2)
-)
+seq = useq.MDASequence(channels=["FITC"])
 
 
 def test_image_preview_update_while_running_mda(qtbot: "QtBot"):

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -39,7 +39,9 @@ def test_image_preview_while_running_mda(qtbot: "QtBot"):
     qtbot.addWidget(widget)
     mmc = widget._mmc
 
-    seq = useq.MDASequence(channels=["FITC"])
+    seq = useq.MDASequence(
+        channels=["FITC"], time_plan=useq.TIntervalLoops(interval=0.1, loops=2)
+    )
 
     assert widget.image is None
     assert not widget.use_with_mda

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -35,21 +35,22 @@ def test_image_preview(qtbot: "QtBot"):
 
 
 def test_image_preview_while_running_mda(qtbot: "QtBot"):
-    widget = ImagePreview(use_with_mda=False)
+    widget = ImagePreview()
     qtbot.addWidget(widget)
     mmc = widget._mmc
 
-    assert widget.image is None
-    assert not widget.use_with_mda
-
     seq = useq.MDASequence(channels=["FITC"])
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
-        mmc.run_mda(seq)
     assert widget.image is None
-
-    widget.use_with_mda = True
+    assert widget.use_with_mda
 
     with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
         mmc.run_mda(seq)
     assert widget.image is not None
+
+    widget.image = None
+    widget.use_with_mda = True
+
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+        mmc.run_mda(seq)
+    assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -40,9 +40,18 @@ def test_image_preview_while_running_mda(qtbot: "QtBot"):
     mmc = widget._mmc
 
     assert widget.image is None
+    assert widget.use_with_mda
+
+    widget.use_with_mda = False
 
     seq = useq.MDASequence(channels=["FITC"])
 
     with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
         mmc.run_mda(seq)
     assert widget.image is None
+
+    widget.use_with_mda = True
+
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+        mmc.run_mda(seq)
+    assert widget.image is not None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
+import useq
 from pymmcore_plus import CMMCorePlus
 
 from pymmcore_widgets import ImagePreview
@@ -31,3 +32,17 @@ def test_image_preview(qtbot: "QtBot"):
     assert widget.streaming_timer.isActive()
     mmcore.stopSequenceAcquisition()
     assert not widget.streaming_timer.isActive()
+
+
+def test_image_preview_while_running_mda(qtbot: "QtBot"):
+    widget = ImagePreview()
+    qtbot.addWidget(widget)
+    mmc = widget._mmc
+
+    assert widget.image is None
+
+    seq = useq.MDASequence(channels=["FITC"])
+
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+        mmc.run_mda(seq)
+    assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -47,7 +47,7 @@ def test_image_preview_update_while_running_mda(qtbot: "QtBot"):
     assert widget.image is None
     assert widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+    with qtbot.waitSignal(mmc.events.imageSnapped):
         mmc.run_mda(seq)
     assert widget.image is not None
 
@@ -62,6 +62,6 @@ def test_image_preview_no_update_while_running_mda(qtbot: "QtBot"):
     assert widget.image is None
     assert not widget.use_with_mda
 
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+    with qtbot.waitSignal(mmc.events.imageSnapped):
         mmc.run_mda(seq)
     assert widget.image is None

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -35,14 +35,12 @@ def test_image_preview(qtbot: "QtBot"):
 
 
 def test_image_preview_while_running_mda(qtbot: "QtBot"):
-    widget = ImagePreview()
+    widget = ImagePreview(use_with_mda=False)
     qtbot.addWidget(widget)
     mmc = widget._mmc
 
     assert widget.image is None
-    assert widget.use_with_mda
-
-    widget.use_with_mda = False
+    assert not widget.use_with_mda
 
     seq = useq.MDASequence(channels=["FITC"])
 


### PR DESCRIPTION
Necessary after https://github.com/pymmcore-plus/pymmcore-plus/pull/314

When a MDA is running, we should be able to choose whether the ImagePreview  widget should update or not.
