### PR TITLE
refactor: split run mda in mda widget

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -184,7 +184,17 @@ class MDAWidget(MDASequenceWidget):
         return get_next_available_path(requested_path=requested_path)
 
     def prepare_mda(self) -> bool | str | None:
-        """Prepare the MDA sequence experiment."""
+        """Prepare the MDA sequence experiment.
+
+        Returns
+        -------
+        bool
+            False if to be cancelled due to autofocus issue.
+        str
+            Preparation successful, save path to be used for saving and saving active
+        None
+            Preparation successful, saving deactivated
+        """
         # in case the user does not press enter after editing the save name.
         self.save_info.save_name.editingFinished.emit()
 

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -189,7 +189,7 @@ class MDAWidget(MDASequenceWidget):
         Returns
         -------
         bool
-            False if to be cancelled due to autofocus issue.
+            False if MDA to be cancelled due to autofocus issue.
         str
             Preparation successful, save path to be used for saving and saving active
         None

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -183,14 +183,14 @@ class MDAWidget(MDASequenceWidget):
         """
         return get_next_available_path(requested_path=requested_path)
 
-    def prepare_mda(self) -> bool | str | None:
+    def prepare_mda(self) -> bool | str | Path | None:
         """Prepare the MDA sequence experiment.
 
         Returns
         -------
         bool
             False if MDA to be cancelled due to autofocus issue.
-        str
+        str | Path
             Preparation successful, save path to be used for saving and saving active
         None
             Preparation successful, saving deactivated

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -183,7 +183,7 @@ class MDAWidget(MDASequenceWidget):
         """
         return get_next_available_path(requested_path=requested_path)
 
-    def prepare_mda(self) -> bool|str|None:
+    def prepare_mda(self) -> bool | str | None:
         """Prepare the MDA sequence experiment."""
         # in case the user does not press enter after editing the save name.
         self.save_info.save_name.editingFinished.emit()
@@ -208,7 +208,7 @@ class MDAWidget(MDASequenceWidget):
             return None
 
     def execute_mda(self, output: Path | str | object | None) -> None:
-        """Execute the MDA experiment corresponding to the current value"""
+        """Execute the MDA experiment corresponding to the current value."""
         sequence = self.value()
         # run the MDA experiment asynchronously
         self._mmc.run_mda(sequence, output=output)

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -183,7 +183,7 @@ class MDAWidget(MDASequenceWidget):
         """
         return get_next_available_path(requested_path=requested_path)
 
-    def prepare_mda(self) -> str:
+    def prepare_mda(self) -> bool|str|None:
         """Prepare the MDA sequence experiment."""
         # in case the user does not press enter after editing the save name.
         self.save_info.save_name.editingFinished.emit()
@@ -197,7 +197,7 @@ class MDAWidget(MDASequenceWidget):
             and (not self.tab_wdg.isChecked(pos) or not pos.af_per_position.isChecked())
             and not self._confirm_af_intentions()
         ):
-            return
+            return False
 
         # technically, this is in the metadata as well, but isChecked is more direct
         if self.save_info.isChecked():
@@ -215,6 +215,8 @@ class MDAWidget(MDASequenceWidget):
 
     def run_mda(self) -> None:
         save_path = self.prepare_mda()
+        if save_path is False:
+            return
         self.execute_mda(save_path)
 
     # ------------------- private Methods ----------------------

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -183,8 +183,8 @@ class MDAWidget(MDASequenceWidget):
         """
         return get_next_available_path(requested_path=requested_path)
 
-    def run_mda(self) -> None:
-        """Run the MDA sequence experiment."""
+    def prepare_mda(self) -> str:
+        """Prepare the MDA sequence experiment."""
         # in case the user does not press enter after editing the save name.
         self.save_info.save_name.editingFinished.emit()
 
@@ -199,18 +199,23 @@ class MDAWidget(MDASequenceWidget):
         ):
             return
 
-        sequence = self.value()
-
         # technically, this is in the metadata as well, but isChecked is more direct
         if self.save_info.isChecked():
-            save_path = self._update_save_path_from_metadata(
-                sequence, update_metadata=True
+            return self._update_save_path_from_metadata(
+                self.value(), update_metadata=True
             )
         else:
-            save_path = None
+            return None
 
+    def execute_mda(self, output: Path | str | object | None) -> None:
+        """Execute the MDA experiment corresponding to the current value"""
+        sequence = self.value()
         # run the MDA experiment asynchronously
-        self._mmc.run_mda(sequence, output=save_path)
+        self._mmc.run_mda(sequence, output=output)
+
+    def run_mda(self) -> None:
+        save_path = self.prepare_mda()
+        self.execute_mda(save_path)
 
     # ------------------- private Methods ----------------------
 


### PR DESCRIPTION
Just a first thought potentially for viewer integration etc. Would give a little more fine-grained control when customizing/subclassing the MDAWidget.