### PR TITLE
fix: fix include_z when setting stage positions value in PositionTable widget

### DIFF
--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -137,6 +137,7 @@ class CoreConnectedPositionTable(PositionTable):
             self._set_position_table_editable(False)
             value = tuple(value)
         super().setValue(value)
+        self._update_z_enablement()
 
     # ----------------------- private methods -----------------------
 

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -21,6 +21,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from superqt.fonticon import icon
+from superqt.utils import signals_blocked
 
 from ._column_info import FloatColumn, TextColumn, WdgGetSet, WidgetColumn
 from ._data_table import DataTableWidget
@@ -289,8 +290,9 @@ class PositionTable(DataTableWidget):
             _values.append({**v.model_dump(exclude_unset=True), **_af})
 
         super().setValue(_values)
-        self.include_z.setChecked(_include_z)
-        self.af_per_position.setChecked(_use_af)
+        with signals_blocked(self):
+            self.include_z.setChecked(_include_z)
+            self.af_per_position.setChecked(_use_af)
 
     def save(self, file: str | Path | None = None) -> None:
         """Save the current positions to a JSON file."""

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -169,6 +169,22 @@ def test_mda_wdg_load_save(
         assert dest.read_text() == mda_no_meta.yaml(exclude_defaults=True)
 
 
+def test_mda_wdg_set_value_ignore_z(qtbot: QtBot) -> None:
+    wdg = MDASequenceWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    MDA_noZ = useq.MDASequence(
+        axis_order="p",
+        stage_positions=[(0, 1), useq.Position(x=42, y=0)],
+        keep_shutter_open_across=("z",),
+    )
+    assert wdg.stage_positions.include_z.isChecked()
+    wdg.setValue(MDA_noZ)
+    assert wdg.value().replace(metadata={}) == MDA_noZ
+    assert not wdg.stage_positions.include_z.isChecked()
+
+
 def test_qquant_line_edit(qtbot: QtBot) -> None:
     wdg = QTimeLineEdit("1.0 s")
     wdg.show()

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -184,6 +184,16 @@ def test_mda_wdg_set_value_ignore_z(qtbot: QtBot) -> None:
     assert wdg.value().replace(metadata={}) == MDA_noZ
     assert not wdg.stage_positions.include_z.isChecked()
 
+    MDA_partialZ = useq.MDASequence(
+        axis_order="p",
+        stage_positions=[(0, 1), useq.Position(x=42, y=0, z=3)],
+        keep_shutter_open_across=("z",),
+    )
+
+    with pytest.warns(match="Only some positions have a z-position"):
+        wdg.setValue(MDA_partialZ)
+    assert wdg.stage_positions.include_z.isChecked()
+
 
 def test_qquant_line_edit(qtbot: QtBot) -> None:
     wdg = QTimeLineEdit("1.0 s")


### PR DESCRIPTION
fixes #380 

for now, this will set the "include z" checkbox to True if _any_ of the positions have a Z position.   If only some of them have a z position, it will emit a warning.

If we need the feature in the future, we could further elaborate to somehow let some rows have a Z position of None while others don't