### PR TITLE
fix: enable ct axis order

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -51,7 +51,6 @@ AXES = "tpgcz"
 ALLOWED_ORDERS = {"".join(p) for x in range(1, 6) for p in permutations(AXES, x)}
 for x in list(ALLOWED_ORDERS):
     for first, second in (
-        ("t", "c"),  # t cannot come after c
         ("t", "z"),  # t cannot come after z
         ("p", "g"),  # p cannot come after g
         ("p", "c"),  # p cannot come after c


### PR DESCRIPTION
Currently we cannot set the axis order as `ct` to acquire a timelapse per channel. This PR enable the `ct` option.