### PR TITLE
fix: Only allow YAML save/load when YAML available

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib.util import find_spec
 from itertools import permutations
 from pathlib import Path
 from typing import cast
@@ -439,7 +440,7 @@ class MDASequenceWidget(QWidget):
                 self,
                 "Save MDASequence and filename.",
                 "",
-                "All (*.yaml *yml *json);;YAML (*.yaml *.yml);;JSON (*.json)",
+                self._settings_extensions(),
             )
             if not file:  # pragma: no cover
                 return
@@ -467,7 +468,7 @@ class MDASequenceWidget(QWidget):
                 self,
                 "Select an MDAsequence file.",
                 "",
-                "All (*.yaml *yml *json);;YAML (*.yaml *.yml);;JSON (*.json)",
+                self._settings_extensions(),
             )
             if not file:  # pragma: no cover
                 return
@@ -484,6 +485,14 @@ class MDASequenceWidget(QWidget):
         self.setValue(mda_seq)
 
     # -------------- Private API --------------
+
+    def _settings_extensions(self) -> str:
+        """Returns the available extensions for MDA settings save/load."""
+        if find_spec("yaml") is not None:
+            # YAML available
+            return "All (*.yaml *yml *.json);;YAML (*.yaml *.yml);;JSON (*.json)"
+        # Only JSON
+        return "All (*.json);;JSON (*.json)"
 
     def _on_af_toggled(self, checked: bool) -> None:
         # if the 'af_per_position' checkbox in the PositionTable is checked, set checked


### PR DESCRIPTION
This PR avoids exceptions arising from the attempt to save/load MDA settings from YAML files, when pyyaml is not installed.

Notably, I made the decision to prevent the selection of a YAML file within the `QFileDialog`. We could have alternatively shown it, but prevented the exception (through a `try`/`except` or other means) instead. I prefer this method as it leaves no room for unexpected behavior (namely a user trying to save into a YAML file and then save not being completed).

Closes #333