### PR TITLE
[WIP] feat: add tensorstore-zarr option  + create writers within MDAWidget

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - pymmcore-plus >=0.9.0
+          - pymmcore-plus >=0.9.5
           - useq-schema >=0.4.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - pymmcore-plus >=0.9.5
+          - pymmcore-plus@git+https://github.com/fdrgsp/pymmcore-plus.git # -> when released pymmcore-plus >=0.9.6
           - useq-schema >=0.4.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - 'pymmcore-plus >=0.10.0'
+          - pymmcore-plus >=0.10.2
           - useq-schema >=0.4.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - pymmcore-plus@git+https://github.com/fdrgsp/pymmcore-plus.git # -> when released pymmcore-plus >=0.9.6
+          - 'pymmcore-plus >=0.10.0'
           - useq-schema >=0.4.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,6 @@ ignore = [
 [tool.ruff.format]
 docstring-code-format = true
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    'pymmcore-plus[cli] >=0.9.5',
+    'pymmcore-plus@git+https://github.com/fdrgsp/pymmcore-plus.git',  # -> when released pymmcore-plus >=0.9.6
     'qtpy >=2.0',
     'superqt[quantity] >=0.5.3',
     'useq-schema >=0.4.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ ignore = [
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    'pymmcore-plus[cli] >=0.9.0',
+    "pymmcore-plus@git+https://github.com/pymmcore-plus/pymmcore-plus.git",
     'qtpy >=2.0',
     'superqt[quantity] >=0.5.3',
     'useq-schema >=0.4.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    "pymmcore-plus[cli] >=0.9.5",
+    'pymmcore-plus[cli] >=0.9.5',
     'qtpy >=2.0',
     'superqt[quantity] >=0.5.3',
     'useq-schema >=0.4.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    "pymmcore-plus@git+https://github.com/pymmcore-plus/pymmcore-plus.git",
+    "pymmcore-plus >=0.9.5",
     'qtpy >=2.0',
     'superqt[quantity] >=0.5.3',
     'useq-schema >=0.4.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    'pymmcore-plus@git+https://github.com/fdrgsp/pymmcore-plus.git',  # -> when released pymmcore-plus >=0.9.6
+    'pymmcore-plus >=0.10.0',
     'qtpy >=2.0',
     'superqt[quantity] >=0.5.3',
     'useq-schema >=0.4.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    "pymmcore-plus >=0.9.5",
+    "pymmcore-plus[cli] >=0.9.5",
     'qtpy >=2.0',
     'superqt[quantity] >=0.5.3',
     'useq-schema >=0.4.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-cov", "pytest-qt", "PyYAML", "vispy", "cmap", "zarr"]
+test = ["pytest>=6.0", "pytest-cov", "pytest-qt", "PyYAML", "vispy", "cmap", "zarr", "tifffile"]
 pyqt5 = ["PyQt5"]
 pyside2 = ["PySide2"]
 pyqt6 = ["PyQt6"]

--- a/src/pymmcore_widgets/_util.py
+++ b/src/pymmcore_widgets/_util.py
@@ -143,8 +143,11 @@ def get_next_available_path(requested_path: Path | str, min_digits: int = 3) -> 
     extension = requested_path.suffix
     # ome files like .ome.tiff or .ome.zarr are special,treated as a single extension
     if (stem := requested_path.stem).endswith(".ome"):
-        extension = ".ome" + extension
+        extension = f".ome{extension}"
         stem = stem[:-4]
+    elif (stem := requested_path.stem).endswith(".tensorstore"):
+        extension = f".tensorstore{extension}"
+        stem = stem[:-12]
 
     # look for ANY existing files in the folder that follow the pattern of
     # stem_###.extension

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -254,23 +254,6 @@ class MDAWidget(MDASequenceWidget):
         z = self._mmc.getPosition() if self._mmc.getFocusDevice() else None
         return Position(x=x, y=y, z=z)
 
-    def _confirm_af_intentions(self) -> bool:
-        msg = (
-            "You've selected to use autofocus for this experiment, "
-            f"but the '{self._mmc.getAutoFocusDevice()!r}' autofocus device "
-            "is not currently engaged. "
-            "\n\nRun anyway?"
-        )
-
-        response = QMessageBox.warning(
-            self,
-            "Confirm AutoFocus",
-            msg,
-            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Cancel,
-        )
-        return bool(response == QMessageBox.StandardButton.Ok)
-
     def _update_save_path_from_metadata(
         self,
         sequence: MDASequence,
@@ -304,8 +287,22 @@ class MDAWidget(MDASequenceWidget):
             return next_path
         return None
 
-    def _on_mda_started(self) -> None:
-        self._enable_widgets(False)
+    def _confirm_af_intentions(self) -> bool:
+        msg = (
+            "You've selected to use autofocus for this experiment, "
+            f"but the '{self._mmc.getAutoFocusDevice()!r}' autofocus device "
+            "is not currently engaged. "
+            "\n\nRun anyway?"
+        )
+
+        response = QMessageBox.warning(
+            self,
+            "Confirm AutoFocus",
+            msg,
+            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        return bool(response == QMessageBox.StandardButton.Ok)
 
     def _enable_widgets(self, enable: bool) -> None:
         for child in self.children():
@@ -313,6 +310,9 @@ class MDAWidget(MDASequenceWidget):
                 child._enable_tabs(enable)
             elif child is not self.control_btns and hasattr(child, "setEnabled"):
                 child.setEnabled(enable)
+
+    def _on_mda_started(self) -> None:
+        self._enable_widgets(False)
 
     def _on_mda_finished(self, sequence: MDASequence) -> None:
         self._enable_widgets(True)

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -228,7 +228,7 @@ class MDAWidget(MDASequenceWidget):
             save_path = self._update_save_path_from_metadata(
                 sequence, update_metadata=True
             )
-            if isinstance(save_path, Path):
+            if save_path is not None:
                 # get save format from metadata
                 save_meta = sequence.metadata.get(PYMMCW_METADATA_KEY, {})
                 save_format = save_meta.get("format", "")

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -32,7 +32,14 @@ from ._core_channels import CoreConnectedChannelTable
 from ._core_grid import CoreConnectedGridPlanWidget
 from ._core_positions import CoreConnectedPositionTable
 from ._core_z import CoreConnectedZPlanWidget
-from ._save_widget import OME_TIFF, OME_ZARR, WRITERS, ZARR_TESNSORSTORE, SaveGroupBox
+from ._save_widget import (
+    OME_TIFF,
+    OME_ZARR,
+    TIFF_SEQ,
+    WRITERS,
+    ZARR_TESNSORSTORE,
+    SaveGroupBox,
+)
 
 OME_TIFFS = tuple(WRITERS[OME_TIFF])
 
@@ -298,8 +305,10 @@ class MDAWidget(MDASequenceWidget):
             return OMEZarrWriter(path)
         elif ZARR_TESNSORSTORE in save_format:
             return TensorStoreHandler(driver="zarr", path=path, delete_existing=True)
-        else:
+        elif TIFF_SEQ in save_format:
             return ImageSequenceWriter(path)
+        else:
+            raise ValueError(f"Unknown save format: {save_format}")
 
     def _on_mda_started(self) -> None:
         self._enable_widgets(False)

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -36,14 +36,14 @@ from ._save_widget import (
     OME_TIFF,
     OME_ZARR,
     TIFF_SEQ,
-    ZARR_TESNSORSTORE,
+    ZARR_TENSORSTORE,
     SaveGroupBox,
 )
 
 MAKE_WRITERS: dict[str, Callable] = {
     OME_TIFF: OMETiffWriter,
     OME_ZARR: OMEZarrWriter,
-    ZARR_TESNSORSTORE: lambda path: TensorStoreHandler(
+    ZARR_TENSORSTORE: lambda path: TensorStoreHandler(
         path=path, driver="zarr", delete_existing=True
     ),
     TIFF_SEQ: ImageSequenceWriter,

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -299,13 +299,13 @@ class MDAWidget(MDASequenceWidget):
         self, path: Path, save_format: str
     ) -> OMEZarrWriter | OMETiffWriter | TensorStoreHandler | ImageSequenceWriter:
         """Return a writer based on the save format."""
-        if OME_TIFF in save_format:
+        if save_format == OME_TIFF:
             return OMETiffWriter(path)
-        elif OME_ZARR in save_format:
+        elif save_format == OME_ZARR:
             return OMEZarrWriter(path)
-        elif ZARR_TESNSORSTORE in save_format:
+        elif save_format == ZARR_TESNSORSTORE:
             return TensorStoreHandler(driver="zarr", path=path, delete_existing=True)
-        elif TIFF_SEQ in save_format:
+        elif save_format == TIFF_SEQ:
             return ImageSequenceWriter(path)
         else:
             raise ValueError(f"Unknown save format: {save_format}")

--- a/src/pymmcore_widgets/mda/_save_widget.py
+++ b/src/pymmcore_widgets/mda/_save_widget.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         should_save: bool
 
 
-ZARR_TENSORSTORE  = "tensorstore-zarr"
+ZARR_TENSORSTORE = "tensorstore-zarr"
 OME_ZARR = "ome-zarr"
 OME_TIFF = "ome-tiff"
 TIFF_SEQ = "tiff-sequence"

--- a/src/pymmcore_widgets/mda/_save_widget.py
+++ b/src/pymmcore_widgets/mda/_save_widget.py
@@ -28,12 +28,14 @@ if TYPE_CHECKING:
         should_save: bool
 
 
+ZARR_TESNSORSTORE = "tensorstore-zarr"
 OME_ZARR = "ome-zarr"
 OME_TIFF = "ome-tiff"
 TIFF_SEQ = "tiff-sequence"
 
 # dict with writer name and extension
 WRITERS: dict[str, list[str]] = {
+    ZARR_TESNSORSTORE: [".tensorstore.zarr"],
     OME_ZARR: [".ome.zarr"],
     OME_TIFF: [".ome.tif", ".ome.tiff"],
     TIFF_SEQ: [""],
@@ -41,7 +43,7 @@ WRITERS: dict[str, list[str]] = {
 
 EXT_TO_WRITER = {x: w for w, exts in WRITERS.items() for x in exts}
 ALL_EXTENSIONS = [x for exts in WRITERS.values() for x in exts if x]
-DIRECTORY_WRITERS = {TIFF_SEQ}  # technically could be zarr too
+DIRECTORY_WRITERS = {TIFF_SEQ, ZARR_TESNSORSTORE}  # technically could be zarr too
 
 FILE_NAME = "Filename:"
 SUBFOLDER = "Subfolder:"

--- a/src/pymmcore_widgets/mda/_save_widget.py
+++ b/src/pymmcore_widgets/mda/_save_widget.py
@@ -35,7 +35,7 @@ TIFF_SEQ = "tiff-sequence"
 
 # dict with writer name and extension
 WRITERS: dict[str, list[str]] = {
-    ZARR_TESNSORSTORE: [".tensorstore.zarr"],
+    ZARR_TENSORSTORE: [".tensorstore.zarr"],
     OME_ZARR: [".ome.zarr"],
     OME_TIFF: [".ome.tif", ".ome.tiff"],
     TIFF_SEQ: [""],

--- a/src/pymmcore_widgets/mda/_save_widget.py
+++ b/src/pymmcore_widgets/mda/_save_widget.py
@@ -43,7 +43,7 @@ WRITERS: dict[str, list[str]] = {
 
 EXT_TO_WRITER = {x: w for w, exts in WRITERS.items() for x in exts}
 ALL_EXTENSIONS = [x for exts in WRITERS.values() for x in exts if x]
-DIRECTORY_WRITERS = {TIFF_SEQ, ZARR_TESNSORSTORE}  # technically could be zarr too
+DIRECTORY_WRITERS = {TIFF_SEQ}  # technically could be zarr too
 
 FILE_NAME = "Filename:"
 SUBFOLDER = "Subfolder:"

--- a/src/pymmcore_widgets/mda/_save_widget.py
+++ b/src/pymmcore_widgets/mda/_save_widget.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         should_save: bool
 
 
-ZARR_TESNSORSTORE = "tensorstore-zarr"
+ZARR_TENSORSTORE  = "tensorstore-zarr"
 OME_ZARR = "ome-zarr"
 OME_TIFF = "ome-tiff"
 TIFF_SEQ = "tiff-sequence"

--- a/tests/test_save_widget.py
+++ b/tests/test_save_widget.py
@@ -11,6 +11,7 @@ from pymmcore_widgets.mda._save_widget import (
     SUBFOLDER,
     TIFF_SEQ,
     WRITERS,
+    ZARR_TESNSORSTORE,
     SaveGroupBox,
 )
 
@@ -53,6 +54,24 @@ def test_set_get_value(qtbot: QtBot) -> None:
         "save_name": "some_file.ome.zarr",
         "should_save": False,
         "format": OME_ZARR,
+    }
+
+    # setting zarr tensorstore format (dict)
+    wdg.setValue({"save_dir": str(path.parent), "save_name": "ts.tensorstore.zarr"})
+    assert wdg.value() == {
+        "save_dir": str(path.parent),
+        "save_name": "ts.tensorstore.zarr",
+        "should_save": False,
+        "format": ZARR_TESNSORSTORE,
+    }
+
+    # setting zarr tensorstore format (path / string)
+    wdg.setValue("/some_path/ts.tensorstore.zarr")
+    assert wdg.value() == {
+        "save_dir": "/some_path",
+        "save_name": "ts.tensorstore.zarr",
+        "should_save": True,
+        "format": ZARR_TESNSORSTORE,
     }
 
 

--- a/tests/test_save_widget.py
+++ b/tests/test_save_widget.py
@@ -11,7 +11,6 @@ from pymmcore_widgets.mda._save_widget import (
     SUBFOLDER,
     TIFF_SEQ,
     WRITERS,
-    ZARR_TENSORSTORE,
     SaveGroupBox,
 )
 

--- a/tests/test_save_widget.py
+++ b/tests/test_save_widget.py
@@ -61,7 +61,7 @@ def test_set_get_value(qtbot: QtBot) -> None:
         "save_dir": str(path.parent),
         "save_name": "ts.tensorstore.zarr",
         "should_save": False,
-        "format": ZARR_TESNSORSTORE,
+        "format": ZARR_TENSORSTORE,
     }
 
     # setting zarr tensorstore format (path / string)
@@ -70,7 +70,7 @@ def test_set_get_value(qtbot: QtBot) -> None:
         "save_dir": str(path.parent),
         "save_name": "ts.tensorstore.zarr",
         "should_save": True,
-        "format": ZARR_TESNSORSTORE,
+        "format": ZARR_TENSORSTORE,
     }
 
 

--- a/tests/test_save_widget.py
+++ b/tests/test_save_widget.py
@@ -11,6 +11,7 @@ from pymmcore_widgets.mda._save_widget import (
     SUBFOLDER,
     TIFF_SEQ,
     WRITERS,
+    ZARR_TENSORSTORE,
     SaveGroupBox,
 )
 

--- a/tests/test_save_widget.py
+++ b/tests/test_save_widget.py
@@ -68,7 +68,7 @@ def test_set_get_value(qtbot: QtBot) -> None:
     # setting zarr tensorstore format (path / string)
     wdg.setValue("/some_path/ts.tensorstore.zarr")
     assert wdg.value() == {
-        "save_dir": "/some_path",
+        "save_dir": str(path.parent),
         "save_name": "ts.tensorstore.zarr",
         "should_save": True,
         "format": ZARR_TESNSORSTORE,

--- a/tests/test_save_widget.py
+++ b/tests/test_save_widget.py
@@ -11,7 +11,7 @@ from pymmcore_widgets.mda._save_widget import (
     SUBFOLDER,
     TIFF_SEQ,
     WRITERS,
-    ZARR_TESNSORSTORE,
+    ZARR_TENSORSTORE,
     SaveGroupBox,
 )
 

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -702,7 +702,7 @@ def test_get_next_available_paths_special_cases(tmp_path: Path) -> None:
 data = [
     ("./test.ome.tiff", OME_TIFF, OMETiffWriter),
     ("./test.ome.zarr", OME_ZARR, OMEZarrWriter),
-    ("./test.tensorstore.zarr", ZARR_TESNSORSTORE, TensorStoreHandler),
+    ("./test.tensorstore.zarr", ZARR_TENSORSTORE, TensorStoreHandler),
     ("./test", TIFF_SEQ, ImageSequenceWriter),
 ]
 

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -26,6 +26,7 @@ from pymmcore_widgets.mda._save_widget import (
     OME_TIFF,
     OME_ZARR,
     TIFF_SEQ,
+    ZARR_TENSORSTORE,
 )
 from pymmcore_widgets.useq_widgets._mda_sequence import (
     PYMMCW_METADATA_KEY,

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -26,7 +26,6 @@ from pymmcore_widgets.mda._save_widget import (
     OME_TIFF,
     OME_ZARR,
     TIFF_SEQ,
-    ZARR_TENSORSTORE,
 )
 from pymmcore_widgets.useq_widgets._mda_sequence import (
     PYMMCW_METADATA_KEY,

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -19,7 +19,7 @@ from pymmcore_widgets._util import get_next_available_path
 from pymmcore_widgets.mda import MDAWidget
 from pymmcore_widgets.mda._core_channels import CoreConnectedChannelTable
 from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
-from pymmcore_widgets.mda._core_mda import CoreMDATabs
+from pymmcore_widgets.mda._core_mda import MAKE_WRITERS, CoreMDATabs
 from pymmcore_widgets.mda._core_positions import CoreConnectedPositionTable
 from pymmcore_widgets.mda._core_z import CoreConnectedZPlanWidget
 from pymmcore_widgets.mda._save_widget import (
@@ -714,5 +714,5 @@ def test_mda_writer(qtbot: QtBot, tmp_path: Path, data: tuple) -> None:
     qtbot.addWidget(wdg)
     wdg.show()
     path, save_format, cls = data
-    writer = wdg._create_writer(Path(path), save_format)
+    writer = MAKE_WRITERS[save_format](path)
     assert isinstance(writer, cls)

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -26,7 +26,7 @@ from pymmcore_widgets.mda._save_widget import (
     OME_TIFF,
     OME_ZARR,
     TIFF_SEQ,
-    ZARR_TESNSORSTORE,
+    ZARR_TENSORSTORE,
 )
 from pymmcore_widgets.useq_widgets._mda_sequence import (
     PYMMCW_METADATA_KEY,

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -6,6 +6,12 @@ from unittest.mock import patch
 
 import pytest
 import useq
+from pymmcore_plus.mda.handlers import (
+    ImageSequenceWriter,
+    OMETiffWriter,
+    OMEZarrWriter,
+    TensorStoreHandler,
+)
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QMessageBox
 
@@ -16,6 +22,12 @@ from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
 from pymmcore_widgets.mda._core_mda import CoreMDATabs
 from pymmcore_widgets.mda._core_positions import CoreConnectedPositionTable
 from pymmcore_widgets.mda._core_z import CoreConnectedZPlanWidget
+from pymmcore_widgets.mda._save_widget import (
+    OME_TIFF,
+    OME_ZARR,
+    TIFF_SEQ,
+    ZARR_TESNSORSTORE,
+)
 from pymmcore_widgets.useq_widgets._mda_sequence import (
     PYMMCW_METADATA_KEY,
     AutofocusAxis,
@@ -686,3 +698,21 @@ def test_get_next_available_paths_special_cases(tmp_path: Path) -> None:
     high = tmp_path / "test_12345.txt"
     high.touch()
     assert get_next_available_path(high).name == "test_12346.txt"
+
+
+data = [
+    ("./test.ome.tiff", OME_TIFF, OMETiffWriter),
+    ("./test.ome.zarr", OME_ZARR, OMEZarrWriter),
+    ("./test.tensorstore.zarr", ZARR_TESNSORSTORE, TensorStoreHandler),
+    ("./test", TIFF_SEQ, ImageSequenceWriter),
+]
+
+
+@pytest.mark.parametrize("data", data)
+def test_mda_writer(qtbot: QtBot, tmp_path: Path, data: tuple) -> None:
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+    path, save_format, cls = data
+    writer = wdg._create_writer(Path(path), save_format)
+    assert isinstance(writer, cls)


### PR DESCRIPTION
This PR:
- adds the `tensorstore-zarr` option to the `SaveGroupBox` in the `MDAWidget`.
- creates the writer directly in the `MDAWidget` (so that we will pass to the core `run_mda` method the full writer instead of just a path)

NOTE: this PR requires the `TensorStoreHandler` of `pymmcore-plus` which is not yet present in the current version.

related to https://github.com/pymmcore-plus/pymmcore-plus/pull/355.