### PR TITLE
fix: fix a bug in the CoreConnectedGridPlanWidget when selecting the bound mode

### DIFF
--- a/src/pymmcore_widgets/mda/_xy_bounds.py
+++ b/src/pymmcore_widgets/mda/_xy_bounds.py
@@ -182,9 +182,9 @@ class CoreXYBoundsControl(XYBoundsControl):
         """Return the current value of the grid plan widget."""
         return self._bounds_wdg.value()
 
-    def setValue(self, value: useq.GridFromEdges) -> None:
+    def setValue(self, plan: useq.GridFromEdges) -> None:
         """Set the value of the grid plan widget."""
-        self._bounds_wdg.setValue(value)
+        self._bounds_wdg.setValue(plan)
 
     def _mark_or_visit(self, top: bool | None = None, left: bool | None = None) -> None:
         self._visit(top, left) if self.go_middle.isChecked() else self._mark(top, left)

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 import useq
 from qtpy.QtCore import Qt, Signal
@@ -31,6 +31,9 @@ if TYPE_CHECKING:
     GridPlan: TypeAlias = (
         useq.GridFromEdges | useq.GridRowsColumns | useq.GridWidthHeight
     )
+
+    class ValueWidget(Protocol, QWidget):  # pyright: ignore
+        def setValue(self, plan: Any) -> None: ...
 
 
 class RelativeTo(Enum):
@@ -105,9 +108,7 @@ class GridPlanWidget(QScrollArea):
         self.width_height_wdg = _WidthHeightWidget()
         self.bounds_wdg = _BoundsWidget()
         # ease of lookup
-        self._mode_to_widget: dict[
-            Mode, _RowsColsWidget | _WidthHeightWidget | _BoundsWidget
-        ] = {
+        self._mode_to_widget: dict[Mode, ValueWidget] = {
             Mode.NUMBER: self.row_col_wdg,
             Mode.AREA: self.width_height_wdg,
             Mode.BOUNDS: self.bounds_wdg,
@@ -226,7 +227,7 @@ class GridPlanWidget(QScrollArea):
 
         with signals_blocked(self):
             mode_wdg = self._mode_to_widget[mode]
-            mode_wdg.setValue(value)  # type: ignore [arg-type]
+            mode_wdg.setValue(value)
             self._stack.setCurrentWidget(mode_wdg)
             if value.fov_height:
                 self._fov_height = value.fov_height

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -971,29 +971,3 @@ def test_core_mda_autofocus_and_z_plan(
         # AF column should be hidden
         assert pos_table.table().isColumnHidden(af_col)
         assert pos_table.table().isColumnHidden(af_btn_col)
-
-
-def test_core_connected_grid_wdg(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
-    wdg = MDAWidget()
-    qtbot.addWidget(wdg)
-    wdg.show()
-
-    grid_plan = {
-        "top": 256,
-        "bottom": -256,
-        "left": -256,
-        "right": 768,
-        "fov_height": 512,
-        "fov_width": 512,
-    }
-    mda = useq.MDASequence(stage_positions=[(10, 10)], grid_plan=grid_plan)
-
-    wdg.setValue(mda)
-
-    g_plan = wdg.value().grid_plan
-    assert isinstance(g_plan, useq.GridFromEdges)
-    assert g_plan.top == 256
-    assert g_plan.bottom == -256
-    assert g_plan.left == -256
-    assert g_plan.right == 768
-    assert len(list(mda)) == 6

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -971,3 +971,29 @@ def test_core_mda_autofocus_and_z_plan(
         # AF column should be hidden
         assert pos_table.table().isColumnHidden(af_col)
         assert pos_table.table().isColumnHidden(af_btn_col)
+
+
+def test_core_connected_grid_wdg(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    grid_plan = {
+        "top": 256,
+        "bottom": -256,
+        "left": -256,
+        "right": 768,
+        "fov_height": 512,
+        "fov_width": 512,
+    }
+    mda = useq.MDASequence(stage_positions=[(10, 10)], grid_plan=grid_plan)
+
+    wdg.setValue(mda)
+
+    g_plan = wdg.value().grid_plan
+    assert isinstance(g_plan, useq.GridFromEdges)
+    assert g_plan.top == 256
+    assert g_plan.bottom == -256
+    assert g_plan.left == -256
+    assert g_plan.right == 768
+    assert len(list(mda)) == 6


### PR DESCRIPTION
Not sure if this is the best fix but...

To reproduce the current bug:

```py
from pymmcore_plus import CMMCorePlus
from pymmcore_widgets.mda._core_grid import CoreConnectedGridPlanWidget
mmc = CMMCorePlus()
mmc.loadSystemConfiguration()
g = CoreConnectedGridPlanWidget()
g.show()
g.setMode("bounds")
```

 Now manually modify any of the `top/bottom/left/right` values and then run:

```py
g.value()
```

In the current version the `top/bottom/left/right` values are always `0`.


I'm not sure how to test this because if we setup the widget `top/bottom/left/right` values  with the `setValue()` method and then we call the `value()` the `top/bottom/left/right` values  are correct. The difference is that graphically on the widget we do not see the `top/bottom/left/right` values added through the  `setValue()`.

https://github.com/user-attachments/assets/15779e0e-77f0-4543-aeca-a26c4f56806d

