### PR TITLE
fix: Align spin boxes and labels in GridPlan

### DIFF
--- a/src/pymmcore_widgets/mda/_xy_bounds.py
+++ b/src/pymmcore_widgets/mda/_xy_bounds.py
@@ -142,9 +142,9 @@ class XYBoundsControl(QWidget):
             QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
         )
         values_layout.addRow("Top:", self.top_edit)
-        values_layout.addRow("Left:", self.bottom_edit)
-        values_layout.addRow("Right:", self.left_edit)
-        values_layout.addRow("Bottom:", self.right_edit)
+        values_layout.addRow("Left:", self.left_edit)
+        values_layout.addRow("Right:", self.right_edit)
+        values_layout.addRow("Bottom:", self.bottom_edit)
 
         top_layout = QHBoxLayout()
         top_layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
I believe that the behavior I described in #337 was a simple misordering of the `_PositionSpinBox`es. I reordered them and things seem to work as described!

Closes #337