### PR TITLE
fix: WellPlateWidget initial drawing

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
+++ b/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
@@ -112,7 +112,7 @@ class WellPlateWidget(QWidget):
         self.plate_name.currentTextChanged.connect(self._on_plate_name_changed)
         self._show_rotation.toggled.connect(self._on_show_rotation_toggled)
 
-        self.setValue(plan if plan is not None else self.value())
+        self.setValue(plan or self.value())
 
     # _________________________PUBLIC METHODS_________________________ #
 

--- a/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
+++ b/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
@@ -112,8 +112,7 @@ class WellPlateWidget(QWidget):
         self.plate_name.currentTextChanged.connect(self._on_plate_name_changed)
         self._show_rotation.toggled.connect(self._on_show_rotation_toggled)
 
-        if plan:
-            self.setValue(plan)
+        self.setValue(plan if plan is not None else self.value())
 
     # _________________________PUBLIC METHODS_________________________ #
 

--- a/tests/useq_widgets/test_plate_widget.py
+++ b/tests/useq_widgets/test_plate_widget.py
@@ -47,6 +47,11 @@ def test_plate_widget_selection(qtbot: QtBot) -> None:
     wdg = WellPlateWidget()
     qtbot.addWidget(wdg)
     wdg.show()
+
+    # Ensure that if no plate is provided when instantiating the widget, the currently
+    # selected plate in the combobox is used.
+    assert wdg._view.scene().items()
+
     wdg.plate_name.setCurrentText("96-well")
     wdg.setCurrentSelection((slice(0, 4, 2), (1, 2)))
     selection = wdg.currentSelection()


### PR DESCRIPTION
currently if we create the `WellPlateWidget` without passing a `plate` arg, the plate is not drawn even if there is a plate selected in the combobox. This will fix that.

<img width="732" alt="Screenshot 2024-07-12 at 9 51 09 PM" src="https://github.com/user-attachments/assets/6289b0d2-1b13-4671-aa3b-ce9c956e7e0b">

<img width="732" alt="Screenshot 2024-07-12 at 9 51 24 PM" src="https://github.com/user-attachments/assets/56e742a3-08c5-4ffb-9b1a-f3bca4b13b1a">
