### PR TITLE
docs: bunch of documentations fixes

### DIFF
--- a/docs/_gen_widget_pages.py
+++ b/docs/_gen_widget_pages.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import mkdocs_gen_files
+from pymmcore_plus.core import _mmcore_plus
 
 WIDGET_LIST = Path(__file__).parent / "widget_list.json"
 WIDGETS = Path(__file__).parent / "widgets"
@@ -54,12 +55,14 @@ def _example_screenshot(cls_name: str, dest: str) -> None:
     # remove all classes that are Qframe or QMenu
     new = [w for w in new if w.__class__.__name__ not in ["QFrame", "QMenu"]]
     SEEN.update(id(w) for w in new)
-    if not new:
-        return
-    widget = next((w for w in new if w.__class__.__name__ == cls_name), new[0])
-    widget.setMinimumWidth(300)  # turns out this is very important for grab
-    widget.grab().save(dest)
+    if new:
+        widget = next((w for w in new if w.__class__.__name__ == cls_name), new[0])
+        widget.setMinimumWidth(300)  # turns out this is very important for grab
+        widget.grab().save(dest)
 
+    # clean up core instance and application
+    del _mmcore_plus._instance
+    _mmcore_plus._instance = None
     for w in app.topLevelWidgets():
         w.deleteLater()
 

--- a/docs/_hooks.py
+++ b/docs/_hooks.py
@@ -1,30 +1,28 @@
 import json
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
+
+from qtpy.QtWidgets import QWidget
+
+import pymmcore_widgets
 
 WIDGET_LIST = Path(__file__).parent / "widget_list.json"
 
 
-def on_page_markdown(md: str, **kwargs):
+def on_page_markdown(md: str, **_: Any) -> str:
     """Called when the markdown for a page is loaded."""
     with open(WIDGET_LIST) as f:
         widget_dict = json.load(f)
 
-        for widget in widget_dict:
-            widget = cast(str, widget)
-            if widget.upper() in md:  # e.g. CONFIGURATION_WIDGETS in index.md
-                md = md.replace(
-                    "{{ " + f"{widget.upper()}" + " }}",
-                    _widget_table(widget_dict[widget]),
-                )
+        for section, widget_list in widget_dict.items():
+            # e.g.  {{ CONFIGURATION_WIDGETS }} in index.md
+            section_key = "{{ " + cast(str, section).upper() + " }}"
+            if section_key in md:
+                md = md.replace(section_key, _widget_table(widget_list))
         return md
 
 
-def _widget_table(widget_list: list[str]):
-    from qtpy.QtWidgets import QWidget
-
-    import pymmcore_widgets
-
+def _widget_table(widget_list: list[str]) -> str:
     table = ["| Widget | Description |", "| ------ | ----------- |"]
     for name in dir(pymmcore_widgets):
         if name.startswith("_") or name not in widget_list:
@@ -32,6 +30,6 @@ def _widget_table(widget_list: list[str]):
         obj = getattr(pymmcore_widgets, name)
         if isinstance(obj, type) and issubclass(obj, QWidget):
             doc = (obj.__doc__ or "").strip().splitlines()[0]
-            table.append(f"| [{name}][pymmcore_widgets.{name}] | {doc} |")
+            table.append(f"| [{name}]({name}.md) | {doc} |")
 
     return "\n".join(table)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -43,7 +43,7 @@ As shown in the example from the [Overview](./index.md#usage) section, for a bas
 3. load a configuration file.
 4. create and show the wanted widget(s).
 
-In this example, we substitute step 3 with the [ConfigurationWidget](./widgets/ConfigurationWidget/) widget which enables us to load any `Micro-Manager` configuration file. Additionally, we use the [GroupPresetTableWidget](./widgets/GroupPresetTableWidget/) widget, which provides an interactive interface for the `groups` and `presets` stored in the configuration file.
+In this example, we substitute step 3 with the [ConfigurationWidget](widgets/ConfigurationWidget.md) widget which enables us to load any `Micro-Manager` configuration file. Additionally, we use the [GroupPresetTableWidget](widgets/GroupPresetTableWidget.md) widget, which provides an interactive interface for the `groups` and `presets` stored in the configuration file.
 
 ```python title="basic_usage.py"
 --8<-- "examples/basic_usage.py"
@@ -70,7 +70,15 @@ As shown in the video below, in this section, we only provide a simple example t
 
 ![type:video](./images/my_widget.mp4){: style='width: 100%'}
 
-Here we create a [Qt Application](https://doc.qt.io/qt-6/qapplication.html) with a general-purpose [QWidget](https://doc.qt.io/qt-6/qwidget.html) that incorporates a variety of `pymmcore-widgets`: [ConfigurationWidget](./widgets/ConfigurationWidget/), [ChannelGroupWidget](./widgets/ChannelGroupWidget/), [ChannelWidget](./widgets/ChannelWidget/), [DefaultCameraExposureWidget](./widgets/DefaultCameraExposureWidget/), [ImagePreview](./widgets/ImagePreview/), [SnapButton](./widgets/SnapButton/), and [LiveButton](./widgets/LiveButton/).
+Here we create a [Qt Application](https://doc.qt.io/qt-6/qapplication.html) with
+a general-purpose [QWidget](https://doc.qt.io/qt-6/qwidget.html) that
+incorporates a variety of `pymmcore-widgets`:
+[ConfigurationWidget](widgets/ConfigurationWidget.md),
+[ChannelGroupWidget](widgets/ChannelGroupWidget.md),
+[ChannelWidget](widgets/ChannelWidget.md),
+[DefaultCameraExposureWidget](widgets/DefaultCameraExposureWidget.md),
+[ImagePreview](widgets/ImagePreview.md), [SnapButton](widgets/SnapButton.md),
+and [LiveButton](widgets/LiveButton.md).
 
 This simple GUI can be used to load a `Micro-Manager` configuration file, snap an image or live stream images from the camera, with the flexibility to select a channel and adjust the exposure time.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,50 +67,6 @@ A more detailed description on how to use the `pymmcore-widgets` package is expl
 
 For a pre-made user interface, see [napari-micromanager](https://pypi.org/project/napari-micromanager/) ([github](https://github.com/pymmcore-plus/napari-micromanager)).
 
-## Widgets List
+## Widgets
 
-Below there is a list of all the widgets available in this package **grouped by their functionality**.
-
-For a more detailed information on each widget, explore their [individual documentation](./widgets/CameraRoiWidget/).
-
-### Cameras Widgets
-
-The widgets in this section can be used to **control** any `Micro-Manager` device of type [CameraDevice](https://pymmcore-plus.github.io/pymmcore-plus/api/constants/#pymmcore_plus.core._constants.DeviceType.CameraDevice).
-
-{{ CAMERA_WIDGETS }}
-
-### Configurations Widgets
-
-The widgets in this section can be used to **create, load and modify a Micro-Manager configuration** file.
-
-{{ CONFIGURATION_WIDGETS }}
-
-### Devices and Properties Widgets
-
-The widgets in this section can be used to **control and intract with the devices and properties** of a `Micro-Manager` core ([CMMCorePlus](https://pymmcore-plus.github.io/pymmcore-plus/api/cmmcoreplus/#cmmcoreplus)).
-
-{{ DEVICE_PROPERTY_WIDGETS }}
-
-### Multi-Dimensional Acquisition Widgets
-
-The widgets in this section can be used to **define (and run) a multi-dimensional acquisition** based on the [useq-schema MDASequence](https://pymmcore-plus.github.io/useq-schema/schema/sequence/#useq.MDASequence).
-
-{{ MDA_WIDGETS }}
-
-### Shutters Widgets
-
-The widgets in this section can be used to **control** any `Micro-Manager` device of type [ShutterDevice](https://pymmcore-plus.github.io/pymmcore-plus/api/constants/#pymmcore_plus.core._constants.DeviceType.ShutterDevice).
-
-{{ SHUTTER_WIDGETS }}
-
-### Stages Widgets
-
-The widgets in this section can be used to **control** any `Micro-Manager` device of type [StageDevice](https://pymmcore-plus.github.io/pymmcore-plus/api/constants/#pymmcore_plus.core._constants.DeviceType.StageDevice).
-
-{{ STAGE_WIDGETS }}
-
-### Misc Widgets
-
-The widgets in this section are **miscellaneous** widgets that can be used for different purposes. See their [individual documentation](./widgets/ChannelGroupWidget/) for more details.
-
-{{ MISC_WIDGETS }}
+For a complete list of widgets offered by this package, see the [Widgets List](widgets).

--- a/docs/widgets/index.md
+++ b/docs/widgets/index.md
@@ -1,0 +1,45 @@
+# Widgets List
+
+Below there is a list of all the widgets available in this package **grouped by their functionality**.
+
+## Camera Widgets
+
+The widgets in this section can be used to **control** any `Micro-Manager` device of type [CameraDevice](https://pymmcore-plus.github.io/pymmcore-plus/api/constants/#pymmcore_plus.core._constants.DeviceType.CameraDevice).
+
+{{ CAMERA_WIDGETS }}
+
+## Configuration Widgets
+
+The widgets in this section can be used to **create, load and modify a Micro-Manager configuration** file.
+
+{{ CONFIGURATION_WIDGETS }}
+
+## Devices and Properties Widgets
+
+The widgets in this section can be used to **control and intract with the devices and properties** of a `Micro-Manager` core ([CMMCorePlus](https://pymmcore-plus.github.io/pymmcore-plus/api/cmmcoreplus/#cmmcoreplus)).
+
+{{ DEVICE_PROPERTY_WIDGETS }}
+
+## Multi-Dimensional Acquisition Widgets
+
+The widgets in this section can be used to **define (and run) a multi-dimensional acquisition** based on the [useq-schema MDASequence](https://pymmcore-plus.github.io/useq-schema/schema/sequence/#useq.MDASequence).
+
+{{ MDA_WIDGETS }}
+
+## Shutter Widgets
+
+The widgets in this section can be used to **control** any `Micro-Manager` [ShutterDevice](https://pymmcore-plus.github.io/pymmcore-plus/api/constants/#pymmcore_plus.core._constants.DeviceType.ShutterDevice).
+
+{{ SHUTTER_WIDGETS }}
+
+## Stage Widgets
+
+The widgets in this section can be used to **control** any `Micro-Manager` [StageDevice](https://pymmcore-plus.github.io/pymmcore-plus/api/constants/#pymmcore_plus.core._constants.DeviceType.StageDevice).
+
+{{ STAGE_WIDGETS }}
+
+## Misc Widgets
+
+The widgets in this section are **miscellaneous** widgets that can be used for different purposes.
+
+{{ MISC_WIDGETS }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ plugins:
   - search
   - autorefs
   - literate-nav # autegenerate nav from _gen_widgets
+  - section-index
   - gen-files:
       scripts:
         - docs/_gen_widget_pages.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ docs = [
     "mkdocstrings-python",
     "mkdocs-literate-nav",
     "mkdocs-gen-files",
+    "mkdocs-section-index",
     "mkdocs-video",
 ]
 

--- a/src/pymmcore_widgets/_camera_roi_widget.py
+++ b/src/pymmcore_widgets/_camera_roi_widget.py
@@ -34,8 +34,6 @@ class CameraRoiWidget(QWidget):
     When the ROI changes, the `roiChanged` Signal is emitted with the current ROI
     (x, y, width, height, comboBoxText)
 
-    [`pymmcore_plus.CMMCoreSignaler`]
-
     Parameters
     ----------
     parent : QWidget | None

--- a/src/pymmcore_widgets/_channel_widget.py
+++ b/src/pymmcore_widgets/_channel_widget.py
@@ -34,7 +34,7 @@ class ChannelWidget(QWidget):
     --------
     !!! example "Combining `ChannelWidget` with other widgets"
 
-        see [ImagePreview](../ImagePreview#example)
+        see [ImagePreview](ImagePreview.md#example)
 
     """
 

--- a/src/pymmcore_widgets/_exposure_widget.py
+++ b/src/pymmcore_widgets/_exposure_widget.py
@@ -26,7 +26,7 @@ class ExposureWidget(QWidget):
     --------
     !!! example "Combining `ExposureWidget` with other widgets"
 
-        see [ImagePreview](../ImagePreview#example)
+        see [ImagePreview](ImagePreview.md#example)
 
     """
 

--- a/src/pymmcore_widgets/_install_widget.py
+++ b/src/pymmcore_widgets/_install_widget.py
@@ -30,7 +30,12 @@ LOC_ROLE = Qt.ItemDataRole.UserRole + 1
 
 
 class InstallWidget(QWidget):
-    """Widget to manage installation of MicroManager."""
+    """Widget to manage installation of MicroManager.
+
+    This widget will let you download and install a specific version of MicroManager
+    from <https://micro-manager.org/downloads>. It will also manage the currently
+    installed versions.
+    """
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)

--- a/src/pymmcore_widgets/_live_button_widget.py
+++ b/src/pymmcore_widgets/_live_button_widget.py
@@ -43,7 +43,7 @@ class LiveButton(QPushButton):
     --------
     !!! example "Combining `LiveButton` with other widgets"
 
-        see [ImagePreview](../ImagePreview#example)
+        see [ImagePreview](ImagePreview.md#example)
     """
 
     def __init__(

--- a/src/pymmcore_widgets/_snap_button_widget.py
+++ b/src/pymmcore_widgets/_snap_button_widget.py
@@ -42,7 +42,7 @@ class SnapButton(QPushButton):
     --------
     !!! example "Combining `SnapButton` with other widgets"
 
-        see [ImagePreview](../ImagePreview#example)
+        see [ImagePreview](ImagePreview.md#example)
     """
 
     def __init__(

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -69,9 +69,12 @@ class CoreMDATabs(MDATabs):
 
 
 class MDAWidget(MDASequenceWidget):
-    """[MDASequenceWidget](../MDASequenceWidget#) connected to a [`pymmcore_plus.CMMCorePlus`][] instance.
+    """Main MDA Widget connected to a [`pymmcore_plus.CMMCorePlus`][] instance.
 
-    It provides a GUI to construct and run a [`useq.MDASequence`][].
+    It provides a GUI to construct and run a [`useq.MDASequence`][].  Unlike
+    [`useq_widgets.MDASequenceWidget`][pymmcore_widgets.MDASequenceWidget], this
+    widget is connected to a [`pymmcore_plus.CMMCorePlus`][] instance, enabling
+    awareness and control of the current state of the microscope.
 
     Parameters
     ----------

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -254,7 +254,11 @@ class KeepShutterOpen(QWidget):
 
 
 class MDASequenceWidget(QWidget):
-    """A widget that provides a GUI to construct and edit a [`useq.MDASequence`][]."""
+    """A widget that provides a GUI to construct and edit a [`useq.MDASequence`][].
+
+    This widget requires no connection to a microscope or core instance.  It strictly
+    deals with loading and creating `useq-schema` [`useq.MDASequence`][] objects.
+    """
 
     valueChanged = Signal()
 


### PR DESCRIPTION
- fixes a bunch of broken links that were showing up in the build logs
- fixes #253 
- adjust widget links to link to top of page
- pulls out widget list from overview page to widgets/index