### PR TITLE
fix: fix plate calibration

### DIFF
--- a/src/pymmcore_widgets/hcs/_plate_calibration_widget.py
+++ b/src/pymmcore_widgets/hcs/_plate_calibration_widget.py
@@ -333,8 +333,8 @@ class PlateCalibrationWidget(QWidget):
         osr = self._origin_spacing_rotation()
         if fully_calibrated := (osr is not None):
             self._a1_center_xy, self._well_spacing, self._rotation = osr
-            if self._current_plate:
-                self._plate_test.drawPlate(self._current_plate)
+            if (plate_plan := self.value()) is not None:
+                self._plate_test.drawPlate(plate_plan)
         else:
             self._a1_center_xy = (0.0, 0.0)
             self._rotation = None

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from fonticon_mdi6 import MDI6
 from pymmcore_plus import CMMCorePlus
@@ -102,10 +102,6 @@ class CoreConnectedPositionTable(PositionTable):
         table.addColumn(self._xy_btn_col, table.indexOf(self.X))
         table.addColumn(self._z_btn_col, table.indexOf(self.Z) + 1)
         table.addColumn(self._af_btn_col, table.indexOf(self.AF) + 1)
-
-        # when a new row is inserted, call _on_rows_inserted
-        # to update the new values from the core position
-        table.model().rowsInserted.connect(self._on_rows_inserted)
 
         # add move_to_selection to toolbar and link up callback
         toolbar = self.toolBar()
@@ -336,16 +332,10 @@ class CoreConnectedPositionTable(PositionTable):
         # has had a chance to update the values from the current stage position
         with signals_blocked(self):
             super()._add_row()
-        self.valueChanged.emit()
-
-    def _on_rows_inserted(self, parent: Any, start: int, end: int) -> None:
-        # when a new row is inserted by any means, populate it with default values
-        # this is connected above in __init_ with self.model().rowsInserted.connect
-        with signals_blocked(self):
-            for row_idx in range(start, end + 1):
-                self._set_xy_from_core(row_idx)
-                self._set_z_from_core(row_idx)
-                self._set_af_from_core(row_idx)
+            row_idx = self.table().rowCount() - 1
+            self._set_xy_from_core(row_idx)
+            self._set_z_from_core(row_idx)
+            self._set_af_from_core(row_idx)
         self.valueChanged.emit()
 
     def _set_xy_from_core(self, row: int, col: int = 0) -> None:

--- a/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
+++ b/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
@@ -511,7 +511,10 @@ class WellPlateView(ResizingGraphicsView):
 
         for x, y in positions:
             edge_rect = QRectF(x - width / 2, y - width / 2, width, width)
-            new_pos = useq.Position(x=x, y=y, name=pos.name)
+            # NOTE: we are inverting the y-coordinate because the y-axis is inverted
+            # in the scene coordinate system (in pymmcore-plus we use a coordinate
+            # system where y is negative downwards and positive upwards)
+            new_pos = useq.Position(x=x, y=-y, name=pos.name)
             item = HoverEllipse(edge_rect)
             item.setData(DATA_POSITION, new_pos)
             if new_pos.x is not None and new_pos.y is not None:

--- a/tests/hcs/test_well_plate_calibration_widget.py
+++ b/tests/hcs/test_well_plate_calibration_widget.py
@@ -186,8 +186,8 @@ def test_plate_calibration_test_positions(global_mmcore: CMMCorePlus, qtbot) -> 
         (0, 0, "A1"),
         (-3200, 0, "A1"),
         (3200, 0, "A1"),
-        (0, -3200, "A1"),
         (0, 3200, "A1"),
+        (0, -3200, "A1"),
     ]
     data = []
     for hover_item in hover_items:


### PR DESCRIPTION
I found two bugs in the `PlateCalibrationWidget` of the `HCSWizard`:


- The `y` positions stored in each `HoverEllipse` item should be negative since we use a coordinate system where y is positive upwards and negative downwards. This PR inverts the sign.

<img width="556" alt="Screenshot 2025-04-02 at 8 17 14 PM" src="https://github.com/user-attachments/assets/ba33c9f6-e1b9-4208-a788-181133d247b7" />
 
---

- It also fixes the slow behavior that I found when adding position from the HCSWidget (the `_on_rows_inserted` was unnecessarily called every time a row was added)
