### PR TITLE
fix: fix z plan and hardware autofocus plan validation error

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -339,6 +339,13 @@ class MDAWidget(MDASequenceWidget):
             self._mmc.mda.events.sequenceStarted.disconnect(self._on_mda_started)
             self._mmc.mda.events.sequenceFinished.disconnect(self._on_mda_finished)
 
+    def _enable_af(self, state: bool, tooltip1: str, tooltip2: str) -> None:
+        """Override the autofocus enablement to account for the autofocus device."""
+        if not self._mmc.getAutoFocusDevice():
+            self.stage_positions._update_autofocus_enablement()
+            return
+        return super()._enable_af(state, tooltip1, tooltip2)
+
 
 class _MDAControlButtons(QWidget):
     """Run, pause, and cancel buttons at the bottom of the MDA Widget."""

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -500,6 +500,14 @@ class MDASequenceWidget(QWidget):
         # Only JSON
         return "All (*.json);;JSON (*.json)"
 
+    def _enable_af(self, state: bool, tooltip1: str, tooltip2: str) -> None:
+        """Enable or disable autofocus settings."""
+        self.af_axis.setEnabled(state)
+        self.af_axis.setToolTip(tooltip1)
+        self.stage_positions.af_per_position.setEnabled(state)
+        self.stage_positions.af_per_position.setChecked(state)
+        self.stage_positions.af_per_position.setToolTip(tooltip2)
+
     def _validate_af_with_z_plan(self) -> None:
         """Check if the autofocus plan can be used with the current Z Plan.
 
@@ -510,11 +518,7 @@ class MDASequenceWidget(QWidget):
                 "The hardware autofocus cannot be used with absolute Z positions "
                 "(TOP_BOTTOM mode)."
             )
-            self.af_axis.setEnabled(False)
-            self.af_axis.setToolTip(tooltip)
-            self.stage_positions.af_per_position.setEnabled(False)
-            self.stage_positions.af_per_position.setChecked(False)
-            self.stage_positions.af_per_position.setToolTip(tooltip)
+            self._enable_af(False, tooltip, tooltip)
             if self.af_axis.use_af_p.isChecked():
                 QMessageBox.warning(
                     self,
@@ -527,10 +531,7 @@ class MDASequenceWidget(QWidget):
                     defaultButton=QMessageBox.StandardButton.Ok,
                 )
         else:
-            self.af_axis.setEnabled(True)
-            self.af_axis.setToolTip(AF_TOOLTIP)
-            self.stage_positions.af_per_position.setEnabled(True)
-            self.stage_positions.af_per_position.setToolTip(AF_DEFAULT_TOOLTIP)
+            self._enable_af(True, AF_TOOLTIP, AF_DEFAULT_TOOLTIP)
 
         self.valueChanged.emit()
 
@@ -540,10 +541,7 @@ class MDASequenceWidget(QWidget):
             if self.tab_wdg.isChecked(self.z_plan):
                 self._validate_af_with_z_plan()
             else:
-                self.af_axis.setEnabled(True)
-                self.af_axis.setToolTip(AF_TOOLTIP)
-                self.stage_positions.af_per_position.setEnabled(True)
-                self.stage_positions.af_per_position.setToolTip(AF_DEFAULT_TOOLTIP)
+                self._enable_af(True, AF_TOOLTIP, AF_DEFAULT_TOOLTIP)
 
         self._update_available_axis_orders()
 

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -64,6 +64,10 @@ for x in list(ALLOWED_ORDERS):
         if _check_order(x, first, second):
             ALLOWED_ORDERS.discard(x)
 AF_TOOLTIP = "Use Hardware Autofocus on the selected axes."
+AF_DISABLED_TOOLTIP = (
+    "The hardware autofocus cannot be used with absolute Z positions "
+    "(TOP_BOTTOM mode)."
+)
 
 
 class MDATabs(CheckableTabWidget):
@@ -521,12 +525,8 @@ class MDASequenceWidget(QWidget):
         If the Z Plan is set to TOP_BOTTOM, the autofocus plan cannot be used.
         """
         if self.z_plan.mode() == Mode.TOP_BOTTOM:
-            tooltip = (
-                "The hardware autofocus cannot be used with absolute Z positions "
-                "(TOP_BOTTOM mode)."
-            )
             self._use_af_per_pos = self.stage_positions.af_per_position.isChecked()
-            self._enable_af(False, tooltip, tooltip)
+            self._enable_af(False, AF_DISABLED_TOOLTIP, AF_DISABLED_TOOLTIP)
             if self.af_axis.use_af_p.isChecked():
                 QMessageBox.warning(
                     self,

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -25,7 +25,7 @@ import pymmcore_widgets
 from pymmcore_widgets.useq_widgets._channels import ChannelTable
 from pymmcore_widgets.useq_widgets._checkable_tabwidget_widget import CheckableTabWidget
 from pymmcore_widgets.useq_widgets._grid import GridPlanWidget
-from pymmcore_widgets.useq_widgets._positions import PositionTable
+from pymmcore_widgets.useq_widgets._positions import AF_DEFAULT_TOOLTIP, PositionTable
 from pymmcore_widgets.useq_widgets._time import TimePlanWidget
 from pymmcore_widgets.useq_widgets._z import Mode, ZPlanWidget
 
@@ -506,11 +506,15 @@ class MDASequenceWidget(QWidget):
         If the Z Plan is set to TOP_BOTTOM, the autofocus plan cannot be used.
         """
         if self.z_plan.mode() == Mode.TOP_BOTTOM:
-            self.af_axis.setEnabled(False)
-            self.af_axis.setToolTip(
+            tooltip = (
                 "The hardware autofocus cannot be used with absolute Z positions "
                 "(TOP_BOTTOM mode)."
             )
+            self.af_axis.setEnabled(False)
+            self.af_axis.setToolTip(tooltip)
+            self.stage_positions.af_per_position.setEnabled(False)
+            self.stage_positions.af_per_position.setChecked(False)
+            self.stage_positions.af_per_position.setToolTip(tooltip)
             if self.af_axis.use_af_p.isChecked():
                 QMessageBox.warning(
                     self,
@@ -525,6 +529,8 @@ class MDASequenceWidget(QWidget):
         else:
             self.af_axis.setEnabled(True)
             self.af_axis.setToolTip(AF_TOOLTIP)
+            self.stage_positions.af_per_position.setEnabled(True)
+            self.stage_positions.af_per_position.setToolTip(AF_DEFAULT_TOOLTIP)
 
         self.valueChanged.emit()
 
@@ -536,6 +542,8 @@ class MDASequenceWidget(QWidget):
             else:
                 self.af_axis.setEnabled(True)
                 self.af_axis.setToolTip(AF_TOOLTIP)
+                self.stage_positions.af_per_position.setEnabled(True)
+                self.stage_positions.af_per_position.setToolTip(AF_DEFAULT_TOOLTIP)
 
         self._update_available_axis_orders()
 

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -286,6 +286,9 @@ class MDASequenceWidget(QWidget):
         self.axis_order.setToolTip("Slowest to fastest axis order.")
         self.axis_order.setMinimumWidth(80)
 
+        # used in _validate_af_with_z_plan to store state of the autofocus per position
+        self._use_af_per_pos: bool = False
+
         # -------------- Other Widgets --------------
 
         # QLabel with standard warning icon to indicate time overflow
@@ -505,8 +508,12 @@ class MDASequenceWidget(QWidget):
         self.af_axis.setEnabled(state)
         self.af_axis.setToolTip(tooltip1)
         self.stage_positions.af_per_position.setEnabled(state)
-        self.stage_positions.af_per_position.setChecked(state)
         self.stage_positions.af_per_position.setToolTip(tooltip2)
+        if not state:
+            self.stage_positions.af_per_position.setChecked(state)
+        else:
+            # re-enable autofocus per position only if it was checked before
+            self.stage_positions.af_per_position.setChecked(self._use_af_per_pos)
 
     def _validate_af_with_z_plan(self) -> None:
         """Check if the autofocus plan can be used with the current Z Plan.
@@ -518,6 +525,7 @@ class MDASequenceWidget(QWidget):
                 "The hardware autofocus cannot be used with absolute Z positions "
                 "(TOP_BOTTOM mode)."
             )
+            self._use_af_per_pos = self.stage_positions.af_per_position.isChecked()
             self._enable_af(False, tooltip, tooltip)
             if self.af_axis.use_af_p.isChecked():
                 QMessageBox.warning(

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -533,7 +533,7 @@ class MDASequenceWidget(QWidget):
                     "Autofocus Plan Disabled",
                     "The hardware autofocus cannot be used with absolute Z positions "
                     "(TOP_BOTTOM mode). It has been disabled.\n\n"
-                    "To re-enable autofocus, set the Z Plan Mode to a relative position"
+                    "To re-enable it, set the Z Plan Mode to a relative position"
                     " (RANGE_AROUND or ABOVE_BELOW mode).",
                     buttons=QMessageBox.StandardButton.Ok,
                     defaultButton=QMessageBox.StandardButton.Ok,

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -490,9 +490,11 @@ def test_autofocus_with_z_plans(qtbot: QtBot) -> None:
     qtbot.addWidget(wdg)
     wdg.show()
 
+    wdg.tab_wdg.setChecked(wdg.stage_positions, True)
+
     assert not wdg.tab_wdg.isChecked(wdg.z_plan)
     assert wdg.af_axis.isEnabled()
-
+    assert wdg.stage_positions.af_per_position.isEnabled()
     wdg.af_axis.setValue(("p", "t"))
     assert wdg.af_axis.value() == ("p", "t")
 
@@ -504,12 +506,14 @@ def test_autofocus_with_z_plans(qtbot: QtBot) -> None:
 
     assert wdg.z_plan.mode() == _z.Mode.TOP_BOTTOM
     assert not wdg.af_axis.isEnabled()
+    assert not wdg.stage_positions.af_per_position.isEnabled()
     assert wdg.af_axis.value() == ()
 
     with patch.object(QMessageBox, "warning", _qmsgbox):
         wdg.tab_wdg.setChecked(wdg.z_plan, False)
 
     assert wdg.af_axis.isEnabled()
+    assert wdg.stage_positions.af_per_position.isEnabled()
 
     with patch.object(QMessageBox, "warning", _qmsgbox):
         wdg.tab_wdg.setChecked(wdg.z_plan, True)
@@ -518,3 +522,4 @@ def test_autofocus_with_z_plans(qtbot: QtBot) -> None:
         wdg.z_plan.setValue(useq.ZRangeAround(range=4, step=0.2))
 
     assert wdg.af_axis.isEnabled()
+    assert wdg.stage_positions.af_per_position.isEnabled()


### PR DESCRIPTION
tests failing because of https://github.com/hgrecco/pint/issues/2074.

fix the bug in #373.

@tlambert03 the error in #373 is due to the validation of the `useq.schema` [here](https://github.com/pymmcore-plus/useq-schema/blob/6dc031498f62c0d8853ada40188567f6d542335c/src/useq/_mda_sequence.py#L395-L402).  Basically we cannot use the hardware autofocus plan if an absolute z plan (top-bottom) is selected.

to fix that, I've created a method that disables the autofocus checkboxes (and thus remove the autofocus plan to avoid the validation error) if an absolute z plan is selected. If any other z plans (or None) are selected, the autofocus checkboxes are re-enabled. Do you agree with this solution?

closes #373 