### PR TITLE
feat: use QRadioButtons to select z_plan

### DIFF
--- a/src/pymmcore_widgets/mda/_core_z.py
+++ b/src/pymmcore_widgets/mda/_core_z.py
@@ -51,7 +51,7 @@ class CoreConnectedZPlanWidget(ZPlanWidget):
 
     def setMode(
         self,
-        mode: Mode | Literal["top_bottom", "range_around", "above_below"] | None = None,
+        mode: Mode | Literal["top_bottom", "range_around", "above_below"],
     ) -> None:
         super().setMode(mode)
         self.bottom_btn.setVisible(self._mode == Mode.TOP_BOTTOM)

--- a/src/pymmcore_widgets/useq_widgets/_z.py
+++ b/src/pymmcore_widgets/useq_widgets/_z.py
@@ -64,13 +64,13 @@ class ZPlanWidget(QWidget):
 
         # #################### Mode Buttons ####################
 
-        self._btn_top_bot = QRadioButton("TopBottom")
+        self._btn_top_bot = QRadioButton("Top/Bottom")
         self._btn_top_bot.setIcon(icon(MDI6.arrow_expand_vertical))
         self._btn_top_bot.setToolTip("Mark top and bottom.")
-        self._btn_range = QRadioButton("RangeAround")
+        self._btn_range = QRadioButton("Range Around (Symmetric)")
         self._btn_range.setIcon(icon(MDI6.arrow_split_horizontal))
         self._btn_range.setToolTip("Range symmetric around reference.")
-        self._button_above_below = QRadioButton("AboveBelow")
+        self._button_above_below = QRadioButton("Range Asymmetric")
         self._button_above_below.setIcon(icon(MDI6.arrow_expand_up))
         self._button_above_below.setToolTip(
             "Range asymmetrically above/below reference."
@@ -82,14 +82,13 @@ class ZPlanWidget(QWidget):
         self._mode_btn_group.addButton(self._button_above_below)
         self._mode_btn_group.buttonToggled.connect(self.setMode)
 
+        # radio buttons on the top row
         btn_wdg = QWidget()
         btn_layout = QHBoxLayout(btn_wdg)
         btn_layout.setContentsMargins(0, 0, 0, 0)
-        btn_layout.setSpacing(10)
         btn_layout.addWidget(self._btn_top_bot)
         btn_layout.addWidget(self._btn_range)
         btn_layout.addWidget(self._button_above_below)
-        btn_layout.addStretch()
 
         # FIXME: On Windows 11, buttons within an inner widget of a ScrollArea
         # are filled in with the accent color, making it very difficult to see

--- a/src/pymmcore_widgets/useq_widgets/_z.py
+++ b/src/pymmcore_widgets/useq_widgets/_z.py
@@ -62,15 +62,20 @@ class ZPlanWidget(QWidget):
         # to store a "suggested" step size
         self._suggested: float | None = None
 
+        self._mode: Mode = Mode.TOP_BOTTOM
+
         # #################### Mode Buttons ####################
 
         self._btn_top_bot = QRadioButton("Top/Bottom")
+        self._btn_top_bot.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._btn_top_bot.setIcon(icon(MDI6.arrow_expand_vertical))
         self._btn_top_bot.setToolTip("Mark top and bottom.")
         self._btn_range = QRadioButton("Range Around (Symmetric)")
+        self._btn_range.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._btn_range.setIcon(icon(MDI6.arrow_split_horizontal))
         self._btn_range.setToolTip("Range symmetric around reference.")
         self._button_above_below = QRadioButton("Range Asymmetric")
+        self._button_above_below.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._button_above_below.setIcon(icon(MDI6.arrow_expand_up))
         self._button_above_below.setToolTip(
             "Range asymmetrically above/below reference."
@@ -86,9 +91,9 @@ class ZPlanWidget(QWidget):
         btn_wdg = QWidget()
         btn_layout = QHBoxLayout(btn_wdg)
         btn_layout.setContentsMargins(0, 0, 0, 0)
-        btn_layout.addWidget(self._btn_top_bot)
-        btn_layout.addWidget(self._btn_range)
-        btn_layout.addWidget(self._button_above_below)
+        btn_layout.addWidget(self._btn_top_bot, 0)
+        btn_layout.addWidget(self._btn_range, 0)
+        btn_layout.addWidget(self._button_above_below, 1)
 
         # FIXME: On Windows 11, buttons within an inner widget of a ScrollArea
         # are filled in with the accent color, making it very difficult to see
@@ -250,7 +255,7 @@ class ZPlanWidget(QWidget):
 
         # #################### Defaults ####################
 
-        self._btn_top_bot.setChecked(True)
+        self.setMode(Mode.TOP_BOTTOM)
 
     # ------------------------- Public API -------------------------
 
@@ -282,7 +287,7 @@ class ZPlanWidget(QWidget):
 
         if self._mode is Mode.TOP_BOTTOM:
             with signals_blocked(self._mode_btn_group):
-                self._bottom_to_top.setChecked(True)
+                self._btn_top_bot.setChecked(True)
             self._set_row_visible(ROW_RANGE_AROUND, False)
             self._set_row_visible(ROW_ABOVE_BELOW, False)
             self._set_row_visible(ROW_TOP_BOTTOM, True)

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -358,12 +358,15 @@ def test_z_plan_widget(qtbot: QtBot) -> None:
     assert wdg.mode() == _z.Mode.TOP_BOTTOM
     assert wdg.top.isVisible()
     assert not wdg.above.isVisible()
-    wdg._mode_range.trigger()
+    assert wdg._btn_top_bot.isChecked()
+    wdg.setMode(_z.Mode.RANGE_AROUND)
     assert wdg.range.isVisible()
     assert not wdg.top.isVisible()
-    wdg._mode_above_below.trigger()
+    assert wdg._btn_range.isChecked()
+    wdg.setMode(_z.Mode.ABOVE_BELOW)
     assert wdg.above.isVisible()
     assert not wdg.range.isVisible()
+    assert wdg._button_above_below.isChecked()
 
     assert wdg.step.value() == 1
     wdg.setSuggestedStep(0.5)


### PR DESCRIPTION
Use radio button in the z plan widget (as in the grid plan widget)

@tlambert03 what do you think?

---
with this PR:
<img width="672" alt="Screenshot 2024-11-09 at 9 32 12 PM" src="https://github.com/user-attachments/assets/06abefa7-f0ef-48ba-8a1c-80886a61bbbd">


before:
<img width="672" alt="Screenshot 2024-11-09 at 9 33 46 PM" src="https://github.com/user-attachments/assets/15c58141-bef7-44e8-be2a-914dd65be2e9">
