### PR TITLE
style: clarify save/load buttons in MDAWidget

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -297,10 +297,10 @@ class MDASequenceWidget(QWidget):
         )
         self._duration_label.setWordWrap(True)
 
-        self._save_button = QPushButton("Save")
+        self._save_button = QPushButton("Save Settings")
         self._save_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._save_button.clicked.connect(self.save)
-        self._load_button = QPushButton("Load")
+        self._load_button = QPushButton("Load Settings")
         self._load_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._load_button.clicked.connect(self.load)
 


### PR DESCRIPTION
I believe that these alterations make it clearer that the buttons save and load MDA parameters, and not images/devices/etc.

I do wonder if the text is a little wide though, what do others think?

![image](https://github.com/user-attachments/assets/78251729-aa63-4a45-bb6a-dbcf45c998fd)

Closes #335