### PR TITLE
fix: minor HCSWizard bugs

### DIFF
--- a/src/pymmcore_widgets/hcs/_plate_calibration_widget.py
+++ b/src/pymmcore_widgets/hcs/_plate_calibration_widget.py
@@ -148,6 +148,10 @@ class PlateCalibrationWidget(QWidget):
             plan = plate_or_plan
             plate = plan.plate
             calibrated = True
+            # set the well spacing to the plate's well spacing to correctly update the
+            # info label (since we are assuming the plate is correctly calibrated,
+            # we can assume the well spacing is correct)
+            self._well_spacing = plate.well_spacing
         elif isinstance(plate_or_plan, useq.WellPlate):
             plate = plate_or_plan
 
@@ -164,6 +168,10 @@ class PlateCalibrationWidget(QWidget):
 
         if calibrated and plan is not None:
             self._plate_test.drawPlate(plan)
+            # make sure no wells are selected since we are in test mode
+            self._plate_test.setSelectedIndices([])
+            # seyt the tab to the test mode
+            self._tab_wdg.setCurrentIndex(1)
         else:
             self._plate_test.clear()
 
@@ -349,6 +357,9 @@ class PlateCalibrationWidget(QWidget):
         style = self.style()
         if self._rotation is not None:
             spacing = self._well_spacing or (0, 0)
+
+            print("spacing", spacing)
+
             txt = "<strong>Plate calibrated.</strong>"
             ico = icon(CALIBRATED_ICON, color=GREEN)
             if self._current_plate is not None:

--- a/src/pymmcore_widgets/hcs/_plate_calibration_widget.py
+++ b/src/pymmcore_widgets/hcs/_plate_calibration_widget.py
@@ -357,9 +357,6 @@ class PlateCalibrationWidget(QWidget):
         style = self.style()
         if self._rotation is not None:
             spacing = self._well_spacing or (0, 0)
-
-            print("spacing", spacing)
-
             txt = "<strong>Plate calibrated.</strong>"
             ico = icon(CALIBRATED_ICON, color=GREEN)
             if self._current_plate is not None:

--- a/tests/hcs/test_well_plate_calibration_widget.py
+++ b/tests/hcs/test_well_plate_calibration_widget.py
@@ -20,11 +20,20 @@ def test_plate_calibration(global_mmcore: CMMCorePlus, qtbot) -> None:
 
     with qtbot.waitSignal(wdg.calibrationChanged) as sig:
         wdg.setValue(
-            useq.WellPlatePlan(plate="24-well", a1_center_xy=(0, 0), rotation=2)
+            useq.WellPlatePlan(
+                plate="24-well",
+                a1_center_xy=(0, 0),
+                rotation=2,
+                selected_wells=slice(0, 8, 2),
+            )
         )
     assert sig.args == [True]
     assert wdg.value().plate.rows == 4
     assert wdg._tab_wdg.isTabEnabled(1)
+    assert wdg._tab_wdg.currentIndex() == 1
+    assert not wdg._plate_test.selectedIndices()
+    # the info text should nnot contain the warning about well spacing
+    assert "Expected well spacing of" not in wdg._info.text()
 
     with qtbot.waitSignal(wdg.calibrationChanged) as sig:
         wdg.setValue("96-well")


### PR DESCRIPTION
Fix few bugs I found in the HCSWizard when loading a calibration config.

- the test plate wells should always be without color since it it just a plate for testing all the wells
- wen loading a configuration that contains calibration info, the info label should correctly say that the plate is calibrated

BEFORE
<img width="992" alt="Screenshot 2025-04-17 at 10 21 21 AM" src="https://github.com/user-attachments/assets/2b9552dd-b247-4812-97af-62ea09ff9526" />
AFTER
<img width="992" alt="Screenshot 2025-04-17 at 10 21 05 AM" src="https://github.com/user-attachments/assets/af76cd2f-54d6-48ec-b5c5-e7d1fd95a652" />
