### PR TITLE
feat: reload prior config file on HCW rejection

### DIFF
--- a/src/pymmcore_widgets/hcwizard/config_wizard.py
+++ b/src/pymmcore_widgets/hcwizard/config_wizard.py
@@ -128,6 +128,13 @@ class ConfigWizard(QWizard):
         self._model.save(dest_path)
         super().accept()
 
+    def reject(self) -> None:
+        """Reject the wizard and reload the prior configuration."""
+        super().reject()
+        last_config_file = self._core.systemConfigurationFile()
+        if last_config_file is not None:
+            self._core.loadSystemConfiguration(last_config_file)
+
     def _update_step(self, current_index: int) -> None:
         """Change text on the left when the page changes."""
         for i, label in enumerate(self.step_labels):

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -76,6 +76,21 @@ def test_config_wizard(global_mmcore: CMMCorePlus, qtbot, tmp_path: Path):
                 wiz.closeEvent(QCloseEvent())
 
 
+def test_config_wizard_rejection(global_mmcore: CMMCorePlus, qtbot, tmp_path: Path):
+    global_mmcore.loadSystemConfiguration(str(TEST_CONFIG))
+    st1 = global_mmcore.getSystemState()
+
+    wiz = ConfigWizard(str(TEST_CONFIG), global_mmcore)
+    qtbot.addWidget(wiz)
+    wiz.show()
+    wiz.reject()
+
+    # Assert system state prior to wizard execution still present
+    st2 = global_mmcore.getSystemState()
+
+    assert st1 == st2
+
+
 def test_config_wizard_devices(
     global_mmcore: CMMCorePlus, qtbot: QtBot, tmp_path: Path, qapp
 ):


### PR DESCRIPTION
Often, I've found myself accidentally launching the Hardware Configuration Wizard. When I cancel (`reject`) the wizard, my configuration is unloaded. See gselzer/pymmcore-plus-sandbox#29 for more discussion.

This PR remedies the situation by reloading the last used configuration on rejection.