### PR TITLE
feat: add overlap checkbox

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/points_plans/_random_points_widget.py
+++ b/src/pymmcore_widgets/useq_widgets/points_plans/_random_points_widget.py
@@ -5,6 +5,7 @@ from typing import Mapping
 
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QDoubleSpinBox,
     QFormLayout,
@@ -25,7 +26,6 @@ class RandomPointWidget(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        self.allow_overlap: bool = False
         # setting a random seed for point generation reproducibility
         self.random_seed: int = self._new_seed()
         self._fov_size: tuple[float | None, float | None] = (None, None)
@@ -48,6 +48,8 @@ class RandomPointWidget(QWidget):
         self.num_points = QSpinBox()
         self.num_points.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.num_points.setRange(1, 1000)
+        # allow overlap checkbox
+        self.allow_overlap = QCheckBox()
         # random button
         self._random_button = QPushButton(text="Randomize")
 
@@ -64,6 +66,7 @@ class RandomPointWidget(QWidget):
         form.addRow("Height (µm):", self.max_height)
         form.addRow("Num Points:", self.num_points)
         form.addRow("Shape:", self.shape)
+        form.addRow("Allow Overlap:", self.allow_overlap)
 
         # main
         main_layout = QVBoxLayout(self)
@@ -78,6 +81,7 @@ class RandomPointWidget(QWidget):
         self.max_height.valueChanged.connect(self._on_value_changed)
         self.num_points.valueChanged.connect(self._on_value_changed)
         self.shape.currentTextChanged.connect(self._on_value_changed)
+        self.allow_overlap.stateChanged.connect(self._on_value_changed)
         self._random_button.clicked.connect(self._on_random_clicked)
 
     @property
@@ -108,7 +112,7 @@ class RandomPointWidget(QWidget):
             random_seed=self.random_seed,
             max_width=self.max_width.value(),
             max_height=self.max_height.value(),
-            allow_overlap=self.allow_overlap,
+            allow_overlap=self.allow_overlap.isChecked(),
             fov_width=fov_x,
             fov_height=fov_y,
         )
@@ -124,7 +128,7 @@ class RandomPointWidget(QWidget):
         self.max_height.setValue(value.max_height)
         self.shape.setCurrentText(value.shape.value)
         self._fov_size = (value.fov_width, value.fov_height)
-        self.allow_overlap = value.allow_overlap
+        self.allow_overlap.setChecked(value.allow_overlap)
 
     def reset(self) -> None:
         """Reset value to 1 point and 0 area."""

--- a/src/pymmcore_widgets/useq_widgets/points_plans/_random_points_widget.py
+++ b/src/pymmcore_widgets/useq_widgets/points_plans/_random_points_widget.py
@@ -15,7 +15,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from useq import RandomPoints, Shape
+from useq import RandomPoints, Shape, TraversalOrder
 
 
 class RandomPointWidget(QWidget):
@@ -37,17 +37,23 @@ class RandomPointWidget(QWidget):
         # well area doublespinbox along x
         self.max_width = QDoubleSpinBox()
         self.max_width.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.max_width.setRange(0, 1000000)
-        self.max_width.setSingleStep(100)
+        self.max_width.setRange(1, 1000000)
+        self.max_width.setValue(1000)
+        self.max_width.setStepType(QDoubleSpinBox.StepType.AdaptiveDecimalStepType)
         # well area doublespinbox along y
         self.max_height = QDoubleSpinBox()
         self.max_height.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.max_height.setRange(0, 1000000)
-        self.max_height.setSingleStep(100)
+        self.max_height.setRange(1, 1000000)
+        self.max_height.setValue(1000)
+        self.max_height.setStepType(QDoubleSpinBox.StepType.AdaptiveDecimalStepType)
         # number of FOVs spinbox
         self.num_points = QSpinBox()
         self.num_points.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.num_points.setRange(1, 1000)
+        # order combobox
+        self.order = QComboBox()
+        self.order.addItems([mode.value for mode in TraversalOrder])
+        self.order.setCurrentText(TraversalOrder.TWO_OPT.value)
         # allow overlap checkbox
         self.allow_overlap = QCheckBox()
         # random button
@@ -65,6 +71,7 @@ class RandomPointWidget(QWidget):
         form.addRow("Width (µm):", self.max_width)
         form.addRow("Height (µm):", self.max_height)
         form.addRow("Num Points:", self.num_points)
+        form.addRow("Order:", self.order)
         form.addRow("Shape:", self.shape)
         form.addRow("Allow Overlap:", self.allow_overlap)
 
@@ -80,6 +87,7 @@ class RandomPointWidget(QWidget):
         self.max_width.valueChanged.connect(self._on_value_changed)
         self.max_height.valueChanged.connect(self._on_value_changed)
         self.num_points.valueChanged.connect(self._on_value_changed)
+        self.order.currentTextChanged.connect(self._on_value_changed)
         self.shape.currentTextChanged.connect(self._on_value_changed)
         self.allow_overlap.stateChanged.connect(self._on_value_changed)
         self._random_button.clicked.connect(self._on_random_clicked)
@@ -113,6 +121,7 @@ class RandomPointWidget(QWidget):
             max_width=self.max_width.value(),
             max_height=self.max_height.value(),
             allow_overlap=self.allow_overlap.isChecked(),
+            order=self.order.currentText(),
             fov_width=fov_x,
             fov_height=fov_y,
         )
@@ -129,6 +138,8 @@ class RandomPointWidget(QWidget):
         self.shape.setCurrentText(value.shape.value)
         self._fov_size = (value.fov_width, value.fov_height)
         self.allow_overlap.setChecked(value.allow_overlap)
+        if value.order is not None:  # type: ignore  # until useq is released
+            self.order.setCurrentText(value.order.value)  # type: ignore  # until useq is released
 
     def reset(self) -> None:
         """Reset value to 1 point and 0 area."""

--- a/tests/useq_widgets/test_useq_points_plans.py
+++ b/tests/useq_widgets/test_useq_points_plans.py
@@ -17,6 +17,7 @@ RANDOM_POINTS = RandomPoints(
     fov_height=10,
     fov_width=10,
     random_seed=123,
+    allow_overlap=True,
 )
 
 GRID_ROWS_COLS = GridRowsColumns(
@@ -37,6 +38,7 @@ def test_random_points_widget(qtbot: QtBot) -> None:
     assert wdg.max_width.value() == 0
     assert wdg.max_height.value() == 0
     assert wdg.shape.currentText() == "ellipse"
+    assert not wdg.allow_overlap.isChecked()
     assert wdg.random_seed is not None
 
     with qtbot.waitSignal(wdg.valueChanged):
@@ -48,6 +50,7 @@ def test_random_points_widget(qtbot: QtBot) -> None:
     assert wdg.max_height.value() == RANDOM_POINTS.max_height
     assert wdg.shape.currentText() == RANDOM_POINTS.shape.value
     assert wdg.random_seed == RANDOM_POINTS.random_seed
+    assert wdg.allow_overlap.isChecked() == RANDOM_POINTS.allow_overlap
 
 
 def test_grid_plan_widget(qtbot: QtBot) -> None:

--- a/tests/useq_widgets/test_useq_points_plans.py
+++ b/tests/useq_widgets/test_useq_points_plans.py
@@ -17,6 +17,7 @@ RANDOM_POINTS = RandomPoints(
     fov_height=10,
     fov_width=10,
     random_seed=123,
+    order="random",
     allow_overlap=True,
 )
 
@@ -35,10 +36,11 @@ def test_random_points_widget(qtbot: QtBot) -> None:
     wdg = pp.RandomPointWidget()
     qtbot.addWidget(wdg)
     assert wdg.num_points.value() == 1
-    assert wdg.max_width.value() == 0
-    assert wdg.max_height.value() == 0
+    assert wdg.max_width.value() == 1000
+    assert wdg.max_height.value() == 1000
     assert wdg.shape.currentText() == "ellipse"
     assert not wdg.allow_overlap.isChecked()
+    assert wdg.order.currentText() == "two_opt"
     assert wdg.random_seed is not None
 
     with qtbot.waitSignal(wdg.valueChanged):
@@ -50,6 +52,7 @@ def test_random_points_widget(qtbot: QtBot) -> None:
     assert wdg.max_height.value() == RANDOM_POINTS.max_height
     assert wdg.shape.currentText() == RANDOM_POINTS.shape.value
     assert wdg.random_seed == RANDOM_POINTS.random_seed
+    assert wdg.order.currentText() == RANDOM_POINTS.order.value
     assert wdg.allow_overlap.isChecked() == RANDOM_POINTS.allow_overlap
 
 


### PR DESCRIPTION
@tlambert03 what do you think about adding the `allow_overlap` option as a checkbox? I think it can be a useful one to have...


<img width="375" alt="Screenshot 2024-07-08 at 5 59 36 PM" src="https://github.com/pymmcore-plus/pymmcore-widgets/assets/70725613/121091dc-c653-4b2e-a34f-3d0fcd10bc53">


in this PR:
- add allow_overlap checkbox
- add order combobox