### PR TITLE
Fix: Bump default maximum for IntColumn from 10_000 to 99_999

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -281,7 +281,7 @@ class _RangeColumn(WidgetColumn, Generic[W, T]):
 class IntColumn(_RangeColumn):
     data_type: WdgGetSet = TableIntWidget
     minimum: int = 0
-    maximum: int = 10_000
+    maximum: int = 99_999
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
# Issue
The Maximum value set in the IntColumn dataclass dictates the maximum number of loops that can be entered into the MDAWidget's  TimePlanWidget.

# Proposed Solution
Requesting to bump the value from the current 10_000 to 99_999 

```python
@dataclass(frozen=True)
class IntColumn(_RangeColumn):
    data_type: WdgGetSet = TableIntWidget
    minimum: int = 0
    maximum: int = 99_999 #was 10_000
```
