### PR TITLE
fix: disable Autofocus checkbox when using HCSWizard

### DIFF
--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -199,6 +199,7 @@ class CoreConnectedPositionTable(PositionTable):
         """Enable/disable the position table depending on the use of the HCS wizard."""
         self._edit_hcs_pos.setVisible(not state)
         self.include_z.setVisible(state)
+        self.af_per_position.setVisible(state)
 
         # Hide or show all columns that are irrelevant when using the HCS wizard
         table = self.table()

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -770,10 +770,10 @@ def test_core_mda_with_hcs_enable_disable(
     assert all(
         not action.isEnabled() for action in wdg.stage_positions.toolBar().actions()[1:]
     )
-    # include_z checkbox disablex
+    # include_z checkbox disabled
     assert wdg.stage_positions.include_z.isHidden()
-    # autofocus checkbox enabled
-    assert wdg.stage_positions.af_per_position.isEnabled()
+    # autofocus checkbox disabled
+    assert wdg.stage_positions.af_per_position.isHidden()
 
 
 @pytest.mark.parametrize("ext", ["json", "yaml"])


### PR DESCRIPTION
@tlambert03 I removed this in #362 but it was a mistake. AF per position should be disabled when using HCS since it is not in the WellPlatePlan model.