### PR TITLE
[wip] info widget with image histogram, min and max values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ image = [
     # fix OSError: dlopen(Quartz.framework/Quartz on vispy
     "pyopengl; platform_system == 'Darwin'",
 ]
+plot = ["pyqtgraph"]
 
 test = [
     "pymmcore-widgets[image]",

--- a/src/pymmcore_widgets/__init__.py
+++ b/src/pymmcore_widgets/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "GroupPresetTableWidget",
     "HCSWizard",
     "ImagePreview",
+    "ImageInfo",
     "InstallWidget",
     "LiveButton",
     "MDASequenceWidget",
@@ -75,7 +76,7 @@ from .useq_widgets import (
     TimePlanWidget,
     ZPlanWidget,
 )
-from .views import ImagePreview
+from .views import ImagePreview, ImageInfo
 
 if TYPE_CHECKING:
     from ._deprecated._device_widget import (

--- a/src/pymmcore_widgets/__init__.py
+++ b/src/pymmcore_widgets/__init__.py
@@ -22,8 +22,8 @@ __all__ = [
     "GridPlanWidget",
     "GroupPresetTableWidget",
     "HCSWizard",
-    "ImagePreview",
     "ImageInfo",
+    "ImagePreview",
     "InstallWidget",
     "LiveButton",
     "MDASequenceWidget",
@@ -76,7 +76,7 @@ from .useq_widgets import (
     TimePlanWidget,
     ZPlanWidget,
 )
-from .views import ImagePreview, ImageInfo
+from .views import ImageInfo, ImagePreview
 
 if TYPE_CHECKING:
     from ._deprecated._device_widget import (

--- a/src/pymmcore_widgets/views/__init__.py
+++ b/src/pymmcore_widgets/views/__init__.py
@@ -1,5 +1,7 @@
 """View-related Widgets."""
 
 from ._image_widget import ImagePreview
+from ._image_info import ImageInfo
 
-__all__ = ["ImagePreview"]
+__all__ = ["ImagePreview",
+           "ImageInfo"]

--- a/src/pymmcore_widgets/views/__init__.py
+++ b/src/pymmcore_widgets/views/__init__.py
@@ -1,7 +1,9 @@
 """View-related Widgets."""
 
-from ._image_widget import ImagePreview
 from ._image_info import ImageInfo
+from ._image_widget import ImagePreview
 
-__all__ = ["ImagePreview",
-           "ImageInfo"]
+__all__ = [
+    "ImageInfo",
+    "ImagePreview",
+]

--- a/src/pymmcore_widgets/views/_image_info.py
+++ b/src/pymmcore_widgets/views/_image_info.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING
 
-from pymmcore_plus import CMMCorePlus
-from qtpy.QtCore import Qt, QTimer, Signal
-from qtpy.QtWidgets import QVBoxLayout, QWidget, QLabel
 import numpy as np
-
-if TYPE_CHECKING:
-    from typing import Literal
-
-    import numpy as np
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 _DEFAULT_WAIT = 10
+
 
 class ImageInfo(QWidget):
     """A Widget that displays information about the last image by active core.
@@ -62,7 +57,7 @@ class ImageInfo(QWidget):
         self._max: float | None = None
         self._std: float | None = None
         self._cvals: list[float] = []
- 
+
         self.streaming_timer = QTimer(parent=self)
         self.streaming_timer.setTimerType(Qt.TimerType.PreciseTimer)
         self.streaming_timer.setInterval(int(self._mmc.getExposure()) or _DEFAULT_WAIT)
@@ -74,19 +69,23 @@ class ImageInfo(QWidget):
         ev.sequenceAcquisitionStopped.connect(self._on_streaming_stop)
         ev.exposureChanged.connect(self._on_exposure_changed)
 
-        self.info_label = QLabel(f"Min: {self._min}, Max: {self._max}, Std: {self._std}")
+        self.info_label = QLabel(
+            f"Min: {self._min}, Max: {self._max}, Std: {self._std}"
+        )
         self.info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self._histogram_widget = pg.PlotWidget(background=None)
         self._histogram_widget.setLabel("left", "Frequency")
         self._histogram_widget.setLabel("bottom", "Pixel Value")
-        self._histogram_plot = self._histogram_widget.plot(stepMode=True, fillLevel=0, brush=(0, 0, 255, 80))
+        self._histogram_plot = self._histogram_widget.plot(
+            stepMode=True, fillLevel=0, brush=(0, 0, 255, 80)
+        )
 
         self.setLayout(QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().addWidget(self._histogram_widget)
         self.layout().addWidget(self.info_label)
-        
+
         self.destroyed.connect(self._disconnect)
 
     @property
@@ -133,7 +132,9 @@ class ImageInfo(QWidget):
     def _update_image(self, img: np.ndarray) -> None:
         self._min, self._max = img.min(), img.max()
         self._std = img.std()
-        self.info_label.setText(f"Min: {self._min}, Max: {self._max}, Std: {self._std:.1f}")
+        self.info_label.setText(
+            f"Min: {self._min}, Max: {self._max}, Std: {self._std:.1f}"
+        )
 
-        y,x = np.histogram(img.flatten())
+        y, x = np.histogram(img.flatten())
         self._histogram_plot.setData(x, y)

--- a/src/pymmcore_widgets/views/_image_info.py
+++ b/src/pymmcore_widgets/views/_image_info.py
@@ -56,7 +56,6 @@ class ImageInfo(QWidget):
         self._min: float | None = None
         self._max: float | None = None
         self._std: float | None = None
-        self._cvals: list[float] = []
 
         self.streaming_timer = QTimer(parent=self)
         self.streaming_timer.setTimerType(Qt.TimerType.PreciseTimer)

--- a/src/pymmcore_widgets/views/_image_info.py
+++ b/src/pymmcore_widgets/views/_image_info.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import numpy as np
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout, QWidget, QComboBox
+from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 _DEFAULT_WAIT = 10
 
@@ -56,7 +56,7 @@ class ImageInfo(QWidget):
         self._min: float | None = None
         self._max: float | None = None
         self._std: float | None = None
-        self._clims: tuple[float, float] | Literal["auto"] = "auto"
+        self._clims: tuple[float, float] | Literal[auto] = "auto"
 
         self.streaming_timer = QTimer(parent=self)
         self.streaming_timer.setTimerType(Qt.TimerType.PreciseTimer)
@@ -69,7 +69,6 @@ class ImageInfo(QWidget):
         )
         self.info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-
         # histogram plot ---
         self._histogram_widget = pg.PlotWidget(background=None)
         self._histogram_widget.setXRange(0, 255)  # Set the x-limits here
@@ -81,7 +80,15 @@ class ImageInfo(QWidget):
 
         # options
         self._range_selector = QComboBox()
-        self._range_selector.addItems(["auto", "8-bit (0-255)", "10-bit (0-1023)", "12-bit (0-4095)", "16-bit (0-65535)"])
+        self._range_selector.addItems(
+            [
+                "auto",
+                "8-bit (0-255)",
+                "10-bit (0-1023)",
+                "12-bit (0-4095)",
+                "16-bit (0-65535)",
+            ]
+        )
         self._range_selector.setCurrentText("auto")
 
         # layout

--- a/src/pymmcore_widgets/views/_image_info.py
+++ b/src/pymmcore_widgets/views/_image_info.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtCore import Qt, QTimer, Signal
+from qtpy.QtWidgets import QVBoxLayout, QWidget, QLabel
+import numpy as np
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    import numpy as np
+
+_DEFAULT_WAIT = 10
+
+class ImageInfo(QWidget):
+    """A Widget that displays information about the last image by active core.
+
+    This widget will automatically update when the active core snaps an image, when the
+    active core starts streaming or when a Multi-Dimensional Acquisition is running.
+
+    Heavily based/stolen from `pymmcore_widgets.ImagePreview`.
+
+    Parameters
+    ----------
+    parent : QWidget | None
+        Optional parent widget. By default, None.
+    mmcore : CMMCorePlus | None
+        Optional [`pymmcore_plus.CMMCorePlus`][] micromanager core.
+        By default, None. If not specified, the widget will use the active
+        (or create a new)
+        [`CMMCorePlus.instance`][pymmcore_plus.core._mmcore_plus.CMMCorePlus.instance].
+    use_with_mda: bool
+        If False, the widget will not update when a Multi-Dimensional Acquisition is
+        running. By default, True.
+    """
+
+    # image_updated = Signal()
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        mmcore: CMMCorePlus | None = None,
+        use_with_mda: bool = True,
+    ):
+        try:
+            import pyqtgraph as pg
+        except ImportError as e:
+            raise ImportError(
+                "pyqtgraph is required for ImageInfo. "
+                "Please run `pip install pymmcore-widgets[plot]`"
+            ) from e
+
+        super().__init__(parent=parent)
+        self._mmc = mmcore or CMMCorePlus.instance()
+        self._use_with_mda = use_with_mda
+
+        self._min: float | None = None
+        self._max: float | None = None
+        self._std: float | None = None
+        self._cvals: list[float] = []
+ 
+        self.streaming_timer = QTimer(parent=self)
+        self.streaming_timer.setTimerType(Qt.TimerType.PreciseTimer)
+        self.streaming_timer.setInterval(int(self._mmc.getExposure()) or _DEFAULT_WAIT)
+        self.streaming_timer.timeout.connect(self._on_streaming_timeout)
+
+        ev = self._mmc.events
+        ev.imageSnapped.connect(self._on_image_snapped)
+        ev.continuousSequenceAcquisitionStarted.connect(self._on_streaming_start)
+        ev.sequenceAcquisitionStopped.connect(self._on_streaming_stop)
+        ev.exposureChanged.connect(self._on_exposure_changed)
+
+        self.info_label = QLabel(f"Min: {self._min}, Max: {self._max}, Std: {self._std}")
+        self.info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self._histogram_widget = pg.PlotWidget(background=None)
+        self._histogram_widget.setLabel("left", "Frequency")
+        self._histogram_widget.setLabel("bottom", "Pixel Value")
+        self._histogram_plot = self._histogram_widget.plot(stepMode=True, fillLevel=0, brush=(0, 0, 255, 80))
+
+        self.setLayout(QVBoxLayout())
+        self.layout().setContentsMargins(0, 0, 0, 0)
+        self.layout().addWidget(self._histogram_widget)
+        self.layout().addWidget(self.info_label)
+        
+        self.destroyed.connect(self._disconnect)
+
+    @property
+    def use_with_mda(self) -> bool:
+        """Get whether the widget should update when a MDA is running."""
+        return self._use_with_mda
+
+    @use_with_mda.setter
+    def use_with_mda(self, use_with_mda: bool) -> None:
+        """Set whether the widget should update when a MDA is running.
+
+        Parameters
+        ----------
+        use_with_mda : bool
+            Whether the widget is used with MDA.
+        """
+        self._use_with_mda = use_with_mda
+
+    def _disconnect(self) -> None:
+        ev = self._mmc.events
+        ev.imageSnapped.disconnect(self._on_image_snapped)
+        ev.continuousSequenceAcquisitionStarted.disconnect(self._on_streaming_start)
+        ev.sequenceAcquisitionStopped.disconnect(self._on_streaming_stop)
+        ev.exposureChanged.disconnect(self._on_exposure_changed)
+
+    def _on_streaming_start(self) -> None:
+        self.streaming_timer.start()
+
+    def _on_streaming_stop(self) -> None:
+        self.streaming_timer.stop()
+
+    def _on_exposure_changed(self, device: str, value: str) -> None:
+        self.streaming_timer.setInterval(int(value))
+
+    def _on_streaming_timeout(self) -> None:
+        with suppress(RuntimeError, IndexError):
+            self._update_image(self._mmc.getLastImage())
+
+    def _on_image_snapped(self) -> None:
+        if self._mmc.mda.is_running() and not self._use_with_mda:
+            return
+        self._update_image(self._mmc.getImage())
+
+    def _update_image(self, img: np.ndarray) -> None:
+        self._min, self._max = img.min(), img.max()
+        self._std = img.std()
+        self.info_label.setText(f"Min: {self._min}, Max: {self._max}, Std: {self._std:.1f}")
+
+        y,x = np.histogram(img.flatten())
+        self._histogram_plot.setData(x, y)


### PR DESCRIPTION
Still work in progress - the idea is to have something similar to the Inspect window in Micro-Manager studio.

It could be linked to an `ImagePreview` widget to control clims - that's the next step as well as making it a bit nicer by including the option to control the range displayed/bins etc.

It uses `pyqtgraph` instead of `vispy` - I think in principle same result can be achieved with `vispy`

![image](https://github.com/user-attachments/assets/75e4e92f-df10-4ec9-84a3-af8e331ba89d)