### PR TITLE
fix: fix af per pos bug on prop changed

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -150,7 +150,11 @@ class MDAWidget(MDASequenceWidget):
 
         # if there is an autofocus_plan but the autofocus_motor_offset is None, set it
         # to the current value
-        if (afplan := val.autofocus_plan) and afplan.autofocus_motor_offset is None:
+        if (
+            self._mmc.getAutoFocusDevice()
+            and (afplan := val.autofocus_plan)
+            and afplan.autofocus_motor_offset is None
+        ):
             p2 = afplan.replace(autofocus_motor_offset=self._mmc.getAutoFocusOffset())
             replace["autofocus_plan"] = p2
 

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -259,7 +259,7 @@ class CoreConnectedPositionTable(PositionTable):
         self._update_autofocus_enablement()
 
     def _on_property_changed(self, device: str, prop: str, _val: str = "") -> None:
-        """Update the autofocus device combo box when the autofocus device changes."""
+        """Enable/Disable stages columns."""
         if device == "Core":
             if prop == "XYStage":
                 self._update_xy_enablement()
@@ -291,6 +291,9 @@ class CoreConnectedPositionTable(PositionTable):
         """Update the autofocus device combo box."""
         af_device = self._mmc.getAutoFocusDevice()
         self.af_per_position.setEnabled(bool(af_device))
+        # also hide the AF column if the autofocus device is not available
+        if not af_device:
+            self.af_per_position.setChecked(False)
         self.af_per_position.setToolTip(
             AF_DEFAULT_TOOLTIP if af_device else "AutoFocus device unavailable."
         )

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -195,15 +195,6 @@ def test_core_connected_position_wdg_property_changed(
     # stage device is set as default device.
     mmc = global_mmcore
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
-        if stage == "XY":
-            mmc.setProperty("Core", "XYStage", "")
-        elif stage == "Z":
-            mmc.setProperty("Core", "Focus", "")
-        elif stage == "Autofocus":
-            mmc.setProperty("Core", "AutoFocus", "")
-        mmc.waitForSystem()
-
     wdg = MDAWidget()
     qtbot.addWidget(wdg)
     wdg.show()
@@ -212,6 +203,17 @@ def test_core_connected_position_wdg_property_changed(
     assert isinstance(pos_table, CoreConnectedPositionTable)
 
     wdg.setValue(MDA)
+
+    pos_table.af_per_position.setChecked(True)
+
+    with qtbot.waitSignal(mmc.events.propertyChanged):
+        if stage == "XY":
+            mmc.setProperty("Core", "XYStage", "")
+        elif stage == "Z":
+            mmc.setProperty("Core", "Focus", "")
+        elif stage == "Autofocus":
+            mmc.setProperty("Core", "AutoFocus", "")
+        mmc.waitForSystem()
 
     # stage is not set as default device
     _assert_position_wdg_state(stage, pos_table, is_hidden=True)


### PR DESCRIPTION
I found a bug in the `CoreConnectedPositionTable` `_update_autofocus_enablement` method when core `propertyChanged` is called.

to reproduce:
- check the `CoreConnectedPositionTable.af_per_position` checkbox (the AF column will be visible).
- set the `Core Autofocus` to `""`.
- the `CoreConnectedPositionTable.af_per_position` is now disabled but the AF column is still visible.
 
I fixed this and modified the test so this bug is exposed without this fix.