### PR TITLE
style: unfill radio buttions in GridPlanWidget

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -200,6 +200,12 @@ class GridPlanWidget(QScrollArea):
         self.order.currentIndexChanged.connect(self._on_change)
         self.relative_to.currentIndexChanged.connect(self._on_change)
 
+        # FIXME: On Windows 11, buttons within an inner widget of a ScrollArea
+        # are filled in with the accent color, making it very difficult to see
+        # which radio button is checked. This HACK solves the issue. It's
+        # likely future Qt versions will fix this.
+        inner_widget.setStyleSheet("QRadioButton {color: none}")
+
     # ------------------------- Public API -------------------------
 
     def mode(self) -> Mode:


### PR DESCRIPTION
This PR, closing #339, adds a `HACK` to prevent the OS accent color from filling up the `GridPlanWidget`'s radio buttons on Windows 11. This `HACK` seems to be the least-bad of the different options that could resolve the issue, which are:
* Setting the style sheet, as I did here, to override the accent color fill
* Adding the radio buttons to the layout of the `QScrollArea` itself, which is worse as it alters the hierarchy of the widget.

@tlambert03 and/or @fdrgsp: I'd be happy for your opinions and/or testing. It looks nice to me on Windows 11, and on WSL (Wayland)