### PR TITLE
fix: update shutter widget color when closed

### DIFF
--- a/src/pymmcore_widgets/control/_shutter_widget.py
+++ b/src/pymmcore_widgets/control/_shutter_widget.py
@@ -60,7 +60,7 @@ class ShuttersWidget(QWidget):
         self._icon_open: str = MDI6.hexagon_outline
         self._icon_closed: str = MDI6.hexagon_slice_6
         self._icon_color_open: COLOR_TYPE = (0, 255, 0)
-        self._icon_color_closed: COLOR_TYPE = "magenta"
+        self._icon_color_closed: COLOR_TYPE = "gray"
         self._icon_size: int = 25
         self._button_text_open: str = ""
         self._button_text_closed: str = ""

--- a/tests/test_shutter_widget.py
+++ b/tests/test_shutter_widget.py
@@ -202,10 +202,10 @@ def test_shutter_widget_setters(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert shutter.icon_size == 30
 
     assert shutter.icon_color_open == (0, 255, 0)
-    shutter.icon_color_open = "magenta"
-    assert shutter.icon_color_open == "magenta"
+    shutter.icon_color_open = "gray"
+    assert shutter.icon_color_open == "gray"
 
-    assert shutter.icon_color_closed == "magenta"
+    assert shutter.icon_color_closed == "gray"
     shutter.icon_color_closed = (0, 255, 0)
     assert shutter.icon_color_closed == (0, 255, 0)
 


### PR DESCRIPTION
In this PR the `gray` color (instead of `magenta`) is used to indicate when the `shutter` is closed, making it easier to distinguish its state.

<img width="531" alt="Screenshot 2025-02-10 at 4 13 32 PM" src="https://github.com/user-attachments/assets/5e8828d3-0ea6-4759-9441-c56e6998fc53" />
