### PR TITLE
fix: fix docs not grabbing widget png correctly

### DIFF
--- a/docs/_gen_widget_pages.py
+++ b/docs/_gen_widget_pages.py
@@ -51,12 +51,12 @@ def _example_screenshot(cls_name: str, dest: str) -> None:
 
     app = QApplication.instance() or QApplication([])
     new = [w for w in app.topLevelWidgets() if id(w) not in SEEN]
+    # remove all classes that are Qframe or QMenu
+    new = [w for w in new if w.__class__.__name__ not in ["QFrame", "QMenu"]]
     SEEN.update(id(w) for w in new)
     if not new:
         return
-    widget = next((w for w in new if w.__class__.__name__ == cls_name), None) or next(
-        (w for w in new if w.__class__.__name__ != "QFrame"), new[0]
-    )
+    widget = next((w for w in new if w.__class__.__name__ == cls_name), new[0])
     widget.setMinimumWidth(300)  # turns out this is very important for grab
     widget.grab().save(dest)
 


### PR DESCRIPTION
@tlambert03 this fixes the fact that the png of some widgets in the docs are not correct. We just needed to exclude `QMenu` together with  `QFrame` objects.