### PR TITLE
fix: "range" in range-around z-stack widget starts form 0 (no negative numbers)

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_z.py
+++ b/src/pymmcore_widgets/useq_widgets/_z.py
@@ -146,7 +146,7 @@ class ZPlanWidget(QWidget):
         self.steps.setValue(0)
 
         self.range = QDoubleSpinBox()
-        self.range.setRange(-10_000, 10_000)
+        self.range.setRange(0, 10_000)
         self.range.setSingleStep(0.1)
         self.range.setDecimals(3)
         self.range.setValue(0)


### PR DESCRIPTION
fix for #376: set the minimum possible range for the RANGE_AROUND mode to 0 so we do not have negative values.


closes #376 