### PR TITLE
fix: fix issue with channel group widget not working with only one group

### DIFF
--- a/src/pymmcore_widgets/_channel_group_widget.py
+++ b/src/pymmcore_widgets/_channel_group_widget.py
@@ -27,7 +27,7 @@ class ChannelGroupWidget(QComboBox):
     ) -> None:
         super().__init__(parent)
 
-        self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
 
         self._mmc = mmcore or CMMCorePlus.instance()
 
@@ -39,7 +39,7 @@ class ChannelGroupWidget(QComboBox):
         self._mmc.events.propertyChanged.connect(self._on_property_changed)
         self._mmc.events.configDefined.connect(self._update_channel_group_combo)
 
-        self.currentTextChanged.connect(self._mmc.setChannelGroup)
+        self.textActivated.connect(self._mmc.setChannelGroup)
 
         self.destroyed.connect(self._disconnect)
 


### PR DESCRIPTION
use `textActivated` instead of `currentTextChanged` for the `QComboBox` connection.

fixes https://github.com/pymmcore-plus/pymmcore-widgets/issues/289.