### PR TITLE
fix: connect core roiSet signal to MDAWidget _core_grid and _core_position

### DIFF
--- a/src/pymmcore_widgets/mda/_core_grid.py
+++ b/src/pymmcore_widgets/mda/_core_grid.py
@@ -45,6 +45,7 @@ class CoreConnectedGridPlanWidget(GridPlanWidget):
 
         self._mmc.events.systemConfigurationLoaded.connect(self._update_fov_size)
         self._mmc.events.pixelSizeChanged.connect(self._update_fov_size)
+        self._mmc.events.roiSet.connect(self._update_fov_size)
         self._update_fov_size()
 
     def _update_fov_size(self) -> None:

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -995,3 +995,40 @@ def test_grid_plan_fov_update(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
         mmc.setPixelSizeConfig("Res20x")
     assert wdg.value().grid_plan.fov_width == 50
     assert wdg.value().grid_plan.fov_height == 75
+
+
+def test_grid_plan_subsequence_fov_update(
+    qtbot: QtBot, global_mmcore: CMMCorePlus
+) -> None:
+    mmc = global_mmcore
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    pos = useq.AbsolutePosition(
+        x=0.0,
+        y=0.0,
+        z=0.0,
+        sequence=useq.MDASequence(
+            grid_plan=useq.GridRowsColumns(
+                fov_width=512.0, fov_height=512.0, rows=3, columns=1
+            )
+        ),
+    )
+    wdg.tab_wdg.setChecked(wdg.stage_positions, True)
+    wdg.stage_positions.setValue([pos])
+
+    sp = wdg.stage_positions
+    assert sp.value()[0].sequence.grid_plan.fov_width == 512
+    assert sp.value()[0].sequence.grid_plan.fov_height == 512
+
+    with qtbot.waitSignal(mmc.events.roiSet):
+        mmc.setROI(0, 0, 100, 150)
+
+    assert sp.value()[0].sequence.grid_plan.fov_width == 100
+    assert sp.value()[0].sequence.grid_plan.fov_height == 150
+
+    with qtbot.waitSignal(mmc.events.pixelSizeChanged):
+        mmc.setPixelSizeConfig("Res20x")
+    assert sp.value()[0].sequence.grid_plan.fov_width == 50
+    assert sp.value()[0].sequence.grid_plan.fov_height == 75

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -971,3 +971,27 @@ def test_core_mda_autofocus_and_z_plan(
         # AF column should be hidden
         assert pos_table.table().isColumnHidden(af_col)
         assert pos_table.table().isColumnHidden(af_btn_col)
+
+
+def test_grid_plan_fov_update(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    mmc = global_mmcore
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    wdg.tab_wdg.setChecked(wdg.grid_plan, True)
+    grid_plan = useq.GridRowsColumns(rows=2, columns=1)
+    wdg.grid_plan.setValue(grid_plan)
+
+    assert wdg.value().grid_plan.fov_height == 512
+    assert wdg.value().grid_plan.fov_width == 512
+
+    with qtbot.waitSignal(mmc.events.roiSet):
+        mmc.setROI(0, 0, 100, 150)
+    assert wdg.value().grid_plan.fov_width == 100
+    assert wdg.value().grid_plan.fov_height == 150
+
+    with qtbot.waitSignal(mmc.events.pixelSizeChanged):
+        mmc.setPixelSizeConfig("Res20x")
+    assert wdg.value().grid_plan.fov_width == 50
+    assert wdg.value().grid_plan.fov_height == 75


### PR DESCRIPTION
Currently, when the camera ROI is changed, any previously added _grid_plan_ or _positions_ containing a _grid_plan subsequence_ do not automatically update their field of view size.

This PR fixes this bug mentioned in #405 .

closes #405 

