### PR TITLE
fix: fix splitting logic and deduplicate code in Groups Presets Widgets

### DIFF
--- a/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_first_preset_widget.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pymmcore_plus import CMMCorePlus
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QDialog,
     QGroupBox,
@@ -11,14 +10,13 @@ from qtpy.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QSpacerItem,
-    QTableWidget,
-    QTableWidgetItem,
     QVBoxLayout,
     QWidget,
 )
 
-from pymmcore_widgets._property_widget import PropertyWidget
 from pymmcore_widgets._util import block_core
+
+from ._cfg_table import _CfgTable
 
 
 class AddFirstPresetWidget(QDialog):
@@ -39,7 +37,7 @@ class AddFirstPresetWidget(QDialog):
 
         self._create_gui()
 
-        self._populate_table()
+        self.table.populate_table(self._dev_prop_val_list)
 
     def _create_gui(self) -> None:
         self.setWindowTitle(f"Add the first Preset to the new '{self._group}' Group")
@@ -58,7 +56,7 @@ class AddFirstPresetWidget(QDialog):
         top_wdg = self._create_top_wdg()
         wdg_layout.addWidget(top_wdg)
 
-        self.table = _Table()
+        self.table = _CfgTable()
         wdg_layout.addWidget(self.table)
 
         bottom_wdg = self._create_bottom_wdg()
@@ -121,26 +119,8 @@ class AddFirstPresetWidget(QDialog):
 
         return wdg
 
-    def _populate_table(self) -> None:
-        self.table.clearContents()
-
-        self.table.setRowCount(len(self._dev_prop_val_list))
-        for idx, (dev, prop, _) in enumerate(self._dev_prop_val_list):
-            item = QTableWidgetItem(f"{dev}-{prop}")
-            wdg = PropertyWidget(dev, prop, mmcore=self._mmc)
-            wdg._value_widget.valueChanged.disconnect()  # type: ignore
-            self.table.setItem(idx, 0, item)
-            self.table.setCellWidget(idx, 1, wdg)
-
     def _create_first_preset(self) -> None:
-        dev_prop_val = []
-        for row in range(self.table.rowCount()):
-            device_property = self.table.item(row, 0).text()
-            dev = device_property.split("-")[0]
-            prop = device_property.split("-")[1]
-            value = str(self.table.cellWidget(row, 1).value())
-            dev_prop_val.append((dev, prop, value))
-
+        dev_prop_val = self.table.get_state()
         preset = self.preset_name_lineedit.text()
         if not preset:
             preset = self.preset_name_lineedit.placeholderText()
@@ -153,20 +133,3 @@ class AddFirstPresetWidget(QDialog):
 
         self.close()
         self.parent().close()
-
-
-class _Table(QTableWidget):
-    """Set table properties for EditPresetWidget."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
-        vh = self.verticalHeader()
-        vh.setVisible(False)
-        vh.setSectionResizeMode(vh.ResizeMode.Fixed)
-        vh.setDefaultSectionSize(24)
-        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        self.setColumnCount(2)
-        self.setHorizontalHeaderLabels(["Device-Property", "Value"])

--- a/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_add_preset_widget.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import warnings
 
 from pymmcore_plus import CMMCorePlus
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QDialog,
     QGroupBox,
@@ -13,14 +12,13 @@ from qtpy.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QSpacerItem,
-    QTableWidget,
-    QTableWidgetItem,
     QVBoxLayout,
     QWidget,
 )
 
-from pymmcore_widgets._property_widget import PropertyWidget
 from pymmcore_widgets._util import block_core
+
+from ._cfg_table import _CfgTable
 
 
 class AddPresetWidget(QDialog):
@@ -53,7 +51,7 @@ class AddPresetWidget(QDialog):
         top_wdg = self._create_top_wdg()
         wdg_layout.addWidget(top_wdg)
 
-        self.table = _Table()
+        self.table = _CfgTable()
         wdg_layout.addWidget(self.table)
 
         bottom_wdg = self._create_bottom_wdg()
@@ -114,8 +112,6 @@ class AddPresetWidget(QDialog):
         return wdg
 
     def _populate_table(self) -> None:
-        self.table.clearContents()
-
         dev_prop = []
         for preset in self._mmc.getAvailableConfigs(self._group):
             dev_prop.extend(
@@ -125,14 +121,7 @@ class AddPresetWidget(QDialog):
                     if (k[0], k[1]) not in dev_prop
                 ]
             )
-
-        self.table.setRowCount(len(dev_prop))
-        for idx, (dev, prop) in enumerate(dev_prop):
-            item = QTableWidgetItem(f"{dev}-{prop}")
-            wdg = PropertyWidget(dev, prop, mmcore=self._mmc)
-            wdg._value_widget.valueChanged.disconnect()  # type: ignore
-            self.table.setItem(idx, 0, item)
-            self.table.setCellWidget(idx, 1, wdg)
+        self.table.populate_table(dev_prop)
 
     def _add_preset(self) -> None:
         preset_name = self.preset_name_lineedit.text()
@@ -148,14 +137,7 @@ class AddPresetWidget(QDialog):
         if not preset_name:
             preset_name = self.preset_name_lineedit.placeholderText()
 
-        dev_prop_val = []
-        for row in range(self.table.rowCount()):
-            device_property = self.table.item(row, 0).text()
-            dev = device_property.split("-")[0]
-            prop = device_property.split("-")[1]
-            value = str(self.table.cellWidget(row, 1).value())
-            dev_prop_val.append((dev, prop, value))
-
+        dev_prop_val = self.table.get_state()
         for p in self._mmc.getAvailableConfigs(self._group):
             dpv_preset = [
                 (k[0], k[1], k[2]) for k in self._mmc.getConfigData(self._group, p)
@@ -171,28 +153,11 @@ class AddPresetWidget(QDialog):
                 return
 
         with block_core(self._mmc.events):
-            for d, p, v in dev_prop_val:
-                self._mmc.defineConfig(self._group, preset_name, d, p, v)
+            for dev, prop, val in dev_prop_val:
+                self._mmc.defineConfig(self._group, preset_name, dev, prop, val)
 
-        self._mmc.events.configDefined.emit(self._group, preset_name, d, p, v)
+        self._mmc.events.configDefined.emit(self._group, preset_name, dev, prop, val)
 
         self.info_lbl.setStyleSheet("")
         self.info_lbl.setText(f"'{preset_name}' has been added!")
         self.preset_name_lineedit.setPlaceholderText(self._get_placeholder_name())
-
-
-class _Table(QTableWidget):
-    """Set table properties for EditPresetWidget."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        hdr = self.horizontalHeader()
-        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
-        vh = self.verticalHeader()
-        vh.setVisible(False)
-        vh.setSectionResizeMode(vh.ResizeMode.Fixed)
-        vh.setDefaultSectionSize(24)
-        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        self.setColumnCount(2)
-        self.setHorizontalHeaderLabels(["Device-Property", "Value"])

--- a/src/pymmcore_widgets/_group_preset_widget/_cfg_table.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_cfg_table.py
@@ -15,13 +15,13 @@ class _CfgTable(QTableWidget):
 
     def __init__(self) -> None:
         super().__init__()
-        if hdr := self.horizontalHeader():
-            hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
-            hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
-        if vh := self.verticalHeader():
-            vh.setVisible(False)
-            vh.setSectionResizeMode(vh.ResizeMode.Fixed)
-            vh.setDefaultSectionSize(24)
+        hdr = self.horizontalHeader()
+        hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
+        hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
+        vh = self.verticalHeader()
+        vh.setVisible(False)
+        vh.setSectionResizeMode(vh.ResizeMode.Fixed)
+        vh.setDefaultSectionSize(24)
         self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["Device-Property", "Value"])

--- a/src/pymmcore_widgets/_group_preset_widget/_cfg_table.py
+++ b/src/pymmcore_widgets/_group_preset_widget/_cfg_table.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any, Sequence, cast
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QTableWidget, QTableWidgetItem
+
+from pymmcore_widgets._property_widget import PropertyWidget
+
+DEV_PROP_ROLE = Qt.ItemDataRole.UserRole + 1
+
+
+class _CfgTable(QTableWidget):
+    """Set table properties for EditPresetWidget."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        if hdr := self.horizontalHeader():
+            hdr.setSectionResizeMode(hdr.ResizeMode.Stretch)
+            hdr.setDefaultAlignment(Qt.AlignmentFlag.AlignHCenter)
+        if vh := self.verticalHeader():
+            vh.setVisible(False)
+            vh.setSectionResizeMode(vh.ResizeMode.Fixed)
+            vh.setDefaultSectionSize(24)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.setColumnCount(2)
+        self.setHorizontalHeaderLabels(["Device-Property", "Value"])
+
+    def populate_table(self, dev_prop_val: Sequence[Sequence[Any]]) -> None:
+        self.clearContents()
+        self.setRowCount(len(dev_prop_val))
+        for idx, (dev, prop, *_) in enumerate(dev_prop_val):
+            item = QTableWidgetItem(f"{dev}-{prop}")
+            item.setData(DEV_PROP_ROLE, (dev, prop))
+            wdg = PropertyWidget(dev, prop, connect_core=False)
+            self.setItem(idx, 0, item)
+            self.setCellWidget(idx, 1, wdg)
+
+    def get_state(self) -> list[tuple[str, str, str]]:
+        dev_prop_val = []
+        for row in range(self.rowCount()):
+            if (dev_prop_item := self.item(row, 0)) and (
+                wdg := cast("PropertyWidget", self.cellWidget(row, 1))
+            ):
+                dev, prop = dev_prop_item.data(DEV_PROP_ROLE)
+                dev_prop_val.append((dev, prop, str(wdg.value())))
+        return dev_prop_val


### PR DESCRIPTION
fixes #363

This is just a patch for the immediate issue, these widgets still contain a lot of duplicated code and possible bugs, and should be replaced (with one of #307, #320, #338, etc...)