### PR TITLE
refactor: more grid plan cleanup

### DIFF
--- a/examples/grid_plan_widget.py
+++ b/examples/grid_plan_widget.py
@@ -15,6 +15,7 @@ mmc = CMMCorePlus().instance()
 mmc.loadSystemConfiguration()
 
 grid_wdg = GridPlanWidget()
+grid_wdg.valueChanged.connect(print)
 grid_wdg.show()
 
 app.exec_()

--- a/src/pymmcore_widgets/mda/_core_grid.py
+++ b/src/pymmcore_widgets/mda/_core_grid.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QHBoxLayout, QWidget
 
 from pymmcore_widgets.useq_widgets._grid import GridPlanWidget
 
 from ._xy_bounds import CoreXYBoundsControl
-
-if TYPE_CHECKING:
-    from qtpy.QtWidgets import QWidget
 
 
 class CoreConnectedGridPlanWidget(GridPlanWidget):
@@ -41,9 +37,19 @@ class CoreConnectedGridPlanWidget(GridPlanWidget):
         self.bottom = self._core_xy_bounds.bottom_edit
 
         # replace the lrtb_wdg from the parent widget with the core_xy_bounds widget
-        self._bounds_wdg.bounds_layout.removeWidget(self._bounds_wdg.lrtb_wdg)
-        self._bounds_wdg.bounds_layout.insertRow(0, self._core_xy_bounds)
-        self._bounds_wdg.lrtb_wdg.hide()
+        # self.bounds_wdg.bounds_layout.removeWidget(self.bounds_wdg.lrtb_wdg)
+        # self.bounds_wdg.lrtb_wdg.hide()
+
+        for wdg in self.bounds_wdg.children():
+            if isinstance(wdg, QWidget):
+                wdg.setParent(self)
+                wdg.hide()
+        QWidget().setLayout(self.bounds_wdg.layout())
+
+        new_layout = QHBoxLayout()
+        new_layout.addWidget(self._core_xy_bounds)
+        self.bounds_wdg.setLayout(new_layout)
+        # self.bounds_wdg.layout().addWidget(self._core_xy_bounds)
 
         # connect
         self.top.valueChanged.connect(self._on_change)

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -434,7 +434,9 @@ class _BottomStuff(QWidget):
         self.relative_to.currentIndexChanged.connect(self.valueChanged)
 
     def setMode(self, mode: Mode) -> None:
-        self._form_layout.setRowVisible(3, mode != Mode.BOUNDS)
+        vis = mode != Mode.BOUNDS
+        for role in (QFormLayout.ItemRole.LabelRole, QFormLayout.ItemRole.FieldRole):
+            self._form_layout.itemAt(3, role).widget().setVisible(vis)
 
     def value(self) -> dict:
         return {

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -329,7 +329,7 @@ class MDASequenceWidget(QWidget):
 
         layout = QVBoxLayout(self)
         layout.addLayout(top_row)
-        layout.addWidget(self.tab_wdg)
+        layout.addWidget(self.tab_wdg, 1)
         layout.addLayout(cbox_row)
         layout.addLayout(bot_row)
 


### PR DESCRIPTION
taking advantage of @gselzer 's work in #351 to clean up the GridPlan Widget a bit more, removing conditionals and putting them on the stack widget classes