### PR TITLE
fix: disable autofocus axis widget if no autofocus device is loaded/selected

### DIFF
--- a/examples/mda_widget.py
+++ b/examples/mda_widget.py
@@ -9,7 +9,7 @@ import useq
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QApplication
 
-from pymmcore_widgets import MDAWidget
+from pymmcore_widgets import MDAWidget, PropertyBrowser
 
 with suppress(ImportError):
     from rich import print
@@ -17,6 +17,9 @@ with suppress(ImportError):
 app = QApplication([])
 
 CMMCorePlus.instance().loadSystemConfiguration()
+
+p = PropertyBrowser()
+p.show()
 
 wdg = MDAWidget()
 wdg.channels.setChannelGroups({"Channel": ["DAPI", "FITC"]})

--- a/examples/mda_widget.py
+++ b/examples/mda_widget.py
@@ -9,7 +9,7 @@ import useq
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QApplication
 
-from pymmcore_widgets import MDAWidget, PropertyBrowser
+from pymmcore_widgets import MDAWidget
 
 with suppress(ImportError):
     from rich import print
@@ -17,9 +17,6 @@ with suppress(ImportError):
 app = QApplication([])
 
 CMMCorePlus.instance().loadSystemConfiguration()
-
-p = PropertyBrowser()
-p.show()
 
 wdg = MDAWidget()
 wdg.channels.setChannelGroups({"Channel": ["DAPI", "FITC"]})

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -280,8 +280,7 @@ class MDAWidget(MDASequenceWidget):
     def _on_sys_config_loaded(self) -> None:
         self.stage_positions._update_xy_enablement()
         self.stage_positions._update_z_enablement()
-        self._update_af_axis_enablement()
-        self._update_autofocus_per_pos_enablement()
+        self._update_autofocus_enablement()
         # TODO: connect objective change event to update suggested step
         self.z_plan.setSuggestedStep(_guess_NA(self._mmc) or 0.5)
 
@@ -293,29 +292,22 @@ class MDAWidget(MDASequenceWidget):
         elif prop == "Focus":
             self.stage_positions._update_z_enablement()
         else:  # prop == "AutoFocus"
-            self._update_af_axis_enablement()
-            self._update_autofocus_per_pos_enablement()
+            self._update_autofocus_enablement()
         self.valueChanged.emit()
 
-    def _update_af_axis_enablement(self) -> None:
-        """Enable or disable the autofocus axis.
+    def _update_autofocus_enablement(self) -> None:
+        """Enable or disable the autofocus widgets.
 
-        Enable af_axis only if there is an autofocus device and no absolute z plan is
-        selected.
+        Enable af_axis and af_per_position only if there is an autofocus device and no
+        absolute z plan is selected.
         """
         af_device = self._get_autofocus_device()
+
         self.af_axis.setEnabled(bool(af_device))
         self.af_axis.setToolTip(
             AF_TOOLTIP if af_device else "AutoFocus device unavailable."
         )
 
-    def _update_autofocus_per_pos_enablement(self) -> None:
-        """Enable or disable the autofocus per position checkbox.
-
-        Enable autofocus per position only if there is an autofocus device and no
-        absolute z plan is selected.
-        """
-        af_device = self._get_autofocus_device()
         self.stage_positions.af_per_position.setEnabled(bool(af_device))
         # also hide the AF column if the autofocus device is not available
         if not af_device:

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -19,7 +19,11 @@ from useq import MDASequence, Position
 
 from pymmcore_widgets._util import get_next_available_path
 from pymmcore_widgets.useq_widgets import MDASequenceWidget
-from pymmcore_widgets.useq_widgets._mda_sequence import PYMMCW_METADATA_KEY, MDATabs
+from pymmcore_widgets.useq_widgets._mda_sequence import (
+    AF_TOOLTIP,
+    PYMMCW_METADATA_KEY,
+    MDATabs,
+)
 from pymmcore_widgets.useq_widgets._time import TimePlanWidget
 
 from ._core_channels import CoreConnectedChannelTable
@@ -254,8 +258,17 @@ class MDAWidget(MDASequenceWidget):
     # ------------------- private Methods ----------------------
 
     def _on_sys_config_loaded(self) -> None:
+        self._update_af_axis_enablement()
         # TODO: connect objective change event to update suggested step
         self.z_plan.setSuggestedStep(_guess_NA(self._mmc) or 0.5)
+
+    def _update_af_axis_enablement(self) -> None:
+        """Enable or disable the autofocus axis based on the autofocus device."""
+        af_device = self._mmc.getAutoFocusDevice()
+        self.af_axis.setEnabled(bool(af_device))
+        self.af_axis.setToolTip(
+            AF_TOOLTIP if af_device else "AutoFocus device unavailable."
+        )
 
     def _get_current_stage_position(self) -> Position:
         """Return the current stage position."""

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -44,9 +44,9 @@ class _CoreConnectedPositionTable(CoreConnectedPositionTable):
     ):
         super().__init__(rows, mmcore, parent)
 
-        # disconnect the signals from this widget so we use the ones we will implement
-        # in the MDAWidget that takes into account both the autofocus device
-        # and the z plan
+        # subclassing to disconnect the signals from this widget so we use the ones
+        # we will implement in the MDAWidget that take into account both the autofocus
+        # device mand the z plan
         ev = self._mmc.events
         ev.systemConfigurationLoaded.disconnect(self._on_sys_config_loaded)
         ev.propertyChanged.disconnect(self._on_property_changed)

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -313,13 +313,6 @@ class MDAWidget(MDASequenceWidget):
 
         # update the autofocus per position widget
         self.stage_positions.af_per_position.setEnabled(bool(af_device))
-        # also hide the AF column if the autofocus device is not available
-        if not af_device:
-            # not simply calling self.stage_positions.af_per_position.setChecked(False)
-            # because we want to keep the previous state of the checkbox
-            self.stage_positions._on_af_per_position_toggled(False)
-        elif self.stage_positions.af_per_position.isChecked():
-            self.stage_positions._on_af_per_position_toggled(True)
         # set tooltip af_per_position
         self.stage_positions.af_per_position.setToolTip(
             self._get_tooltip(self.stage_positions.af_per_position)

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -285,15 +285,17 @@ class MDAWidget(MDASequenceWidget):
         self.z_plan.setSuggestedStep(_guess_NA(self._mmc) or 0.5)
 
     def _on_property_changed(self, device: str, prop: str, _val: str = "") -> None:
-        if device != "Core" and prop not in ("XYStage", "Focus", "AutoFocus"):
+        if device != "Core":
             return
-        if prop == "XYStage":
-            self.stage_positions._update_xy_enablement()
-        elif prop == "Focus":
-            self.stage_positions._update_z_enablement()
-        else:  # prop == "AutoFocus"
-            self._update_autofocus_enablement()
-        self.valueChanged.emit()
+
+        props = {
+            "XYStage": self.stage_positions._update_xy_enablement,
+            "Focus": self.stage_positions._update_z_enablement,
+            "AutoFocus": self._update_autofocus_enablement,
+        }
+        if prop in props:
+            props[prop]()
+            self.valueChanged.emit()
 
     def _update_autofocus_enablement(self) -> None:
         """Enable or disable the autofocus widgets.

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -449,12 +449,12 @@ class MDAWidget(MDASequenceWidget):
         )
         self._mmc.events.propertyChanged.disconnect(self._on_property_changed)
 
-    def _enable_af(self, state: bool, tooltip1: str, tooltip2: str) -> None:
+    def _enable_af(self, state: bool) -> None:
         """Override the autofocus enablement to account for the autofocus device."""
         if not self._mmc.getAutoFocusDevice():
             self._update_autofocus_enablement()
             return
-        return super()._enable_af(state, tooltip1, tooltip2)
+        return super()._enable_af(state)
 
 
 class _MDAControlButtons(QWidget):

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -68,9 +68,6 @@ class CoreConnectedPositionTable(PositionTable):
         # add event filter for the af_per_position checkbox
         self.af_per_position.installEventFilter(self)
 
-        # to store the state of the af_per_position checkbox. Used in the event filter
-        self._use_af_per_pos: bool = False
-
         # -------------- HCS Wizard ----------------
         self._hcs_wizard: HCSWizard | None = None
         self._plate_plan: WellPlatePlan | None = None
@@ -164,11 +161,10 @@ class CoreConnectedPositionTable(PositionTable):
         checkbox is disabled but checked).
         """
         if not self.af_per_position.isEnabled():
-            self._use_af_per_pos = self.af_per_position.isChecked()
             # leave the checkbox checked but disable it
             self.af_per_position.setEnabled(False)
             self._on_af_per_position_toggled(False)
-        elif self._use_af_per_pos:
+        elif self.af_per_position.isChecked():
             self._on_af_per_position_toggled(True)
             self.af_per_position.setEnabled(True)
 

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
 UPDATE_POSITIONS = "Update Positions List"
 ADD_POSITIONS = "Add to Positions List"
+AF_UNAVAILABLE = "AutoFocus device unavailable."
 
 
 class CoreConnectedPositionTable(PositionTable):
@@ -294,9 +295,11 @@ class CoreConnectedPositionTable(PositionTable):
         self.af_per_position.setEnabled(bool(af_device))
         # also hide the AF column if the autofocus device is not available
         if not af_device:
-            self.af_per_position.setChecked(False)
+            # not simply calling self.af_per_position.setChecked(False)
+            # because we want to keep the previous state of the checkbox
+            self._on_af_per_position_toggled(False)
         self.af_per_position.setToolTip(
-            AF_PER_POS_TOOLTIP if af_device else "AutoFocus device unavailable."
+            AF_PER_POS_TOOLTIP if af_device else AF_UNAVAILABLE
         )
 
     def _add_row(self) -> None:

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -24,7 +24,7 @@ from pymmcore_widgets.useq_widgets import PositionTable
 from pymmcore_widgets.useq_widgets._column_info import (
     ButtonColumn,
 )
-from pymmcore_widgets.useq_widgets._positions import AF_DEFAULT_TOOLTIP
+from pymmcore_widgets.useq_widgets._positions import AF_PER_POS_TOOLTIP
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -296,7 +296,7 @@ class CoreConnectedPositionTable(PositionTable):
         if not af_device:
             self.af_per_position.setChecked(False)
         self.af_per_position.setToolTip(
-            AF_DEFAULT_TOOLTIP if af_device else "AutoFocus device unavailable."
+            AF_PER_POS_TOOLTIP if af_device else "AutoFocus device unavailable."
         )
 
     def _add_row(self) -> None:

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -277,6 +277,7 @@ class CoreConnectedPositionTable(PositionTable):
         self.table().setColumnHidden(x_col, not bool(xy_device))
         self.table().setColumnHidden(y_col, not bool(xy_device))
         self.table().setColumnHidden(xy_btn_col, not bool(xy_device))
+        self.valueChanged.emit()
 
     def _update_z_enablement(self) -> None:
         """Enable/disable the Z columns and button."""
@@ -286,9 +287,10 @@ class CoreConnectedPositionTable(PositionTable):
             # but don't recheck it if it's already unchecked
             self.include_z.setChecked(False)
         self.include_z.setToolTip("" if z_device else "Focus device unavailable.")
+        self.valueChanged.emit()
 
     def _update_autofocus_enablement(self) -> None:
-        """Update the autofocus device combo box."""
+        """Update the autofocus per position checkbox state and tooltip."""
         af_device = self._mmc.getAutoFocusDevice()
         self.af_per_position.setEnabled(bool(af_device))
         # also hide the AF column if the autofocus device is not available
@@ -297,6 +299,7 @@ class CoreConnectedPositionTable(PositionTable):
         self.af_per_position.setToolTip(
             AF_DEFAULT_TOOLTIP if af_device else "AutoFocus device unavailable."
         )
+        self.valueChanged.emit()
 
     def _add_row(self) -> None:
         """Add a new to the end of the table and use the current core position."""

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -138,6 +138,7 @@ class CoreConnectedPositionTable(PositionTable):
             value = tuple(value)
         super().setValue(value)
         self._update_z_enablement()
+        self._update_autofocus_enablement()
 
     # ----------------------- private methods -----------------------
 
@@ -277,7 +278,6 @@ class CoreConnectedPositionTable(PositionTable):
         self.table().setColumnHidden(x_col, not bool(xy_device))
         self.table().setColumnHidden(y_col, not bool(xy_device))
         self.table().setColumnHidden(xy_btn_col, not bool(xy_device))
-        self.valueChanged.emit()
 
     def _update_z_enablement(self) -> None:
         """Enable/disable the Z columns and button."""
@@ -287,7 +287,6 @@ class CoreConnectedPositionTable(PositionTable):
             # but don't recheck it if it's already unchecked
             self.include_z.setChecked(False)
         self.include_z.setToolTip("" if z_device else "Focus device unavailable.")
-        self.valueChanged.emit()
 
     def _update_autofocus_enablement(self) -> None:
         """Update the autofocus per position checkbox state and tooltip."""
@@ -299,7 +298,6 @@ class CoreConnectedPositionTable(PositionTable):
         self.af_per_position.setToolTip(
             AF_DEFAULT_TOOLTIP if af_device else "AutoFocus device unavailable."
         )
-        self.valueChanged.emit()
 
     def _add_row(self) -> None:
         """Add a new to the end of the table and use the current core position."""

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -442,6 +442,8 @@ class MDASequenceWidget(QWidget):
             for pos in value.stage_positions:
                 if pos.sequence and pos.sequence.autofocus_plan:
                     axis.update(pos.sequence.autofocus_plan.axes)
+                    # store the current state of the autofocus per position checkbox
+                    self._use_af_per_pos = True
         self.af_axis.setValue(tuple(axis))
         axis_text = "".join(x for x in value.axis_order if x in self.tab_wdg.usedAxes())
         self.axis_order.setCurrentText(axis_text)

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -504,14 +504,16 @@ class MDASequenceWidget(QWidget):
         # Only JSON
         return "All (*.json);;JSON (*.json)"
 
-    def _enable_af(self, state: bool, tooltip1: str, tooltip2: str) -> None:
+    def _enable_af(self, state: bool) -> None:
         """Enable or disable autofocus settings."""
+        af_axis_tooltip = AF_AXIS_TOOLTIP if state else AF_DISABLED_TOOLTIP
+        af_per_pos_tooltip = AF_PER_POS_TOOLTIP if state else AF_DISABLED_TOOLTIP
         # enable autofocus axis widget
         self.af_axis.setEnabled(state)
-        self.af_axis.setToolTip(tooltip1)
+        self.af_axis.setToolTip(af_axis_tooltip)
         # enable autofocus per position checkbox
         self.stage_positions.af_per_position.setEnabled(state)
-        self.stage_positions.af_per_position.setToolTip(tooltip2)
+        self.stage_positions.af_per_position.setToolTip(af_per_pos_tooltip)
         # hide the autofocus columns if autofocus per position is disabled
         if not state:
             # not simply calling self.stage_positions.af_per_position.setChecked(False)
@@ -539,9 +541,9 @@ class MDASequenceWidget(QWidget):
                     buttons=QMessageBox.StandardButton.Ok,
                     defaultButton=QMessageBox.StandardButton.Ok,
                 )
-            self._enable_af(False, AF_DISABLED_TOOLTIP, AF_DISABLED_TOOLTIP)
+            self._enable_af(False)
         else:
-            self._enable_af(True, AF_AXIS_TOOLTIP, AF_PER_POS_TOOLTIP)
+            self._enable_af(True)
 
         self.valueChanged.emit()
 
@@ -558,7 +560,7 @@ class MDASequenceWidget(QWidget):
             if self.tab_wdg.isChecked(self.z_plan):
                 self._validate_af_with_z_plan()
             else:
-                self._enable_af(True, AF_AXIS_TOOLTIP, AF_PER_POS_TOOLTIP)
+                self._enable_af(True)
 
         self._update_available_axis_orders()
 

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -562,7 +562,7 @@ class MDASequenceWidget(QWidget):
 
         self._update_available_axis_orders()
 
-    def _on_af_toggled(self, _checked: bool) -> None:
+    def _on_af_toggled(self) -> None:
         # if the 'af_per_position' checkbox in the PositionTable is checked, set checked
         # also the autofocus p axis checkbox.
         if self._use_af_per_position() and self.tab_wdg.isChecked(self.stage_positions):

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -290,7 +290,7 @@ class MDASequenceWidget(QWidget):
         self.axis_order.setToolTip("Slowest to fastest axis order.")
         self.axis_order.setMinimumWidth(80)
 
-        # used in _validate_af_with_z_plan to store state of the autofocus per position
+        # store the previous state of the autofocus per position checkbox to restore it
         self._use_af_per_pos: bool = False
 
         # -------------- Other Widgets --------------
@@ -525,9 +525,10 @@ class MDASequenceWidget(QWidget):
         If the Z Plan is set to TOP_BOTTOM, the autofocus plan cannot be used.
         """
         if self.z_plan.mode() == Mode.TOP_BOTTOM:
+            # store the current state of the autofocus per position checkbox
             self._use_af_per_pos = self.stage_positions.af_per_position.isChecked()
-            self._enable_af(False, AF_DISABLED_TOOLTIP, AF_DISABLED_TOOLTIP)
-            if self.af_axis.use_af_p.isChecked():
+            # if any autofocus axis is selected, show a warning.
+            if self.af_axis.value():
                 QMessageBox.warning(
                     self,
                     "Autofocus Plan Disabled",
@@ -538,6 +539,7 @@ class MDASequenceWidget(QWidget):
                     buttons=QMessageBox.StandardButton.Ok,
                     defaultButton=QMessageBox.StandardButton.Ok,
                 )
+            self._enable_af(False, AF_DISABLED_TOOLTIP, AF_DISABLED_TOOLTIP)
         else:
             self._enable_af(True, AF_TOOLTIP, AF_DEFAULT_TOOLTIP)
 

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 OK_CANCEL = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
 NULL_SEQUENCE = useq.MDASequence()
 MAX = 9999999
-AF_DEFAULT_TOOLTIP = (
+AF_PER_POS_TOOLTIP = (
     "If checked, the user can set a different Hardware Autofocus Offset for each "
     "Position in the table."
 )
@@ -172,7 +172,7 @@ class PositionTable(DataTableWidget):
         self.include_z.toggled.connect(self._on_include_z_toggled)
 
         self.af_per_position = QCheckBox("Set AF Offset per Position")
-        self.af_per_position.setToolTip(AF_DEFAULT_TOOLTIP)
+        self.af_per_position.setToolTip(AF_PER_POS_TOOLTIP)
         self.af_per_position.toggled.connect(self._on_af_per_position_toggled)
         self._on_af_per_position_toggled(self.af_per_position.isChecked())
 

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -224,7 +224,7 @@ class PositionTable(DataTableWidget):
             if not r.get(self.NAME.key, True):
                 r.pop(self.NAME.key, None)
 
-            if self.af_per_position.isChecked():
+            if self.af_per_position.isChecked() and self.af_per_position.isEnabled():
                 af_offset = r.get(self.AF.key, None)
                 if af_offset is not None:
                     # get the current sub-sequence as dict or create a new one

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -179,6 +179,10 @@ def test_core_connected_position_wdg_cfg_loaded(
     # stage is not loaded
     _assert_position_wdg_state(stage, pos_table, is_hidden=True)
 
+    # the autofocus axis wdg should be disabled if Autofocus device is not loaded
+    if stage == "Autofocus":
+        assert not wdg.af_axis.isEnabled()
+
     with qtbot.waitSignal(mmc.events.systemConfigurationLoaded):
         mmc.loadSystemConfiguration(TEST_CONFIG)
 

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -877,7 +877,7 @@ def test_core_mda_autofocus_and_z_plan(
         mmc.setProperty("Core", "AutoFocus", "")
 
     # both af_axis and af_per_position should be disabled
-    assert not wdg.af_axis.isEnabled()
+    assert not wdg.af_axis.value()
     assert not wdg.stage_positions.af_per_position.isEnabled()
     assert not wdg.stage_positions.af_per_position.isChecked()
     # before disabling, the af_per_position was checked and stored in _use_af_per_pos
@@ -899,48 +899,16 @@ def test_core_mda_autofocus_and_z_plan(
     assert wdg.stage_positions.af_per_position.isChecked()
     assert wdg.value() == SEQ
 
+    if trigger == "core":
+        mmc.setProperty("Core", "AutoFocus", "")
+        wdg.tab_wdg.setChecked(wdg.z_plan, True)
+        assert not wdg.af_axis.value()
+        assert not wdg.stage_positions.af_per_position.isEnabled()
+        assert not wdg.stage_positions.af_per_position.isChecked()
 
-def test_core_mda_autofocus_and_z_plan_prop_change(
-    qtbot: QtBot, global_mmcore: CMMCorePlus
-) -> None:
-    wdg = MDAWidget()
-    qtbot.addWidget(wdg)
-    wdg.show()
-
-
-#     assert mmc.getAutoFocusDevice() == "Autofocus"
-
-#     wdg.setValue(SEQ)
-
-#     # # af_axis and af_per_position should be checked and enabled
-#     # assert wdg.af_axis.value() == ("p",)
-#     # assert wdg.stage_positions.af_per_position.isEnabled()
-#     # assert wdg.stage_positions.af_per_position.isChecked()
-
-#     # disable autofocus device
-#     mmc.setProperty("Core", "AutoFocus", "")
-
-#     # af_axis and af_per_position should be disabled
-#     assert not wdg.af_axis.isEnabled()
-#     assert wdg.af_axis.value() == ()
-#     # before disabling, the af_per_position was checked and stored in _use_af_per_pos
-#     assert wdg._use_af_per_pos
-#     assert not wdg.stage_positions.af_per_position.isEnabled()
-#     assert not wdg.stage_positions.af_per_position.isChecked()
-
-#     assert not wdg.value().autofocus_plan
-#     assert not wdg.value().stage_positions[0].sequence
-#     assert not wdg.value().stage_positions[1].sequence
-
-#     mmc.setProperty("Core", "AutoFocus", "Autofocus")
-
-#     # af_axis and af_per_position should be enabled
-#     assert wdg.af_axis.value() == ("p",)
-#     assert wdg.stage_positions.af_per_position.isEnabled()
-#     assert wdg.stage_positions.af_per_position.isChecked()
-#     assert wdg.value() == SEQ
-
-#     from rich import print
-
-#     print()
-#     print(wdg.value())
+        # is autofocus is re-enabled, the autofocus options should still be disabled
+        # since the absolute TopBottom z plan is active
+        mmc.setProperty("Core", "AutoFocus", "Autofocus")
+        assert not wdg.af_axis.value()
+        assert not wdg.stage_positions.af_per_position.isEnabled()
+        assert not wdg.stage_positions.af_per_position.isChecked()

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -839,6 +839,29 @@ SEQ = useq.MDASequence(
 )
 
 
+def test_core_mda_autofocus_set_value(
+    qtbot: QtBot,
+    global_mmcore: CMMCorePlus,
+) -> None:
+    mmc = global_mmcore
+    mmc.unloadDevice("Autofocus")  # or mmc.setProperty("Core", "AutoFocus", "")
+
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    wdg.setValue(SEQ)
+
+    # even if autofocus_plans are in SEQ, the autofocus options should be disabled
+    # since the autofocus device is not loaded
+    assert not wdg.value().autofocus_plan
+    assert not wdg.value().stage_positions[0].sequence
+    assert not wdg.value().stage_positions[1].sequence
+    assert wdg.af_axis.value() == ()
+    assert not wdg.stage_positions.af_per_position.isEnabled()
+    assert not wdg.stage_positions.af_per_position.isChecked()
+
+
 @pytest.mark.parametrize("trigger", ["zplan", "core"])
 def test_core_mda_autofocus_and_z_plan(
     qtbot: QtBot, global_mmcore: CMMCorePlus, trigger: str

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -145,24 +145,7 @@ def _assert_position_wdg_state(
         tooltip = "Focus device unavailable." if is_hidden else ""
         assert pos_table.include_z.toolTip() == tooltip
 
-    # elif stage == "Autofocus":
-    #     # the set position button should be hidden
-    #     af_btn_col = pos_table.table().indexOf(pos_table._af_btn_col)
-    #     assert pos_table.table().isColumnHidden(af_btn_col)
-    #     if is_hidden:
-    #         sub_seq = [v.sequence for v in pos_table.value()]
-    #         assert all(s is None for s in sub_seq)
-    #     # the use autofocus checkbox should be unchecked
-    #     assert not pos_table.af_per_position.isChecked()
-    #     # the use autofocus checkbox should be disabled if Autofocus device is not
-    #     # loaded/selected
-    #     assert pos_table.af_per_position.isEnabled() == (not is_hidden)
-    #     # tooltip should should change if Autofocus device is not loaded/selected
-    #     tooltip = "AutoFocus device unavailable." if is_hidden else AF_PER_POS_TOOLTIP
-    #     assert pos_table.af_per_position.toolTip() == tooltip
 
-
-# @pytest.mark.parametrize("stage", ["XY", "Z", "Autofocus"])
 @pytest.mark.parametrize("stage", ["XY", "Z"])
 def test_core_connected_position_wdg_cfg_loaded(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
@@ -192,7 +175,6 @@ def test_core_connected_position_wdg_cfg_loaded(
     _assert_position_wdg_state(stage, pos_table, is_hidden=False)
 
 
-# @pytest.mark.parametrize("stage", ["XY", "Z", "Autofocus"])
 @pytest.mark.parametrize("stage", ["XY", "Z"])
 def test_core_connected_position_wdg_property_changed(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
@@ -216,8 +198,6 @@ def test_core_connected_position_wdg_property_changed(
             mmc.setProperty("Core", "XYStage", "")
         elif stage == "Z":
             mmc.setProperty("Core", "Focus", "")
-        # elif stage == "Autofocus":
-        #     mmc.setProperty("Core", "AutoFocus", "")
         mmc.waitForSystem()
 
     # stage is not set as default device
@@ -228,8 +208,6 @@ def test_core_connected_position_wdg_property_changed(
             mmc.setProperty("Core", "XYStage", "XY")
         elif stage == "Z":
             mmc.setProperty("Core", "Focus", "Z")
-        # elif stage == "Autofocus":
-        #     mmc.setProperty("Core", "AutoFocus", "Autofocus")
 
     # stage is set as default device (propertyChanged is triggered)
     _assert_position_wdg_state(stage, pos_table, is_hidden=False)

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -847,6 +847,8 @@ def test_core_mda_autofocus_set_value(
     assert not wdg.stage_positions.af_per_position.isEnabled()
     assert wdg.stage_positions.af_per_position.isChecked()
     assert wdg.stage_positions.af_per_position.toolTip() == AF_UNAVAILABLE
+    af_btn_col = wdg.stage_positions.table().indexOf(wdg.stage_positions._af_btn_col)
+    assert wdg.stage_positions.table().isColumnHidden(af_btn_col)
 
 
 @pytest.mark.parametrize("trigger", ["zplan", "core"])
@@ -858,6 +860,10 @@ def test_core_mda_autofocus_and_z_plan(
     qtbot.addWidget(wdg)
     wdg.show()
 
+    pos_table = wdg.stage_positions
+    af_col = pos_table.table().indexOf(pos_table.AF)
+    af_btn_col = pos_table.table().indexOf(pos_table._af_btn_col)
+
     wdg.setValue(SEQ)
 
     # no general autofocus plan since each pos has a sequence with autofocus plan
@@ -868,9 +874,12 @@ def test_core_mda_autofocus_and_z_plan(
     # af_axis and af_per_position should be checked and enabled
     assert wdg.af_axis.value() == ("p",)
     assert wdg.af_axis.toolTip() == AF_AXIS_TOOLTIP
-    assert wdg.stage_positions.af_per_position.isEnabled()
-    assert wdg.stage_positions.af_per_position.isChecked()
-    assert wdg.stage_positions.af_per_position.toolTip() == AF_PER_POS_TOOLTIP
+    assert pos_table.af_per_position.isEnabled()
+    assert pos_table.af_per_position.isChecked()
+    assert pos_table.af_per_position.toolTip() == AF_PER_POS_TOOLTIP
+    # AF column should be visible
+    assert not pos_table.table().isColumnHidden(af_col)
+    assert not pos_table.table().isColumnHidden(af_btn_col)
 
     # trigger the z plan tab TopBottom mode
     if trigger == "zplan":
@@ -898,13 +907,17 @@ def test_core_mda_autofocus_and_z_plan(
         if trigger == "core"
         else AF_DISABLED_TOOLTIP
     )
-    assert not wdg.stage_positions.af_per_position.isEnabled()
-    assert wdg.stage_positions.af_per_position.isChecked()
+    assert not pos_table.af_per_position.isEnabled()
+    assert pos_table.af_per_position.isChecked()
     assert (
-        wdg.stage_positions.af_per_position.toolTip() == AF_UNAVAILABLE
+        pos_table.af_per_position.toolTip() == AF_UNAVAILABLE
         if trigger == "core"
         else AF_DISABLED_TOOLTIP
     )
+    # AF column should be hidden
+    assert pos_table.table().isColumnHidden(af_col)
+    assert pos_table.table().isColumnHidden(af_btn_col)
+
     assert not wdg.value().autofocus_plan
     assert not wdg.value().stage_positions[0].sequence
     assert not wdg.value().stage_positions[1].sequence
@@ -919,9 +932,12 @@ def test_core_mda_autofocus_and_z_plan(
 
     # af_axis and af_per_position should be enabled
     assert wdg.af_axis.value() == ("p",)
-    assert wdg.stage_positions.af_per_position.isEnabled()
-    assert wdg.stage_positions.af_per_position.isChecked()
+    assert pos_table.af_per_position.isEnabled()
+    assert pos_table.af_per_position.isChecked()
     assert wdg.value().replace(metadata={}) == SEQ.replace(metadata={})
+    # AF column should be visible
+    assert not pos_table.table().isColumnHidden(af_col)
+    assert not pos_table.table().isColumnHidden(af_btn_col)
 
     if trigger == "core":
         with qtbot.waitSignal(mmc.events.propertyChanged):
@@ -932,9 +948,13 @@ def test_core_mda_autofocus_and_z_plan(
         assert wdg.af_axis.use_af_p.isChecked()
         assert not wdg.af_axis.value()
         assert wdg.af_axis.toolTip() == AF_UNAVAILABLE
-        assert not wdg.stage_positions.af_per_position.isEnabled()
-        assert wdg.stage_positions.af_per_position.isChecked()
-        assert wdg.stage_positions.af_per_position.toolTip() == AF_UNAVAILABLE
+        assert not pos_table.af_per_position.isEnabled()
+        assert pos_table.af_per_position.isChecked()
+        assert pos_table.af_per_position.toolTip() == AF_UNAVAILABLE
+
+        # AF column should be hidden
+        assert pos_table.table().isColumnHidden(af_col)
+        assert pos_table.table().isColumnHidden(af_btn_col)
 
         # is autofocus is re-enabled, the autofocus options should still be disabled
         # since the absolute TopBottom z plan is active
@@ -945,6 +965,9 @@ def test_core_mda_autofocus_and_z_plan(
         assert wdg.af_axis.use_af_p.isChecked()
         assert not wdg.af_axis.value()
         assert wdg.af_axis.toolTip() == AF_DISABLED_TOOLTIP
-        assert not wdg.stage_positions.af_per_position.isEnabled()
-        assert wdg.stage_positions.af_per_position.isChecked()
-        assert wdg.stage_positions.af_per_position.toolTip() == AF_DISABLED_TOOLTIP
+        assert not pos_table.af_per_position.isEnabled()
+        assert pos_table.af_per_position.isChecked()
+        assert pos_table.af_per_position.toolTip() == AF_DISABLED_TOOLTIP
+        # AF column should be hidden
+        assert pos_table.table().isColumnHidden(af_col)
+        assert pos_table.table().isColumnHidden(af_btn_col)

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -897,7 +897,8 @@ def test_core_mda_autofocus_and_z_plan(
     # disable autofocus device
     elif trigger == "core":
         assert mmc.getAutoFocusDevice() == "Autofocus"
-        mmc.setProperty("Core", "AutoFocus", "")
+        with qtbot.waitSignal(mmc.events.propertyChanged):
+            mmc.setProperty("Core", "AutoFocus", "")
 
     # both af_axis and af_per_position should be disabled
     assert not wdg.af_axis.value()
@@ -914,7 +915,8 @@ def test_core_mda_autofocus_and_z_plan(
         wdg.tab_wdg.setChecked(wdg.z_plan, False)
     # re-enable autofocus device
     elif trigger == "core":
-        mmc.setProperty("Core", "AutoFocus", "Autofocus")
+        with qtbot.waitSignal(mmc.events.propertyChanged):
+            mmc.setProperty("Core", "AutoFocus", "Autofocus")
 
     # af_axis and af_per_position should be enabled
     assert wdg.af_axis.value() == ("p",)
@@ -923,7 +925,8 @@ def test_core_mda_autofocus_and_z_plan(
     assert wdg.value() == SEQ
 
     if trigger == "core":
-        mmc.setProperty("Core", "AutoFocus", "")
+        with qtbot.waitSignal(mmc.events.propertyChanged):
+            mmc.setProperty("Core", "AutoFocus", "")
         wdg.tab_wdg.setChecked(wdg.z_plan, True)
         assert not wdg.af_axis.value()
         assert not wdg.stage_positions.af_per_position.isEnabled()
@@ -931,7 +934,8 @@ def test_core_mda_autofocus_and_z_plan(
 
         # is autofocus is re-enabled, the autofocus options should still be disabled
         # since the absolute TopBottom z plan is active
-        mmc.setProperty("Core", "AutoFocus", "Autofocus")
+        with qtbot.waitSignal(mmc.events.propertyChanged):
+            mmc.setProperty("Core", "AutoFocus", "Autofocus")
         assert not wdg.af_axis.value()
         assert not wdg.stage_positions.af_per_position.isEnabled()
         assert not wdg.stage_positions.af_per_position.isChecked()

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -141,6 +141,7 @@ def _assert_position_wdg_state(
         assert pos_table.include_z.toolTip() == tooltip
 
     elif stage == "Autofocus":
+        # the set position button should be hidden
         af_btn_col = pos_table.table().indexOf(pos_table._af_btn_col)
         assert pos_table.table().isColumnHidden(af_btn_col)
         if is_hidden:
@@ -178,10 +179,6 @@ def test_core_connected_position_wdg_cfg_loaded(
     # stage is not loaded
     _assert_position_wdg_state(stage, pos_table, is_hidden=True)
 
-    # the autofocus axis wdg should be disabled if Autofocus device is not loaded
-    if stage == "Autofocus":
-        assert not wdg.af_axis.isEnabled()
-
     with qtbot.waitSignal(mmc.events.systemConfigurationLoaded):
         mmc.loadSystemConfiguration(TEST_CONFIG)
 
@@ -189,7 +186,7 @@ def test_core_connected_position_wdg_cfg_loaded(
     _assert_position_wdg_state(stage, pos_table, is_hidden=False)
 
 
-@pytest.mark.parametrize("stage", ["XY", "Z"])
+@pytest.mark.parametrize("stage", ["XY", "Z", "Autofocus"])
 def test_core_connected_position_wdg_property_changed(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
 ) -> None:
@@ -207,11 +204,15 @@ def test_core_connected_position_wdg_property_changed(
 
     wdg.setValue(MDA)
 
+    pos_table.af_per_position.setChecked(True)
+
     with qtbot.waitSignal(mmc.events.propertyChanged):
         if stage == "XY":
             mmc.setProperty("Core", "XYStage", "")
         elif stage == "Z":
             mmc.setProperty("Core", "Focus", "")
+        elif stage == "Autofocus":
+            mmc.setProperty("Core", "AutoFocus", "")
         mmc.waitForSystem()
 
     # stage is not set as default device
@@ -222,6 +223,8 @@ def test_core_connected_position_wdg_property_changed(
             mmc.setProperty("Core", "XYStage", "XY")
         elif stage == "Z":
             mmc.setProperty("Core", "Focus", "Z")
+        elif stage == "Autofocus":
+            mmc.setProperty("Core", "AutoFocus", "Autofocus")
 
     # stage is set as default device (propertyChanged is triggered)
     _assert_position_wdg_state(stage, pos_table, is_hidden=False)

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -189,7 +189,7 @@ def test_core_connected_position_wdg_cfg_loaded(
     _assert_position_wdg_state(stage, pos_table, is_hidden=False)
 
 
-@pytest.mark.parametrize("stage", ["XY", "Z", "Autofocus"])
+@pytest.mark.parametrize("stage", ["XY", "Z"])
 def test_core_connected_position_wdg_property_changed(
     stage: str, qtbot: QtBot, global_mmcore: CMMCorePlus
 ) -> None:
@@ -212,8 +212,6 @@ def test_core_connected_position_wdg_property_changed(
             mmc.setProperty("Core", "XYStage", "")
         elif stage == "Z":
             mmc.setProperty("Core", "Focus", "")
-        elif stage == "Autofocus":
-            mmc.setProperty("Core", "AutoFocus", "")
         mmc.waitForSystem()
 
     # stage is not set as default device
@@ -224,8 +222,6 @@ def test_core_connected_position_wdg_property_changed(
             mmc.setProperty("Core", "XYStage", "XY")
         elif stage == "Z":
             mmc.setProperty("Core", "Focus", "Z")
-        elif stage == "Autofocus":
-            mmc.setProperty("Core", "AutoFocus", "Autofocus")
 
     # stage is set as default device (propertyChanged is triggered)
     _assert_position_wdg_state(stage, pos_table, is_hidden=False)

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -922,11 +922,7 @@ def test_core_mda_autofocus_and_z_plan(
     assert wdg.af_axis.value() == ("p",)
     assert wdg.stage_positions.af_per_position.isEnabled()
     assert wdg.stage_positions.af_per_position.isChecked()
-    print("-------------")
-    print(wdg.value())
-    print(SEQ)
-    print("-------------")
-    assert wdg.value() == SEQ
+    assert wdg.value().replace(metadata={}) == SEQ.replace(metadata={})
 
     if trigger == "core":
         with qtbot.waitSignal(mmc.events.propertyChanged):

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -922,6 +922,10 @@ def test_core_mda_autofocus_and_z_plan(
     assert wdg.af_axis.value() == ("p",)
     assert wdg.stage_positions.af_per_position.isEnabled()
     assert wdg.stage_positions.af_per_position.isChecked()
+    print("-------------")
+    print(wdg.value())
+    print(SEQ)
+    print("-------------")
     assert wdg.value() == SEQ
 
     if trigger == "core":


### PR DESCRIPTION
This PR updates the logic for when the autofocus devices (**Autofocus Axis widget** and **Autofocus Per Position checkbox**)should be disabled to then emit a correct `useq.MDASequence`. 

On top of disabling them when an absolute z plan is selected, this PR adds:

- If no Autofocus device is loaded they are disabled (thus responding to the core `systemConfigurationLoaded` signal).

- They are also disabled if the core `AutoFocus` property is set to `None` (thus responding to the core `propertyChnaged` signal).

<img width="718" alt="Screenshot 2024-11-11 at 6 10 51 PM 1" src="https://github.com/user-attachments/assets/a0926b8d-37ae-4741-ae78-cacfa9d3d5f0">
