### PR TITLE
feat: add 3 decimals to pixel size config widget 

### DIFF
--- a/src/pymmcore_widgets/config_presets/_pixel_configuration_widget.py
+++ b/src/pymmcore_widgets/config_presets/_pixel_configuration_widget.py
@@ -453,7 +453,7 @@ class _PixelTable(DataTableWidget):
 
     ID = TextColumn(key=ID, header="ResolutionID", default=NEW, is_row_selector=False)
     VALUE = FloatColumn(
-        key=PX, header="pixel value [µm]", default=0, is_row_selector=False
+        key=PX, header="pixel value [µm]", default=0, is_row_selector=False, decimals=3
     )
 
     def __init__(self, rows: int = 0, parent: QWidget | None = None):
@@ -499,7 +499,7 @@ class AffineTable(QTableWidget):
         for row, col in itertools.product(range(3), range(3)):
             spin = QDoubleSpinBox()
             spin.setRange(-100000, 100000)
-            spin.setDecimals(1)
+            spin.setDecimals(3)
             spin.setAlignment(Qt.AlignmentFlag.AlignCenter)
             spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
             self.setCellWidget(row, col, spin)

--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -265,6 +265,7 @@ class _RangeColumn(WidgetColumn, Generic[W, T]):
     data_type: WdgGetSet[W, float]
     minimum: float = 0
     maximum: float = 999_999
+    decimals: int = 2
 
     def _init_widget(self) -> W:
         wdg = self.data_type.widget()
@@ -273,6 +274,8 @@ class _RangeColumn(WidgetColumn, Generic[W, T]):
             wdg.setMinimum(self.minimum)
         if self.maximum is not None and hasattr(wdg, "setMaximum"):
             wdg.setMaximum(self.maximum)
+        if self.decimals is not None and hasattr(wdg, "setDecimals"):
+            wdg.setDecimals(self.decimals)
 
         return wdg  # type: ignore
 


### PR DESCRIPTION
This PR increases the decimals in the `pixel value [µm]` column of the `PixelConfigurationWidget` since is currently limited to 2 decimals.

<img width="501" alt="Screenshot 2025-04-15 at 2 45 17 PM" src="https://github.com/user-attachments/assets/afeb7b53-bdee-44de-be46-f36adafac2d7" />
