### PR TITLE
fix: update the GroupPresetTableWidget policy

### DIFF
--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -251,7 +251,7 @@ class GroupPresetTableWidget(QGroupBox):
                     wdg = wdg._value_widget  # type: ignore
 
         # resize to contents the table
-        self.table_wdg.resizeColumnsToContents()
+        self.table_wdg.resizeColumnToContents(0)
 
     def _get_cfg_data(self, group: str, preset: str) -> tuple[str, str, str, int]:
         # Return last device-property-value for the preset and the

--- a/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_group_preset_table_widget.py
@@ -5,6 +5,7 @@ from typing import Any
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
+    QAbstractScrollArea,
     QFileDialog,
     QGroupBox,
     QHBoxLayout,
@@ -38,12 +39,13 @@ class _MainTable(QTableWidget):
     def __init__(self) -> None:
         super().__init__()
         hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
+        hdr.setStretchLastSection(True)
         hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
         vh = self.verticalHeader()
         vh.setVisible(False)
         vh.setSectionResizeMode(vh.ResizeMode.Fixed)
         vh.setDefaultSectionSize(24)
+        self.setSizeAdjustPolicy(QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents)
         self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.setColumnCount(2)
@@ -247,6 +249,9 @@ class GroupPresetTableWidget(QGroupBox):
                     wdg = wdg._combo
                 elif isinstance(wdg, PropertyWidget):
                     wdg = wdg._value_widget  # type: ignore
+
+        # resize to contents the table
+        self.table_wdg.resizeColumnsToContents()
 
     def _get_cfg_data(self, group: str, preset: str) -> tuple[str, str, str, int]:
         # Return last device-property-value for the preset and the


### PR DESCRIPTION
In this PR we enable the columns resizing of the `GroupPresetTableWidget`.

https://github.com/user-attachments/assets/606266dd-f916-46ef-878a-929a66d17d19

closes #323