### PR TITLE
fix: fix bug in config wizard where core state bleeds into model

### DIFF
--- a/src/pymmcore_widgets/hcwizard/intro_page.py
+++ b/src/pymmcore_widgets/hcwizard/intro_page.py
@@ -90,9 +90,13 @@ class IntroPage(ConfigWizardPage):
         super().cleanupPage()
 
     def validatePage(self) -> bool:
-        """Validate. the page when the user clicks Next or Finish."""
+        """Validate the page when the user clicks Next or Finish."""
         if self.btn_group.checkedButton() is self.new_btn:
             self._model.reset()
+            try:
+                self._core.unloadAllDevices()
+            except Exception as e:
+                logger.exception(e)
         else:
             self._model.load_config(self.file_edit.text())
         self._model.mark_clean()

--- a/src/pymmcore_widgets/hcwizard/roles_page.py
+++ b/src/pymmcore_widgets/hcwizard/roles_page.py
@@ -39,17 +39,28 @@ class RolesPage(ConfigWizardPage):
         # reset and populate the combo boxes with available devices
         with signals_blocked(self.camera_combo):
             self.camera_combo.clear()
-            if cameras := self._core.getLoadedDevicesOfType(DeviceType.CameraDevice):
+            cameras = [
+                x.name
+                for x in self._model.filter_devices(device_type=DeviceType.Camera)
+            ]
+            if cameras:
                 self.camera_combo.addItems(("", *cameras))
 
         with signals_blocked(self.shutter_combo):
             self.shutter_combo.clear()
-            if shutters := self._core.getLoadedDevicesOfType(DeviceType.ShutterDevice):
+            shutters = [
+                x.name
+                for x in self._model.filter_devices(device_type=DeviceType.Shutter)
+            ]
+            if shutters:
                 self.shutter_combo.addItems(("", *shutters))
 
         with signals_blocked(self.focus_combo):
             self.focus_combo.clear()
-            if stages := self._core.getLoadedDevicesOfType(DeviceType.StageDevice):
+            stages = [
+                x.name for x in self._model.filter_devices(device_type=DeviceType.Stage)
+            ]
+            if stages:
                 self.focus_combo.addItems(("", *stages))
 
         with signals_blocked(self.auto_shutter_checkbox):

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -27,6 +27,24 @@ if TYPE_CHECKING:
 TEST_CONFIG = Path(__file__).parent / "test_config.cfg"
 
 
+def test_config_wizard_new_empty(
+    global_mmcore: CMMCorePlus, qtbot, tmp_path: Path
+) -> None:
+    global_mmcore.loadSystemConfiguration()
+    wiz = ConfigWizard("", core=global_mmcore)
+    qtbot.addWidget(wiz)
+    wiz.show()
+    wiz.next()
+    wiz.next()
+    wiz.next()
+    wiz.next()
+    wiz.next()
+    out = tmp_path / "out.cfg"
+    wiz.setField(DEST_CONFIG, str(out))
+    wiz.accept()
+    assert "Property,Core,Camera" not in out.read_text()
+
+
 def test_config_wizard(global_mmcore: CMMCorePlus, qtbot, tmp_path: Path):
     out = tmp_path / "out.cfg"
     wiz = ConfigWizard(str(TEST_CONFIG), global_mmcore)


### PR DESCRIPTION
the state of the core devices loaded before opening a config wizard was leaking into the output