### PR TITLE
fix: make name editable EditGroupWidget

### DIFF
--- a/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_edit_group_widget.py
@@ -35,7 +35,6 @@ class EditGroupWidget(QDialog):
         self._create_gui()
 
         self.group_lineedit.setText(self._group)
-        self.group_lineedit.setEnabled(False)
 
         self.destroyed.connect(self._disconnect)
 
@@ -144,6 +143,13 @@ class EditGroupWidget(QDialog):
         )
 
     def _add_group(self) -> None:
+        # rename group if it has been changed
+        renamed: bool = False
+        if self._group != self.group_lineedit.text():
+            self._mmc.renameConfigGroup(self._group, self.group_lineedit.text())
+            self._group = self.group_lineedit.text()
+            renamed = True
+
         # [(device, property, value), ...], need to remove the value
         new_dev_prop = [x[:2] for x in self._prop_table.getCheckedProperties()]
 
@@ -152,7 +158,7 @@ class EditGroupWidget(QDialog):
             (k[0], k[1]) for k in self._mmc.getConfigData(self._group, presets[0])
         ]
 
-        if preset_dev_prop == new_dev_prop:
+        if preset_dev_prop == new_dev_prop and not renamed:
             return
 
         # get any new dev prop to add to each preset

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -165,10 +165,15 @@ def test_edit_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
     item.setCheckState(Qt.CheckState.Checked)
     assert table.item(t_row, 0).text() == "Camera-CCDTemperature"
 
-    edit_gp.modify_group_btn.click()
-    assert edit_gp.info_lbl.text() == "'Camera' Group Modified."
+    edit_gp.group_lineedit.setText("Camera_New")
 
-    dp = [k[:2] for k in mmc.getConfigData("Camera", "LowRes")]
+    edit_gp.modify_group_btn.click()
+    assert edit_gp.info_lbl.text() == "'Camera_New' Group Modified."
+
+    assert "Camera" not in mmc.getAvailableConfigGroups()
+    assert "Camera_New" in mmc.getAvailableConfigGroups()
+
+    dp = [k[:2] for k in mmc.getConfigData("Camera_New", "LowRes")]
     assert ("Camera", "CCDTemperature") in dp
 
 


### PR DESCRIPTION
This PR makes the group name editable when interacting with the edit group dialog in the `GroupPresetTableWidget`.

closes #324 