### PR TITLE
feat: stage explorer part 3

### DIFF
--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -38,4 +38,4 @@ rlayout.addWidget(mda_widget)
 splitter.addWidget(right)
 splitter.show()
 
-# app.exec()
+app.exec()

--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -15,7 +15,9 @@ mmc.loadSystemConfiguration()
 # mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))
 
 # set camera roi (rectangular helps confirm orientation)
-# mmc.setROI(0, 0, 400, 500)
+mmc.setROI(0, 0, 400, 500)
+
+mmc.setProperty("XY", "Velocity", 1)
 
 explorer = StageExplorer()
 
@@ -27,7 +29,6 @@ z_ctrl = StageWidget(mmc.getFocusDevice())
 z_ctrl.snap_checkbox.setChecked(True)
 
 mda_widget = MDAWidget()
-
 
 group_wdg = GroupPresetTableWidget()
 splitter = QSplitter()

--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -9,9 +9,10 @@ app = QApplication([])
 mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
 
+# add a small rotation
 mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))
-
-print(mmc.getPixelSizeAffine())
+mmc.setPixelSizeAffine("Res20x", (0.4981, -0.0436, 0.0, 0.0436, 0.4981, 0.0))
+mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))
 
 # set camera roi (rectangular helps confirm orientation)
 mmc.setROI(0, 0, 400, 500)

--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -10,9 +10,9 @@ mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
 
 # add a small rotation
-mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))
-mmc.setPixelSizeAffine("Res20x", (0.4981, -0.0436, 0.0, 0.0436, 0.4981, 0.0))
-mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))
+mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))  # 1
+mmc.setPixelSizeAffine("Res20x", (0.4981, -0.0436, 0.0, 0.0436, 0.4981, 0.0))  # 0.5
+mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))  # 0.25
 
 # set camera roi (rectangular helps confirm orientation)
 mmc.setROI(0, 0, 400, 500)

--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -9,6 +9,10 @@ app = QApplication([])
 mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
 
+mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))
+
+print(mmc.getPixelSizeAffine())
+
 # set camera roi (rectangular helps confirm orientation)
 mmc.setROI(0, 0, 400, 500)
 

--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -10,12 +10,12 @@ mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
 
 # add a small rotation
-mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))  # 1
-mmc.setPixelSizeAffine("Res20x", (0.4981, -0.0436, 0.0, 0.0436, 0.4981, 0.0))  # 0.5
-mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))  # 0.25
+# mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))
+# mmc.setPixelSizeAffine("Res20x", (0.4981, -0.0436, 0.0, 0.0436, 0.4981, 0.0))
+# mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))
 
 # set camera roi (rectangular helps confirm orientation)
-mmc.setROI(0, 0, 400, 500)
+# mmc.setROI(0, 0, 400, 500)
 
 explorer = StageExplorer()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,9 @@ show_error_codes = true
 pretty = true
 plugins = ["pydantic.mypy"]
 
+[[tool.mypy.overrides]]
+module = ["vispy.*"]
+ignore_missing_imports = true
 
 # https://coverage.readthedocs.io/en/6.4/config.html
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     'fonticon-materialdesignicons6',
     'pymmcore-plus[cli] >=0.13.7',
     'qtpy >=2.0',
-    'superqt[quantity,cmap] >=0.7.1',
+    'superqt[quantity,cmap,iconify] >=0.7.1',
     'useq-schema >=0.5.0',
     'vispy'
 ]

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -152,10 +152,10 @@ class StageExplorer(QWidget):
         self._stage_pos_marker: StagePositionMarker | None = None
 
         # toolbar
-        toolbar = QToolBar()
-        toolbar.setStyleSheet(SS_TOOLBUTTON)
-        toolbar.setMovable(False)
-        toolbar.setContentsMargins(0, 0, 10, 0)
+        self._toolbar = QToolBar()
+        self._toolbar.setStyleSheet(SS_TOOLBUTTON)
+        self._toolbar.setMovable(False)
+        self._toolbar.setContentsMargins(0, 0, 10, 0)
 
         # actions
         self._actions: dict[str, QAction] = {}
@@ -183,22 +183,22 @@ class StageExplorer(QWidget):
                 # create special toolbutton with a context menu on right-click
                 btn = self._create_poll_stage_button()
                 btn.setDefaultAction(action)
-                toolbar.addWidget(btn)
+                self._toolbar.addWidget(btn)
             else:
-                toolbar.addAction(action)
+                self._toolbar.addAction(action)
 
         # add stage pos label to the toolbar
         self._stage_pos_label = QLabel()
         spacer = QWidget()
         spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        toolbar.addWidget(spacer)
-        toolbar.addWidget(self._stage_pos_label)
+        self._toolbar.addWidget(spacer)
+        self._toolbar.addWidget(self._stage_pos_label)
 
         # main layout
         main_layout = QVBoxLayout(self)
         main_layout.setSpacing(0)
         main_layout.setContentsMargins(0, 0, 0, 0)
-        main_layout.addWidget(toolbar, 0)
+        main_layout.addWidget(self._toolbar, 0)
         main_layout.addWidget(self._stage_viewer, 1)
 
         # connections core events
@@ -215,6 +215,10 @@ class StageExplorer(QWidget):
         self._on_sys_config_loaded()
 
     # -----------------------------PUBLIC METHODS-------------------------------------
+
+    def toolBar(self) -> QToolBar:
+        """Return the toolbar of the widget."""
+        return self._toolbar
 
     @property
     def auto_zoom_to_fit(self) -> bool:

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -441,7 +441,7 @@ class StageExplorer(QWidget):
             rect_color="#3A3",
             rect_thickness=4,
             show_rect=True,
-            marker_symbol="x",
+            marker_symbol="++",
             marker_symbol_color="#3A3",
             marker_symbol_size=min((w, h)) / 10,
             show_marker_symbol=True,

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -274,12 +274,12 @@ class StageExplorer(QWidget):
         # map the clicked canvas position to the stage position
         x, y, _, _ = self._stage_viewer.view.camera.transform.imap(event.pos)
         self._mmc.setXYPosition(x, y)
-        # wait for the stage to be in position before continuing
-        self._mmc.waitForDevice(self._mmc.getXYStageDevice())
         # update the stage position label
         self._stage_pos_label.setText(f"X: {x:.2f} µm  Y: {y:.2f} µm")
         # snap an image if the snap on double click property is set
         if self._snap_on_double_click:
+            # wait for the stage to be in position before continuing
+            self._mmc.waitForDevice(self._mmc.getXYStageDevice())
             self._mmc.snapImage()
 
     def _on_image_snapped(self) -> None:

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -332,7 +332,8 @@ class StageExplorer(QWidget):
         if self._stage_pos_marker is None:
             self._create_stage_marker(x, y)
 
-        # update stage marker position
+        # update stage marker position (using the affine matrix since we need to take
+        # into account the rotation and scaling)
         matrix = self._build_stage_marker_complete_affine_matrix(x, y)
         mk = cast("Rectangle", self._stage_pos_marker)
         mk.transform = MatrixTransform(matrix=matrix.T)
@@ -347,7 +348,8 @@ class StageExplorer(QWidget):
     ) -> np.ndarray:
         """Build the affine matrix for the stage position marker.
 
-        We need this to take into account any rotation.
+        We need this to take into account any rotation (but do not need to flip or shift
+        the position half the width and height since the marker is already centered).
         """
         system_affine = self._current_pixel_config_affine()
         if system_affine is None:

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -358,14 +358,11 @@ class StageExplorer(QWidget):
 
     def _create_stage_marker(self, x: float, y: float) -> None:
         """Create a marker at the current stage position."""
-        px = self._mmc.getPixelSizeUm()
-        w = self._mmc.getImageWidth() * px
-        h = self._mmc.getImageHeight() * px
         self._stage_pos_marker = Rectangle(
             parent=self._stage_viewer.view.scene,
-            center=(x, y),
-            width=w,
-            height=h,
+            center=(0, 0),
+            width=self._mmc.getImageWidth(),
+            height=self._mmc.getImageHeight(),
             border_width=4,
             border_color=vispy.color.Color("#3A3"),
             color=vispy.color.Color("transparent"),
@@ -422,16 +419,18 @@ class StageExplorer(QWidget):
 
     def _is_visual_within_view(self, x: float, y: float) -> bool:
         """Return True if the visual is within the view, otherwise False."""
+        # TODO: use the affine matrix to get the correct coordinates, currently this
+        # is not considering any rotation...
         view_rect = self._stage_viewer.view.camera.rect
         px = self._mmc.getPixelSizeUm()
         half_width = self._mmc.getImageWidth() / 2 * px
         half_height = self._mmc.getImageHeight() / 2 * px
         # NOTE: x, y is the center of the image
         vertices = [
-            (x - half_width, y - half_height),
-            (x + half_width, y - half_height),
-            (x - half_width, y + half_height),
-            (x + half_width, y + half_height),
+            (x - half_width, y - half_height),  # bottom-left
+            (x + half_width, y - half_height),  # bottom-right
+            (x - half_width, y + half_height),  # top-left
+            (x + half_width, y + half_height),  # top-right
         ]
         return all(view_rect.contains(*vertex) for vertex in vertices)
 

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -164,7 +164,6 @@ class StageExplorer(QWidget):
             if a_text == POLL_STAGE:
                 btn = QToolButton(self)
                 btn.setDefaultAction(action)
-                self._setup_poll_stage_context_menu(btn)
                 btn.setToolTip(f"{POLL_STAGE} (right-click for marker options)")
                 self._setup_poll_stage_context_menu(btn)
                 toolbar.addWidget(btn)
@@ -272,7 +271,10 @@ class StageExplorer(QWidget):
             self.zoom_to_fit()
 
     def _setup_poll_stage_context_menu(self, button: QToolButton) -> None:
-        # Allow custom context menu
+        # create exclusive action group for the poll mode
+        self._poll_stage_menu = self._create_poll_stage_menu()
+
+        # allow custom context menu
         button.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
 
         # Connect the signal
@@ -280,8 +282,8 @@ class StageExplorer(QWidget):
             lambda pos: self._show_poll_stage_menu(button.mapToGlobal(pos))
         )
 
-    def _show_poll_stage_menu(self, global_pos: QPoint) -> None:
-        # create exclusive action group for the poll mode
+    def _create_poll_stage_menu(self) -> QMenu:
+        """Create the poll stage position context menu."""
         group = QActionGroup(self)
         group.setExclusive(True)
 
@@ -308,7 +310,12 @@ class StageExplorer(QWidget):
 
         menu = QMenu()
         menu.addActions(group.actions())
-        menu.exec(global_pos)
+
+        return menu
+
+    def _show_poll_stage_menu(self, global_pos: QPoint) -> None:
+        """Show the poll stage position context menu at the given global position."""
+        self._poll_stage_menu.exec(global_pos)
 
     def _set_poll_mode(self, mode: str) -> None:
         """Update the poll mode and show/hide the required stage position marker."""

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -444,6 +444,7 @@ class StageExplorer(QWidget):
             marker_symbol="++",
             marker_symbol_color="#3A3",
             marker_symbol_size=min((w, h)) / 10,
+            marker_symbol_edge_width=10,
             show_marker_symbol=True,
         )
         # update the marker state depending on the selected poll mode

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -162,7 +162,7 @@ class StageExplorer(QWidget):
             # add a QToolButton to the toolbar if the action is "Poll Stage" so we can
             # set up a context menu
             if a_text == POLL_STAGE:
-                btn = QToolButton(self)
+                btn = QToolButton(toolbar)
                 btn.setDefaultAction(action)
                 btn.setToolTip(f"{POLL_STAGE} (right-click for marker options)")
                 self._setup_poll_stage_context_menu(btn)

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -419,8 +419,6 @@ class StageExplorer(QWidget):
 
     def _is_visual_within_view(self, x: float, y: float) -> bool:
         """Return True if the visual is within the view, otherwise False."""
-        # TODO: use the affine matrix to get the correct coordinates, currently this
-        # is not considering any rotation...
         view_rect = self._stage_viewer.view.camera.rect
         px = self._mmc.getPixelSizeUm()
         half_width = self._mmc.getImageWidth() / 2 * px

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -69,7 +69,7 @@ class StageExplorer(QWidget):
     ----------
     parent : QWidget | None
         Optional parent widget, by default None.
-    mmc : CMMCorePlus | None
+    mmcore : CMMCorePlus | None
         Optional [`CMMCorePlus`][pymmcore_plus.CMMCorePlus] micromanager core.
         By default, None. If not specified, the widget will use the active
         (or create a new)
@@ -202,11 +202,12 @@ class StageExplorer(QWidget):
         # map the clicked canvas position to the stage position
         x, y, _, _ = self._stage_viewer.view.camera.transform.imap(event.pos)
         self._mmc.setXYPosition(x, y)
+        # wait for the stage to be in position before continuing
+        self._mmc.waitForDevice(self._mmc.getXYStageDevice())
         # update the stage position label
         self._stage_pos_label.setText(f"X: {x:.2f} µm  Y: {y:.2f} µm")
+        # snap an image if the snap on double click property is set
         if self._snap_on_double_click:
-            # wait for the stage to be in position before snapping an images
-            self._mmc.waitForDevice(self._mmc.getXYStageDevice())
             self._mmc.snapImage()
 
     def _on_image_snapped(self) -> None:

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -317,18 +317,14 @@ class StageExplorer(QWidget):
         if self._stage_pos_marker is None:
             return
 
-        if mode == BOTH_MODE:
-            self._stage_pos_marker.show_rectangle(True)
-            self._stage_pos_marker.show_marker(True)
-        elif mode == RECT_MODE:
-            self._stage_pos_marker.show_rectangle(True)
-            self._stage_pos_marker.show_marker(False)
-        elif mode == CENTER_MODE:
-            self._stage_pos_marker.show_rectangle(False)
-            self._stage_pos_marker.show_marker(True)
-        else:
-            self._stage_pos_marker.show_rectangle(False)
-            self._stage_pos_marker.show_marker(False)
+        visibility = {
+            BOTH_MODE: (True, True),
+            RECT_MODE: (True, False),
+            CENTER_MODE: (False, True),
+        }
+        show_rect, show_marker = visibility.get(mode, (False, False))
+        self._stage_pos_marker.show_rectangle(show_rect)
+        self._stage_pos_marker.show_marker(show_marker)
 
     # CORE ------------------------------------------------------------------------
 

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
@@ -34,8 +34,10 @@ class StagePositionMarker(Node):
         Whether to show the rectangle.
     marker_symbol : str
         The symbol to use for the marker. This can be any of the symbols
-        supported by the Markers visual: disc, arrow, ring, clobber, square, diamond,
-        vbar, hbar, cross, tailed_arrow, x, triangle_up, triangle_down, and star.
+        supported by the Markers visual: 'disc', 'arrow', 'ring', 'clobber', 'square',
+        'x', 'diamond', 'vbar', 'hbar', 'cross', 'tailed_arrow', 'triangle_up',
+        'triangle_down', 'star', 'cross_lines', 'o', '+', '++', 's', '-', '|', '->',
+        '>', '^', 'v', '*'. By default, '++'.
     marker_symbol_color : str
         The color of the symbol.
     marker_symbol_size : int
@@ -54,7 +56,7 @@ class StagePositionMarker(Node):
         rect_color: str = GREEN,
         rect_thickness: int = 4,
         show_rect: bool = True,
-        marker_symbol: str = "x",
+        marker_symbol: str = "++",
         marker_symbol_color: str = GREEN,
         marker_symbol_size: float = 15,
         show_marker_symbol: bool = True,

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
@@ -44,6 +44,8 @@ class StagePositionMarker(Node):
         The size of the symbol in pixels.
     show_marker_symbol : bool
         Whether to show the symbol.
+    marker_symbol_edge_width : float
+        The edge width of the symbol in pixels.
     """
 
     def __init__(
@@ -59,6 +61,7 @@ class StagePositionMarker(Node):
         marker_symbol: str = "++",
         marker_symbol_color: str = GREEN,
         marker_symbol_size: float = 15,
+        marker_symbol_edge_width: float = 10,
         show_marker_symbol: bool = True,
     ):
         super().__init__(parent)
@@ -83,6 +86,7 @@ class StagePositionMarker(Node):
         self._marker_symbol: str = marker_symbol
         self._marker_symbol_color: str = marker_symbol_color
         self._marker_symbol_size: float = marker_symbol_size
+        self._marker_symbol_edge_width: float = marker_symbol_edge_width
 
         # rectangle
         self.show_rectangle(show_rect)
@@ -223,6 +227,7 @@ class StagePositionMarker(Node):
             edge_color=Color(self._marker_symbol_color),
             symbol=self._marker_symbol,
             size=self._marker_symbol_size,
+            edge_width=self._marker_symbol_edge_width,
             scaling=True,
         )
         self._marker.set_gl_state(depth_test=False)

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
@@ -1,58 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 from vispy.color import Color
-from vispy.scene import MatrixTransform, Node
+from vispy.scene import Compound, MatrixTransform, Node
 from vispy.scene.visuals import Markers, Rectangle
 
-if TYPE_CHECKING:
-    from vispy.visuals.visual import VisualView
-
-GREEN = "#3A3"
+GREEN = "#33AA33"
 
 
-class StagePositionMarker(Node):
-    """A vispy Visual to use as stage position marker.
-
-    Parameters
-    ----------
-    parent : Node
-        The parent node for embedding the marker in the scene.
-    center : tuple
-        The center of the marker in pixels.
-    rect_width : int
-        The width of the rectangle in pixels.
-    rect_height : int
-        The height of the rectangle in pixels.
-    rect_color : str
-        The color of the rectangle.
-    rect_thickness : int
-        The thickness of the rectangle border in pixels.
-    show_rect : bool
-        Whether to show the rectangle.
-    marker_symbol : str
-        The symbol to use for the marker. This can be any of the symbols
-        supported by the Markers visual: 'disc', 'arrow', 'ring', 'clobber', 'square',
-        'x', 'diamond', 'vbar', 'hbar', 'cross', 'tailed_arrow', 'triangle_up',
-        'triangle_down', 'star', 'cross_lines', 'o', '+', '++', 's', '-', '|', '->',
-        '>', '^', 'v', '*'. By default, '++'.
-    marker_symbol_color : str
-        The color of the symbol.
-    marker_symbol_size : int
-        The size of the symbol in pixels.
-    show_marker_symbol : bool
-        Whether to show the symbol.
-    marker_symbol_edge_width : float
-        The edge width of the symbol in pixels.
-    """
+class StagePositionMarker(Compound):
+    """A vispy CompoundVisual for a stage-position marker (rect + symbol)."""
 
     def __init__(
         self,
         parent: Node,
         *,
-        center: tuple = (0, 0),
+        center: tuple[float, float] = (0, 0),
         rect_width: int = 50,
         rect_height: int = 50,
         rect_color: str = GREEN,
@@ -63,171 +26,41 @@ class StagePositionMarker(Node):
         marker_symbol_size: float = 15,
         marker_symbol_edge_width: float = 10,
         show_marker_symbol: bool = True,
-    ):
-        super().__init__(parent)
-
-        self._view_scene = parent
-
-        self._stage_position_marker_transform: MatrixTransform = MatrixTransform()
-
-        self._rect: Rectangle | None = None
-        self._marker: Markers | None = None
-
-        self._center = center
-
-        self._show_rect = show_rect
-        self._show_marker_symbol = show_marker_symbol
-
-        self._rect_width = rect_width
-        self._rect__height = rect_height
-        self._rect_color: str = rect_color
-        self._rect_thickness: int = rect_thickness
-
-        self._marker_symbol: str = marker_symbol
-        self._marker_symbol_color: str = marker_symbol_color
-        self._marker_symbol_size: float = marker_symbol_size
-        self._marker_symbol_edge_width: float = marker_symbol_edge_width
-
-        # rectangle
-        self.show_rectangle(show_rect)
-
-        # symbol marker
-        self.show_marker(show_marker_symbol)
-
-    # -----------------------PUBLIC METHODS-----------------------
-
-    @property
-    def center(self) -> tuple[float, float]:
-        """Get the center of the marker."""
-        return self._center
-
-    @property
-    def transform(self) -> MatrixTransform:
-        """Get the transform of the marker."""
-        return self._stage_position_marker_transform
-
-    def bounds(
-        self, axis: int, view: VisualView | None = None
-    ) -> tuple[float, float] | None:
-        """Return the bounds that enclose both the rectangle and the marker."""
-        bounds = []
-
-        if self._rect is not None:
-            rect_bounds = self._rect.bounds(axis, view)
-            if rect_bounds is not None:
-                bounds.append(rect_bounds)
-
-        if self._marker is not None:
-            marker_bounds = self._marker.bounds(axis, view)
-            if marker_bounds is not None:
-                bounds.append(marker_bounds)
-
-        if not bounds:
-            return None
-
-        # combine all bounds
-        mins = [b[0] for b in bounds if b[0] is not None]
-        maxs = [b[1] for b in bounds if b[1] is not None]
-
-        return (min(mins), max(maxs)) if mins and maxs else None
-
-    def delete_stage_marker(self) -> None:
-        """Remove the both the rectangle and the marker from the scene."""
-        if self._rect is not None:
-            self._rect.parent = None
-            self._rect = None
-        if self._marker is not None:
-            self._marker.parent = None
-            self._marker = None
-
-    def show_stage_position_marker(self, show: bool) -> None:
-        """Show or hide the stage position marker as a whole."""
-        self.show_rectangle(show)
-        self.show_marker(show)
-
-    def show_rectangle(self, show: bool) -> None:
-        """Show or hide the rectangle."""
-        # if the rectangle does not exist and show is False, do nothing
-        if self._rect is None and not show:
-            return
-        self._show_rect = show
-        # create the rectangle if it does not exist and show is True
-        if self._rect is None:
-            self._add_rectangle()
-        # if the rectangle exists, set its parent to the view scene
-        elif show:
-            self._rect.parent = self._view_scene
-        # if the rectangle exists and show is False, set its parent to None
-        else:
-            self._rect.parent = None
-
-    def show_marker(self, show: bool) -> None:
-        """Show or hide the marker."""
-        # if the marker does not exist and show is False, do nothing
-        if self._marker is None and not show:
-            return
-        self._show_marker_symbol = show
-        # create the marker if it does not exist and show is True
-        if self._marker is None:
-            self._add_marker()
-        # if the marker exists, set its parent to the view scene
-        elif show:
-            self._marker.parent = self._view_scene
-        # if the marker exists and show is False, set its parent to None
-        else:
-            self._marker.parent = None
-
-    def applyTransform(self, matrix: np.ndarray) -> None:
-        """Apply a transformation to both the rectangle and the marker."""
-        if self._rect is None and self._marker is None:
-            return
-        transform = MatrixTransform(matrix=matrix)
-        self._stage_position_marker_transform = transform
-        if self._rect is not None:
-            self._rect.transform = transform
-        if self._marker is not None:
-            self._marker.transform = transform
-
-    # -----------------------PRIVATE METHODS-----------------------
-
-    def _delete_rectangle(self) -> None:
-        """Remove the rectangle from the scene."""
-        if self._rect is not None:
-            self._rect.parent = None
-            self._rect = None
-
-    def _delete_marker(self) -> None:
-        """Remove the marker from the scene."""
-        if self._marker is not None:
-            self._marker.parent = None
-            self._marker = None
-
-    def _add_rectangle(self) -> None:
-        """Add the rectangle to the scene."""
-        # clear the previous rectangle if it exists
-        self._delete_rectangle()
+    ) -> None:
         self._rect = Rectangle(
-            parent=self._view_scene if self._show_rect else None,
-            center=self._center,
-            width=self._rect_width,
-            height=self._rect__height,
-            border_width=self._rect_thickness,
-            border_color=Color(self._rect_color),
+            center=center,
+            width=rect_width,
+            height=rect_height,
+            border_width=rect_thickness,
+            border_color=Color(rect_color),
             color=Color("transparent"),
         )
-        self._rect.set_gl_state(depth_test=False)
 
-    def _add_marker(self) -> None:
-        """Add the symbol to the scene."""
-        self._delete_marker()
         self._marker = Markers(
-            parent=self._view_scene if self._show_marker_symbol else None,
-            pos=np.array([self._center]),
-            face_color=Color(self._marker_symbol_color),
-            edge_color=Color(self._marker_symbol_color),
-            symbol=self._marker_symbol,
-            size=self._marker_symbol_size,
-            edge_width=self._marker_symbol_edge_width,
+            pos=np.array([center]),
+            symbol=marker_symbol,
+            face_color=Color(marker_symbol_color),
+            edge_color=Color(marker_symbol_color),
+            size=marker_symbol_size,
+            edge_width=marker_symbol_edge_width,
             scaling=True,
         )
-        self._marker.set_gl_state(depth_test=False)
+
+        super().__init__([self._marker, self._rect])
+
+        self.parent = parent
+        self._rect.visible = show_rect
+        self._marker.visible = show_marker_symbol
+        self.set_gl_state(depth_test=False)
+
+    def set_rect_visible(self, show: bool) -> None:
+        """Toggle the rectangle border."""
+        self._rect.visible = show
+
+    def set_marker_visible(self, show: bool) -> None:
+        """Toggle the center symbol."""
+        self._marker.visible = show
+
+    def apply_transform(self, mat: np.ndarray) -> None:
+        """Apply a uniform transform to both sub-visuals."""
+        self.transform = MatrixTransform(matrix=mat)

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from vispy.color import Color
+from vispy.scene import MatrixTransform, Node
+from vispy.scene.visuals import Markers, Rectangle
+
+if TYPE_CHECKING:
+    from vispy.visuals.visual import VisualView
+
+GREEN = "#3A3"
+
+
+class StagePositionMarker(Node):
+    """A vispy Visual to use as stage position marker.
+
+    Parameters
+    ----------
+    parent : Node
+        The parent node for embedding the marker in the scene.
+    center : tuple
+        The center of the marker in pixels.
+    rect_width : int
+        The width of the rectangle in pixels.
+    rect_height : int
+        The height of the rectangle in pixels.
+    rect_color : str
+        The color of the rectangle.
+    rect_thickness : int
+        The thickness of the rectangle border in pixels.
+    show_rect : bool
+        Whether to show the rectangle.
+    marker_symbol : str
+        The symbol to use for the marker. This can be any of the symbols
+        supported by the Markers visual: disc, arrow, ring, clobber, square, diamond,
+        vbar, hbar, cross, tailed_arrow, x, triangle_up, triangle_down, and star.
+    marker_symbol_color : str
+        The color of the symbol.
+    marker_symbol_size : int
+        The size of the symbol in pixels.
+    show_marker_symbol : bool
+        Whether to show the symbol.
+    """
+
+    def __init__(
+        self,
+        parent: Node,
+        *,
+        center: tuple = (0, 0),
+        rect_width: int = 50,
+        rect_height: int = 50,
+        rect_color: str = GREEN,
+        rect_thickness: int = 4,
+        show_rect: bool = True,
+        marker_symbol: str = "x",
+        marker_symbol_color: str = GREEN,
+        marker_symbol_size: float = 15,
+        show_marker_symbol: bool = True,
+    ):
+        super().__init__(parent)
+
+        self._view_scene = parent
+
+        self._stage_position_marker_transform: MatrixTransform = MatrixTransform()
+
+        self._rect: Rectangle | None = None
+        self._marker: Markers | None = None
+
+        self._center = center
+
+        self._show_rect = show_rect
+        self._show_marker_symbol = show_marker_symbol
+
+        self._rect_width = rect_width
+        self._rect__height = rect_height
+        self._rect_color: str = rect_color
+        self._rect_thickness: int = rect_thickness
+
+        self._marker_symbol: str = marker_symbol
+        self._marker_symbol_color: str = marker_symbol_color
+        self._marker_symbol_size: float = marker_symbol_size
+
+        # rectangle
+        self.show_rectangle(show_rect)
+
+        # symbol marker
+        self.show_marker(show_marker_symbol)
+
+    # -----------------------PUBLIC METHODS-----------------------
+
+    @property
+    def center(self) -> tuple[float, float]:
+        """Get the center of the marker."""
+        return self._center
+
+    @property
+    def transform(self) -> MatrixTransform:
+        """Get the transform of the marker."""
+        return self._stage_position_marker_transform
+
+    def bounds(
+        self, axis: int, view: VisualView | None = None
+    ) -> tuple[float, float] | None:
+        """Return the bounds that enclose both the rectangle and the marker."""
+        bounds = []
+
+        if self._rect is not None:
+            rect_bounds = self._rect.bounds(axis, view)
+            if rect_bounds is not None:
+                bounds.append(rect_bounds)
+
+        if self._marker is not None:
+            marker_bounds = self._marker.bounds(axis, view)
+            if marker_bounds is not None:
+                bounds.append(marker_bounds)
+
+        if not bounds:
+            return None
+
+        # combine all bounds
+        mins = [b[0] for b in bounds if b[0] is not None]
+        maxs = [b[1] for b in bounds if b[1] is not None]
+
+        return (min(mins), max(maxs)) if mins and maxs else None
+
+    def delete_stage_marker(self) -> None:
+        """Remove the both the rectangle and the marker from the scene."""
+        if self._rect is not None:
+            self._rect.parent = None
+            self._rect = None
+        if self._marker is not None:
+            self._marker.parent = None
+            self._marker = None
+
+    def show_stage_position_marker(self, show: bool) -> None:
+        """Show or hide the stage position marker as a whole."""
+        self.show_rectangle(show)
+        self.show_marker(show)
+
+    def show_rectangle(self, show: bool) -> None:
+        """Show or hide the rectangle."""
+        # if the rectangle does not exist and show is False, do nothing
+        if self._rect is None and not show:
+            return
+        self._show_rect = show
+        # create the rectangle if it does not exist and show is True
+        if self._rect is None:
+            self._add_rectangle()
+        # if the rectangle exists, set its parent to the view scene
+        elif show:
+            self._rect.parent = self._view_scene
+        # if the rectangle exists and show is False, set its parent to None
+        else:
+            self._rect.parent = None
+
+    def show_marker(self, show: bool) -> None:
+        """Show or hide the marker."""
+        # if the marker does not exist and show is False, do nothing
+        if self._marker is None and not show:
+            return
+        self._show_marker_symbol = show
+        # create the marker if it does not exist and show is True
+        if self._marker is None:
+            self._add_marker()
+        # if the marker exists, set its parent to the view scene
+        elif show:
+            self._marker.parent = self._view_scene
+        # if the marker exists and show is False, set its parent to None
+        else:
+            self._marker.parent = None
+
+    def applyTransform(self, matrix: np.ndarray) -> None:
+        """Apply a transformation to both the rectangle and the marker."""
+        if self._rect is None and self._marker is None:
+            return
+        transform = MatrixTransform(matrix=matrix)
+        self._stage_position_marker_transform = transform
+        if self._rect is not None:
+            self._rect.transform = transform
+        if self._marker is not None:
+            self._marker.transform = transform
+
+    # -----------------------PRIVATE METHODS-----------------------
+
+    def _delete_rectangle(self) -> None:
+        """Remove the rectangle from the scene."""
+        if self._rect is not None:
+            self._rect.parent = None
+            self._rect = None
+
+    def _delete_marker(self) -> None:
+        """Remove the marker from the scene."""
+        if self._marker is not None:
+            self._marker.parent = None
+            self._marker = None
+
+    def _add_rectangle(self) -> None:
+        """Add the rectangle to the scene."""
+        # clear the previous rectangle if it exists
+        self._delete_rectangle()
+        self._rect = Rectangle(
+            parent=self._view_scene if self._show_rect else None,
+            center=self._center,
+            width=self._rect_width,
+            height=self._rect__height,
+            border_width=self._rect_thickness,
+            border_color=Color(self._rect_color),
+            color=Color("transparent"),
+        )
+        self._rect.set_gl_state(depth_test=False)
+
+    def _add_marker(self) -> None:
+        """Add the symbol to the scene."""
+        self._delete_marker()
+        self._marker = Markers(
+            parent=self._view_scene if self._show_marker_symbol else None,
+            pos=np.array([self._center]),
+            face_color=Color(self._marker_symbol_color),
+            edge_color=Color(self._marker_symbol_color),
+            symbol=self._marker_symbol,
+            size=self._marker_symbol_size,
+            scaling=True,
+        )
+        self._marker.set_gl_state(depth_test=False)

--- a/src/pymmcore_widgets/control/_stage_explorer/auto_zoom_to_fit_icon.svg
+++ b/src/pymmcore_widgets/control/_stage_explorer/auto_zoom_to_fit_icon.svg
@@ -22,7 +22,7 @@
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
      inkscape:zoom="33.351483"
-     inkscape:cx="18.694821"
+     inkscape:cx="18.709813"
      inkscape:cy="12.862996"
      inkscape:window-width="1728"
      inkscape:window-height="1051"
@@ -44,12 +44,12 @@
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.0796px;font-family:Helvetica;-inkscape-font-specification:'Helvetica, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:0.839969"
      x="8.5317869"
-     y="15.408301"
+     y="15.143373"
      id="text1"
      transform="scale(0.98175197,1.0185872)"><tspan
        sodipodi:role="line"
        id="tspan1"
        x="8.5317869"
-       y="15.408301"
+       y="15.143373"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.0796px;font-family:Helvetica;-inkscape-font-specification:'Helvetica, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#666666;stroke-width:0.839969">A</tspan></text>
 </svg>

--- a/src/pymmcore_widgets/control/_stage_explorer/auto_zoom_to_fit_icon.svg
+++ b/src/pymmcore_widgets/control/_stage_explorer/auto_zoom_to_fit_icon.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="auto_zoom_to_fit_icon.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true"
+     inkscape:zoom="33.351483"
+     inkscape:cx="18.694821"
+     inkscape:cy="12.862996"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1">
+    <sodipodi:guide
+       position="13.348174,11.951205"
+       orientation="0,-1"
+       id="guide1"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <path
+     d="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z"
+     id="path1"
+     fill="#666666" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.0796px;font-family:Helvetica;-inkscape-font-specification:'Helvetica, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:0.839969"
+     x="8.5317869"
+     y="15.408301"
+     id="text1"
+     transform="scale(0.98175197,1.0185872)"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="8.5317869"
+       y="15.408301"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.0796px;font-family:Helvetica;-inkscape-font-specification:'Helvetica, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#666666;stroke-width:0.839969">A</tspan></text>
+</svg>

--- a/tests/test_stage_explorer.py
+++ b/tests/test_stage_explorer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from qtpy.QtWidgets import QToolBar
 from vispy.app.canvas import MouseEvent
 from vispy.scene.visuals import Image
 
@@ -100,8 +99,7 @@ def test_stage_explorer_actions(qtbot: QtBot) -> None:
     qtbot.addWidget(explorer)
     explorer.add_image(IMG, 0, 0)
 
-    tb = explorer.findChild(QToolBar)
-    actions = tb.actions()
+    actions = explorer.toolBar().actions()
     snap_action = next(a for a in actions if a.text() == _stage_explorer.SNAP)
     with qtbot.waitSignal(snap_action.triggered):
         snap_action.trigger()
@@ -121,6 +119,23 @@ def test_stage_explorer_move_on_click(qtbot: QtBot) -> None:
         explorer._move_to_clicked_position(event)
 
     assert explorer._mmc.getXYPosition() != stage_pos
+
+
+def test_stage_explorer_position_indicator(qtbot: QtBot) -> None:
+    explorer = StageExplorer()
+    qtbot.addWidget(explorer)
+
+    poll_action = explorer._actions[_stage_explorer.POLL_STAGE]
+    with qtbot.waitSignal(poll_action.triggered):
+        poll_action.trigger()
+
+    assert explorer._poll_stage_position is True
+    assert explorer._timer_id is not None
+
+    # wait for timerEvent to be triggered
+    qtbot.waitUntil(lambda: explorer._stage_pos_marker is not None, timeout=1000)
+    assert explorer._stage_pos_marker is not None
+    assert explorer._stage_pos_marker.visible
 
 
 # to add 5deg rotation

--- a/tests/test_stage_explorer.py
+++ b/tests/test_stage_explorer.py
@@ -121,3 +121,7 @@ def test_stage_explorer_move_on_click(qtbot: QtBot) -> None:
         explorer._move_to_clicked_position(event)
 
     assert explorer._mmc.getXYPosition() != stage_pos
+
+
+# to add 5deg rotation
+# mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))

--- a/tests/test_stage_explorer.py
+++ b/tests/test_stage_explorer.py
@@ -137,6 +137,13 @@ def test_stage_explorer_position_indicator(qtbot: QtBot) -> None:
     assert explorer._stage_pos_marker is not None
     assert explorer._stage_pos_marker.visible
 
+    with qtbot.waitSignal(poll_action.triggered):
+        poll_action.trigger()
+
+    assert explorer._poll_stage_position is False
+    assert explorer._stage_pos_marker is None
+    assert explorer._timer_id is None
+
 
 # to add 5deg rotation
 # mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))


### PR DESCRIPTION
Third part of the stage explore widget (#400 ) after #420.

Here we add a stage marker to track the position of the microscope stage.  

TODO:
- [ ] add tests