### PR TITLE
fix: Stage controller objects that batch repeated relative/absolute calls and emit moveFinished when done

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.32.0
     hooks:
       - id: typos
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,5 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - pymmcore-plus >=0.13.4
+          - pymmcore-plus >=0.14.0
           - useq-schema >=0.5.0

--- a/examples/stage_explorer_widget.py
+++ b/examples/stage_explorer_widget.py
@@ -9,15 +9,9 @@ app = QApplication([])
 mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
 
-# add a small rotation
-# mmc.setPixelSizeAffine("Res10x", (0.9962, -0.0872, 0.0, 0.0872, 0.9962, 0.0))
-# mmc.setPixelSizeAffine("Res20x", (0.4981, -0.0436, 0.0, 0.0436, 0.4981, 0.0))
-# mmc.setPixelSizeAffine("Res40x", (0.24905, -0.0218, 0.0, 0.0218, 0.24905, 0.0))
-
 # set camera roi (rectangular helps confirm orientation)
 mmc.setROI(0, 0, 400, 500)
 
-mmc.setProperty("XY", "Velocity", 1)
 
 explorer = StageExplorer()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'fonticon-materialdesignicons6',
-    'pymmcore-plus[cli] >=0.13.7',
+    'pymmcore-plus[cli] >=0.14.0',
     'qtpy >=2.0',
     'superqt[quantity,cmap,iconify] >=0.7.1',
     'useq-schema >=0.5.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ Documentation = "https://pymmcore-plus.github.io/pymmcore-widgets"
 line-length = 88
 target-version = "py39"
 src = ["src", "tests"]
+fix = true
+unsafe-fixes = true
 
 [tool.ruff.lint]
 pydocstyle = { convention = "numpy" }
@@ -130,7 +132,7 @@ select = [
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
     "TID",  # tidy
-    "TCH",  # typecheck
+    "TC",  # typecheck
 ]
 ignore = [
     "D100", # Missing docstring in public module

--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -142,10 +142,10 @@ class _ValueBatcher(Generic[T]):
         # issue the move command
         try:
             self._fset(target)
-        except Exception as e:  # pragma: no cover
-            CMMCorePlus.instance().logMessage(
-                f"Error setting ValueBatcher to {target}: {e}"
-            )
+        except Exception:  # pragma: no cover
+            from pymmcore_plus._logger import logger
+
+            logger.exception(f"Error setting ValueBatcher to {target}")
         self._last_issued_seq = self._seq
 
 

--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -140,7 +140,12 @@ class _ValueBatcher(Generic[T]):
         # self._base and self._delta are guaranteed to be not None here
         target = self._fadd(self._base, self._delta)  # type: ignore[arg-type]
         # issue the move command
-        self._fset(target)
+        try:
+            self._fset(target)
+        except Exception as e:  # pragma: no cover
+            CMMCorePlus.instance().logMessage(
+                f"Error setting ValueBatcher to {target}: {e}"
+            )
         self._last_issued_seq = self._seq
 
 

--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -226,7 +226,7 @@ def get_stage_batcher(
 class QStageController(QObject):
     moveFinished = Signal()
 
-    def __init__(self, device: str, mmcore: CMMCorePlus, *, poll_ms: int = 10):
+    def __init__(self, device: str, mmcore: CMMCorePlus, *, poll_ms: int = 20):
         super().__init__()
         self._batcher = get_stage_batcher(device, mmcore)
         self._batcher.finished.connect(self.moveFinished.emit)

--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Generic, TypeVar
+
+import psygnal
+from pymmcore_plus import CMMCorePlus, DeviceType
+from qtpy.QtCore import QObject, QTimerEvent, Signal
+
+# ------------------ Qt agnostic ... could move to pymmcore-plus ---------
+
+T = TypeVar("T")
+
+
+class _ValueBatcher(Generic[T]):
+    """Batches a series of setX calls to a device.
+
+    Abstractly, any device that can get/set a numeric value (i.e. something that can be
+    added) can be used with this class.
+
+    For example, this could be used with a stage device to batch a series of relative
+    moves. Each time set_relative() is called, the target value is updated
+    internally. Some external event loop (polling, timer, etc.) should call
+    `poll_done()` to check if the device is busy.  If it returns `True`, it means that
+    the device is idle and has reached the target position.
+
+    Decoupling here makes it easier to use this class with different event loops or
+    threading models.
+
+    This class is not thread-safe. It is assumed that the event loop calling poll_done()
+    is the same thread that called set_relative().  If you need to call this from
+    different threads, you should use a mutex or other synchronization mechanism to
+    ensure that only one thread is mutating the state of this class at a time.
+
+    Parameters
+    ----------
+    fget : Callable[[], T]
+        Function to get the current position of the device.
+    fset : Callable[[T], None]
+        Function to set the position of the device.
+    fadd : Callable[[T, T], T]
+        Function to add two values together.
+    fbusy : Callable[[], bool]
+        Function that returns True if the device is busy.
+    zero : T
+        An identity ("zero") value for the fadd function. Adding this value to any
+        value T should return T.  This is used to reset the delta value when moving
+        to an absolute position.
+    """
+
+    finished = psygnal.Signal()
+    """Signal emitted when the device has finished moving."""
+
+    def __init__(
+        self,
+        fget: Callable[[], T],
+        fset: Callable[[T], None],
+        fadd: Callable[[T, T], T],
+        fbusy: Callable[[], bool],
+        zero: T,
+    ) -> None:
+        self._fget = fget
+        self._fset = fset
+        self._fadd = fadd
+        self._fbusy = fbusy
+        self._zero = zero
+        self._reset()
+
+    def _reset(self) -> None:
+        # --- batch state ---
+        self._seq = 0  # bumps on every move_relative()
+        self._last_issued_seq = 0  # seq at time of last fset()
+        self._base: T | None = None
+        self._delta: T | None = None
+
+    @property
+    def is_moving(self) -> bool:
+        """Returns True if the device is moving."""
+        return self._delta is not None
+
+    def poll_done(self) -> bool:
+        """Call repeatedly to check if the device is done moving.
+
+        Returns True exactly once when:
+        1. The device is idle (not busy) AND
+        2. The last issued move command has been completed
+
+        After returning True it resets its state and will return False until the next
+        move_relative() call.
+        """
+        # if we have no base or delta, we're not moving
+        if self._delta is None:
+            return False
+
+        # if the device is busy, we're not done
+        if self._fbusy():
+            return False
+
+        # if new calls arrived since we last fset(), re-issue
+        if self._seq != self._last_issued_seq:
+            self._issue_move()
+            return False
+
+        # no new work, we're done
+        self._reset()
+        self.finished.emit()
+        return True
+
+    def add_relative(self, delta: T) -> None:
+        """Add a relative value to the batch."""
+        self._seq += 1
+
+        if self._delta is None:
+            # start new batch
+            self._base = self._fget()
+            self._delta = delta
+        else:
+            self._delta = self._fadd(self._delta, delta)
+        self._issue_move()
+
+    def set_absolute(self, target: T) -> None:
+        """Assign an absolute target position to the batch.
+
+        This will reset the batch state and issue a move to the target position.
+        After the move finishes, new `move_relative()` calls are interpreted
+        relative to *target*.
+        """
+        self._seq += 1  # new batch → new sequence id
+        self._base = target  # anchor for later relatives
+        self._delta = self._zero  # target == base + delta
+        self._issue_move()
+
+    @property
+    def target(self) -> T | None:
+        """The target position of the stage.  Or None if not moving."""
+        if self._base is None or self._delta is None:
+            return None
+        return self._fadd(self._base, self._delta)
+
+    def _issue_move(self) -> None:
+        # self._base and self._delta are guaranteed to be not None here
+        target = self._fadd(self._base, self._delta)  # type: ignore[arg-type]
+        # issue the move command
+        self._fset(target)
+        self._last_issued_seq = self._seq
+
+
+class StageBatcher(_ValueBatcher[float]):
+    """Batcher for single axis stage devices.
+
+    This is a specialized version of _ValueBatcher that works with single axis stage
+    devices. It uses the CMMCorePlus API to get and set the position of the stage.
+    """
+
+    def __init__(self, device: str | None, mmcore: CMMCorePlus | None) -> None:
+        mmcore = mmcore or CMMCorePlus.instance()
+        if device is None:
+            device = mmcore.getFocusDevice()
+            if not device:
+                raise ValueError("No XY stage device found.")
+        if not mmcore.getDeviceType(device) == DeviceType.StageDevice:
+            raise ValueError(f"Device {device} is not a stage device.")
+
+        super().__init__(
+            fget=lambda: mmcore.getPosition(device),
+            fset=lambda pos: mmcore.setPosition(device, pos),
+            fadd=lambda a, b: a + b,
+            fbusy=lambda: mmcore.deviceBusy(device),
+            zero=0.0,
+        )
+
+
+class XYStageBatcher(_ValueBatcher[tuple[float, float]]):
+    """Batcher for XY stage devices.
+
+    This is a specialized version of _ValueBatcher that works with XY stage devices. It
+    uses the CMMCorePlus API to get and set the position of the stage.
+    """
+
+    def __init__(self, device: str | None, mmcore: CMMCorePlus | None) -> None:
+        mmcore = mmcore or CMMCorePlus.instance()
+        if device is None:
+            device = mmcore.getXYStageDevice()
+            if not device:
+                raise ValueError("No XY stage device found.")
+        if not mmcore.getDeviceType(device) == DeviceType.XYStageDevice:
+            raise ValueError(f"Device {device} is not a stage device.")
+
+        super().__init__(
+            fget=lambda: tuple(mmcore.getXYPosition(device)),  # type: ignore
+            fset=lambda pos: mmcore.setXYPosition(device, pos[0], pos[1]),
+            fadd=lambda a, b: (a[0] + b[0], a[1] + b[1]),
+            fbusy=lambda: mmcore.deviceBusy(device),
+            zero=(0.0, 0.0),
+        )
+
+
+_STAGE_BATCHERS: dict[tuple[int, str], StageBatcher | XYStageBatcher] = {}
+
+
+def get_stage_batcher(
+    device: str, mmcore: CMMCorePlus | None = None
+) -> StageBatcher | XYStageBatcher:
+    """Get a stage batcher for the given device."""
+    mmcore = mmcore or CMMCorePlus.instance()
+    key = (id(mmcore), device)
+    if key not in _STAGE_BATCHERS:
+        if mmcore.getDeviceType(device) == DeviceType.XYStageDevice:
+            _STAGE_BATCHERS[key] = XYStageBatcher(device, mmcore)
+        elif mmcore.getDeviceType(device) == DeviceType.StageDevice:
+            _STAGE_BATCHERS[key] = StageBatcher(device, mmcore)
+        else:
+            raise ValueError(f"Device {device} is not a stage device.")
+
+        # pop the key on mmcore.events.systemConfigurationLoaded?
+        @mmcore.events.systemConfigurationLoaded.connect
+        def _on_system_configuration_loaded() -> None:
+            # remove the batcher from the cache
+            _STAGE_BATCHERS.pop(key, None)
+
+    return _STAGE_BATCHERS[key]
+
+
+# -------------------------------- Qt specific --------------------------------
+
+
+class QStageController(QObject):
+    moveFinished = Signal()
+
+    def __init__(self, device: str, mmcore: CMMCorePlus, *, poll_ms: int = 10):
+        super().__init__()
+        self._batcher = get_stage_batcher(device, mmcore)
+        self._batcher.finished.connect(self.moveFinished.emit)
+        self._poll_ms = poll_ms
+        self._timer_id: int | None = None
+
+    def move_relative(self, delta: Any) -> None:
+        self._batcher.add_relative(delta)
+        if self._timer_id is None:
+            self._timer_id = self.startTimer(self._poll_ms)
+
+    def move_absolute(self, target: Any) -> None:
+        self._batcher.set_absolute(target)
+        if self._timer_id is None:
+            self._timer_id = self.startTimer(self._poll_ms)
+
+    def timerEvent(self, event: QTimerEvent | None) -> None:
+        device_idle = self._batcher.poll_done()
+        if device_idle is True and self._timer_id is not None:
+            self.killTimer(self._timer_id)
+            self._timer_id = None
+
+
+_Q_STAGE_CONTROLLERS: dict[tuple[int, str], QStageController] = {}
+
+
+def get_q_stage_controller(
+    device: str, mmcore: CMMCorePlus | None = None
+) -> QStageController:
+    """Get a stage controller for the given device."""
+    mmcore = mmcore or CMMCorePlus.instance()
+    key = (id(mmcore), device)
+    if key not in _Q_STAGE_CONTROLLERS:
+        _Q_STAGE_CONTROLLERS[key] = QStageController(device, mmcore)
+    return _Q_STAGE_CONTROLLERS[key]

--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -1,269 +1,54 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any
 
-import psygnal
-from pymmcore_plus import CMMCorePlus, DeviceType
+from pymmcore_plus import AbstractChangeAccumulator, CMMCorePlus, core
 from qtpy.QtCore import QObject, QTimerEvent, Signal
 
-# ------------------ Qt agnostic ... could move to pymmcore-plus ---------
 
-T = TypeVar("T")
-
-
-class _ValueBatcher(Generic[T]):
-    """Batches a series of setX calls to a device.
-
-    Abstractly, any device that can get/set a numeric value (i.e. something that can be
-    added) can be used with this class.
-
-    For example, this could be used with a stage device to batch a series of relative
-    moves. Each time set_relative() is called, the target value is updated
-    internally. Some external event loop (polling, timer, etc.) should call
-    `poll_done()` to check if the device is busy.  If it returns `True`, it means that
-    the device is idle and has reached the target position.
-
-    Decoupling here makes it easier to use this class with different event loops or
-    threading models.
-
-    This class is not thread-safe. It is assumed that the event loop calling poll_done()
-    is the same thread that called set_relative().  If you need to call this from
-    different threads, you should use a mutex or other synchronization mechanism to
-    ensure that only one thread is mutating the state of this class at a time.
-
-    Parameters
-    ----------
-    fget : Callable[[], T]
-        Function to get the current position of the device.
-    fset : Callable[[T], None]
-        Function to set the position of the device.
-    fadd : Callable[[T, T], T]
-        Function to add two values together.
-    fbusy : Callable[[], bool]
-        Function that returns True if the device is busy.
-    zero : T
-        An identity ("zero") value for the fadd function. Adding this value to any
-        value T should return T.  This is used to reset the delta value when moving
-        to an absolute position.
-    """
-
-    finished = psygnal.Signal()
-    """Signal emitted when the device has finished moving."""
-
-    def __init__(
-        self,
-        fget: Callable[[], T],
-        fset: Callable[[T], None],
-        fadd: Callable[[T, T], T],
-        fbusy: Callable[[], bool],
-        zero: T,
-    ) -> None:
-        self._fget = fget
-        self._fset = fset
-        self._fadd = fadd
-        self._fbusy = fbusy
-        self._zero = zero
-        self._reset()
-
-    def _reset(self) -> None:
-        # --- batch state ---
-        self._seq = 0  # bumps on every move_relative()
-        self._last_issued_seq = 0  # seq at time of last fset()
-        self._base: T | None = None
-        self._delta: T | None = None
-
-    @property
-    def is_moving(self) -> bool:
-        """Returns True if the device is moving."""
-        return self._delta is not None
-
-    def poll_done(self) -> bool:
-        """Call repeatedly to check if the device is done moving.
-
-        Returns True exactly once when:
-        1. The device is idle (not busy) AND
-        2. The last issued move command has been completed
-
-        After returning True it resets its state and will return False until the next
-        move_relative() call.
-        """
-        # if we have no base or delta, we're not moving
-        if self._delta is None:
-            return False
-
-        # if the device is busy, we're not done
-        if self._fbusy():
-            return False
-
-        # if new calls arrived since we last fset(), re-issue
-        if self._seq != self._last_issued_seq:
-            self._issue_move()
-            return False
-
-        # no new work, we're done
-        self._reset()
-        self.finished.emit()
-        return True
-
-    def add_relative(self, delta: T) -> None:
-        """Add a relative value to the batch."""
-        self._seq += 1
-
-        if self._delta is None:
-            # start new batch
-            self._base = self._fget()
-            self._delta = delta
-        else:
-            self._delta = self._fadd(self._delta, delta)
-        self._issue_move()
-
-    def set_absolute(self, target: T) -> None:
-        """Assign an absolute target position to the batch.
-
-        This will reset the batch state and issue a move to the target position.
-        After the move finishes, new `move_relative()` calls are interpreted
-        relative to *target*.
-        """
-        self._seq += 1  # new batch → new sequence id
-        self._base = target  # anchor for later relatives
-        self._delta = self._zero  # target == base + delta
-        self._issue_move()
-
-    @property
-    def target(self) -> T | None:
-        """The target position of the stage.  Or None if not moving."""
-        if self._base is None or self._delta is None:
-            return None
-        return self._fadd(self._base, self._delta)
-
-    def _issue_move(self) -> None:
-        # self._base and self._delta are guaranteed to be not None here
-        target = self._fadd(self._base, self._delta)  # type: ignore[arg-type]
-        # issue the move command
-        try:
-            self._fset(target)
-        except Exception:  # pragma: no cover
-            from pymmcore_plus._logger import logger
-
-            logger.exception(f"Error setting ValueBatcher to {target}")
-        self._last_issued_seq = self._seq
-
-
-class StageBatcher(_ValueBatcher[float]):
-    """Batcher for single axis stage devices.
-
-    This is a specialized version of _ValueBatcher that works with single axis stage
-    devices. It uses the CMMCorePlus API to get and set the position of the stage.
-    """
-
-    def __init__(self, device: str | None, mmcore: CMMCorePlus | None) -> None:
-        mmcore = mmcore or CMMCorePlus.instance()
-        if device is None:
-            device = mmcore.getFocusDevice()
-            if not device:
-                raise ValueError("No XY stage device found.")
-        if not mmcore.getDeviceType(device) == DeviceType.StageDevice:
-            raise ValueError(f"Device {device} is not a stage device.")
-
-        super().__init__(
-            fget=lambda: mmcore.getPosition(device),
-            fset=lambda pos: mmcore.setPosition(device, pos),
-            fadd=lambda a, b: a + b,
-            fbusy=lambda: mmcore.deviceBusy(device),
-            zero=0.0,
-        )
-
-
-class XYStageBatcher(_ValueBatcher[tuple[float, float]]):
-    """Batcher for XY stage devices.
-
-    This is a specialized version of _ValueBatcher that works with XY stage devices. It
-    uses the CMMCorePlus API to get and set the position of the stage.
-    """
-
-    def __init__(self, device: str | None, mmcore: CMMCorePlus | None) -> None:
-        mmcore = mmcore or CMMCorePlus.instance()
-        if device is None:
-            device = mmcore.getXYStageDevice()
-            if not device:
-                raise ValueError("No XY stage device found.")
-        if not mmcore.getDeviceType(device) == DeviceType.XYStageDevice:
-            raise ValueError(f"Device {device} is not a stage device.")
-
-        super().__init__(
-            fget=lambda: tuple(mmcore.getXYPosition(device)),  # type: ignore
-            fset=lambda pos: mmcore.setXYPosition(device, pos[0], pos[1]),
-            fadd=lambda a, b: (a[0] + b[0], a[1] + b[1]),
-            fbusy=lambda: mmcore.deviceBusy(device),
-            zero=(0.0, 0.0),
-        )
-
-
-_STAGE_BATCHERS: dict[tuple[int, str], StageBatcher | XYStageBatcher] = {}
-
-
-def get_stage_batcher(
-    device: str, mmcore: CMMCorePlus | None = None
-) -> StageBatcher | XYStageBatcher:
-    """Get a stage batcher for the given device."""
-    mmcore = mmcore or CMMCorePlus.instance()
-    key = (id(mmcore), device)
-    if key not in _STAGE_BATCHERS:
-        if mmcore.getDeviceType(device) == DeviceType.XYStageDevice:
-            _STAGE_BATCHERS[key] = XYStageBatcher(device, mmcore)
-        elif mmcore.getDeviceType(device) == DeviceType.StageDevice:
-            _STAGE_BATCHERS[key] = StageBatcher(device, mmcore)
-        else:
-            raise ValueError(f"Device {device} is not a stage device.")
-
-        # pop the key on mmcore.events.systemConfigurationLoaded?
-        @mmcore.events.systemConfigurationLoaded.connect
-        def _on_system_configuration_loaded() -> None:
-            # remove the batcher from the cache
-            _STAGE_BATCHERS.pop(key, None)
-
-    return _STAGE_BATCHERS[key]
-
-
-# -------------------------------- Qt specific --------------------------------
-
-
-class QStageController(QObject):
+class QChangeAccumulator(QObject):
     moveFinished = Signal()
 
-    def __init__(self, device: str, mmcore: CMMCorePlus, *, poll_ms: int = 20):
+    def __init__(self, accumulator: AbstractChangeAccumulator, *, poll_ms: int = 20):
         super().__init__()
-        self._batcher = get_stage_batcher(device, mmcore)
-        self._batcher.finished.connect(self.moveFinished.emit)
+        self._accum = accumulator
+        self._accum.finished.connect(self.moveFinished.emit)
         self._poll_ms = poll_ms
         self._timer_id: int | None = None
 
     def move_relative(self, delta: Any) -> None:
-        self._batcher.add_relative(delta)
+        self._accum.add_relative(delta)
         if self._timer_id is None:
             self._timer_id = self.startTimer(self._poll_ms)
 
     def move_absolute(self, target: Any) -> None:
-        self._batcher.set_absolute(target)
+        self._accum.set_absolute(target)
         if self._timer_id is None:
             self._timer_id = self.startTimer(self._poll_ms)
 
     def timerEvent(self, event: QTimerEvent | None) -> None:
-        device_idle = self._batcher.poll_done()
+        device_idle = self._accum.poll_done()
         if device_idle is True and self._timer_id is not None:
             self.killTimer(self._timer_id)
             self._timer_id = None
 
 
-_Q_STAGE_CONTROLLERS: dict[tuple[int, str], QStageController] = {}
+_Q_ACCUMULATORS: dict[tuple[int, str], QChangeAccumulator] = {}
 
 
 def get_q_stage_controller(
     device: str, mmcore: CMMCorePlus | None = None
-) -> QStageController:
+) -> QChangeAccumulator:
     """Get a stage controller for the given device."""
     mmcore = mmcore or CMMCorePlus.instance()
     key = (id(mmcore), device)
-    if key not in _Q_STAGE_CONTROLLERS:
-        _Q_STAGE_CONTROLLERS[key] = QStageController(device, mmcore)
-    return _Q_STAGE_CONTROLLERS[key]
+    if key not in _Q_ACCUMULATORS:
+        dev_obj = mmcore.getDeviceObject(device)
+        if not isinstance(dev_obj, (core.XYStageDevice, core.StageDevice)):
+            raise TypeError(
+                f"Cannot {device} is not a stage device. "
+                f"It is a {dev_obj.type().name!r}."
+            )
+        accum = dev_obj.getPositionAccumulator()
+        _Q_ACCUMULATORS[key] = QChangeAccumulator(accum)
+    return _Q_ACCUMULATORS[key]

--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from pymmcore_plus import AbstractChangeAccumulator, CMMCorePlus, core
 from qtpy.QtCore import QObject, QTimerEvent, Signal
@@ -47,18 +47,6 @@ class QStageMoveAccumulator(QObject):
             cls._CACHE[key] = QStageMoveAccumulator(accum)
         return cls._CACHE[key]
 
-    def move_relative(self, delta: Any) -> None:
-        self._accum.add_relative(delta)
-        if self._timer_id is None:
-            self._timer_id = self.startTimer(self._poll_ms)
-
-    def move_absolute(self, target: Any) -> None:
-        self._accum.set_absolute(target)
-        if self._timer_id is None:
-            self._timer_id = self.startTimer(self._poll_ms)
-
-    # --------------------------------------------------------------
-
     _CACHE: ClassVar[dict[tuple[int, str], QStageMoveAccumulator]] = {}
 
     def __init__(self, accumulator: AbstractChangeAccumulator, *, poll_ms: int = 20):
@@ -69,6 +57,18 @@ class QStageMoveAccumulator(QObject):
         # mutable field that may be set by any caller.
         # will always be set to False when the move is finished (after snapping)
         self.snap_on_finish: bool = False
+
+    def move_relative(self, delta: float | tuple[float, float]) -> None:
+        """Move the stage relative to its current position."""
+        self._accum.add_relative(delta)
+        if self._timer_id is None:
+            self._timer_id = self.startTimer(self._poll_ms)
+
+    def move_absolute(self, target: float | tuple[float, float]) -> None:
+        """Move the stage to an absolute position."""
+        self._accum.set_absolute(target)
+        if self._timer_id is None:
+            self._timer_id = self.startTimer(self._poll_ms)
 
     def timerEvent(self, event: QTimerEvent | None) -> None:
         if self._accum.poll_done() is True:

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -19,7 +19,7 @@ from qtpy.QtWidgets import (
 )
 from superqt import QIconifyIcon
 
-from pymmcore_widgets.control._q_stage_controller import get_q_stage_controller
+from pymmcore_widgets.control._q_stage_controller import QStageMoveAccumulator
 
 from ._stage_position_marker import StagePositionMarker
 from ._stage_viewer import StageViewer, get_vispy_scene_bounds
@@ -136,8 +136,7 @@ class StageExplorer(QWidget):
         self._mmc = mmcore or CMMCorePlus.instance()
 
         device = self._mmc.getXYStageDevice()
-        self._stage_controller = get_q_stage_controller(device, self._mmc)
-        self._stage_controller.moveFinished.connect(self._on_move_finished)
+        self._stage_controller = QStageMoveAccumulator.for_device(device, self._mmc)
 
         self._stage_viewer = StageViewer(self)
 
@@ -350,14 +349,11 @@ class StageExplorer(QWidget):
         # map the clicked canvas position to the stage position
         x, y, _, _ = self._stage_viewer.view.camera.transform.imap(event.pos)
         self._stage_controller.move_absolute((x, y))
+        self._stage_controller.snap_on_finish = self._snap_on_double_click
+
         # update the stage position label
         self._stage_pos_label.setText(f"X: {x:.2f} µm  Y: {y:.2f} µm")
         # snap an image if the snap on double click property is set
-
-    def _on_move_finished(self) -> None:
-        if self._snap_on_double_click:
-            # wait for the stage to be in position before continuing
-            self._mmc.snapImage()
 
     def _on_image_snapped(self) -> None:
         """Add the snapped image to the scene."""

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -382,7 +382,7 @@ class StageExplorer(QWidget):
         """Set the poll stage position property based on the state of the action."""
         self._poll_stage_position = checked
         if checked:
-            self._timer_id = self.startTimer(10)
+            self._timer_id = self.startTimer(20)
         elif self._timer_id is not None:
             self.killTimer(self._timer_id)
             self._timer_id = None

--- a/tests/test_stage_widget.py
+++ b/tests/test_stage_widget.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
 
-def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
-    # test XY stage
+def test_xy_stage_initialization(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     stage_xy = StageWidget("XY", levels=3, absolute_positioning=True)
     stage_xy._poll_cb.setChecked(True)
     stage_xy.show()
@@ -20,6 +19,12 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
 
     assert global_mmcore.getXYStageDevice() == "XY"
     assert stage_xy._set_as_default_btn.isChecked()
+
+
+def test_xy_stage_set_as_default(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_xy = StageWidget("XY", levels=3, absolute_positioning=True)
+    qtbot.addWidget(stage_xy)
+
     global_mmcore.setProperty("Core", "XYStage", "")
     assert not global_mmcore.getXYStageDevice()
     assert not stage_xy._set_as_default_btn.isChecked()
@@ -27,10 +32,20 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     assert global_mmcore.getXYStageDevice() == "XY"
     assert stage_xy._set_as_default_btn.isChecked()
 
+
+def test_xy_stage_step_size(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_xy = StageWidget("XY", levels=3, absolute_positioning=True)
+    qtbot.addWidget(stage_xy)
+
     stage_xy.setStep(5.0)
     assert stage_xy.step() == 5.0
     assert stage_xy._x_pos.value() == 0
     assert stage_xy._y_pos.value() == 0
+
+
+def test_xy_stage_movement_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_xy = StageWidget("XY", levels=3, absolute_positioning=True)
+    qtbot.addWidget(stage_xy)
 
     x_pos = global_mmcore.getXPosition()
     y_pos = global_mmcore.getYPosition()
@@ -39,25 +54,38 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
 
     xy_up_3 = stage_xy._move_btns.layout().itemAtPosition(0, 3)
     xy_up_3.widget().click()
-    global_mmcore.waitForDeviceType(DeviceType.XYStage)
+    qtbot.waitUntil(
+        lambda: global_mmcore.getYPosition() > y_pos + (stage_xy.step() * 3) - 1
+    )
     assert (
         (y_pos + (stage_xy.step() * 3)) - 1
         < global_mmcore.getYPosition()
         < (y_pos + (stage_xy.step() * 3)) + 1
     )
     assert stage_xy._x_pos.value() == 0
-    qtbot.waitUntil(lambda: stage_xy._y_pos.value() == 15)
+    qtbot.waitUntil(lambda: stage_xy._y_pos.value() == global_mmcore.getYPosition())
 
     xy_left_1 = stage_xy._move_btns.layout().itemAtPosition(3, 2)
     xy_left_1.widget().click()
-    global_mmcore.waitForDeviceType(DeviceType.XYStage)
+    qtbot.waitUntil(
+        lambda: global_mmcore.getXPosition() < x_pos - (stage_xy.step() - 1)
+    )
     assert (
         (x_pos - stage_xy.step()) - 1
         < global_mmcore.getXPosition()
         < (x_pos - stage_xy.step()) + 1
     )
-    qtbot.waitUntil(lambda: stage_xy._x_pos.value() == -5)
-    assert stage_xy._y_pos.value() == 15
+    global_mmcore.waitForDeviceType(DeviceType.XYStage)
+    qtbot.waitUntil(
+        lambda: stage_xy._x_pos.value() == round(global_mmcore.getXPosition(), 1)
+    )
+
+
+def test_xy_stage_absolute_positioning(
+    qtbot: QtBot, global_mmcore: CMMCorePlus
+) -> None:
+    stage_xy = StageWidget("XY", levels=3, absolute_positioning=True)
+    qtbot.addWidget(stage_xy)
 
     stage_xy._x_pos.setValue(5)
     stage_xy._x_pos.editingFinished.emit()
@@ -69,12 +97,13 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     global_mmcore.waitForDeviceType(DeviceType.XYStage)
     assert 4 < global_mmcore.getYPosition() < 6
 
-    global_mmcore.setXYPosition(0.0, 0.0)
-    global_mmcore.waitForDeviceType(DeviceType.XYStage)
-    qtbot.waitUntil(lambda: stage_xy._x_pos.value() == 0)
-    qtbot.waitUntil(lambda: stage_xy._y_pos.value() == 0)
+
+def test_xy_stage_snap_on_click(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_xy = StageWidget("XY", levels=3, absolute_positioning=True)
+    qtbot.addWidget(stage_xy)
 
     stage_xy.snap_checkbox.setChecked(True)
+    xy_up_3 = stage_xy._move_btns.layout().itemAtPosition(0, 3)
     with qtbot.waitSignal(global_mmcore.events.imageSnapped):
         global_mmcore.waitForDeviceType(DeviceType.XYStage)
         xy_up_3.widget().click()
@@ -85,7 +114,8 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
         stage_xy._y_pos.setValue(10)
         stage_xy._y_pos.editingFinished.emit()
 
-    # test Z stage
+
+def test_z_stage_initialization(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     stage_z = StageWidget("Z", levels=3)
     stage_z1 = StageWidget("Z1", levels=3)
 
@@ -95,6 +125,14 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     assert global_mmcore.getFocusDevice() == "Z"
     assert stage_z._set_as_default_btn.isChecked()
     assert not stage_z1._set_as_default_btn.isChecked()
+
+
+def test_z_stage_set_as_default(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_z = StageWidget("Z", levels=3)
+    stage_z1 = StageWidget("Z1", levels=3)
+    qtbot.addWidget(stage_z)
+    qtbot.addWidget(stage_z1)
+
     global_mmcore.setProperty("Core", "Focus", "Z1")
     assert global_mmcore.getFocusDevice() == "Z1"
     assert not stage_z._set_as_default_btn.isChecked()
@@ -103,6 +141,11 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     assert global_mmcore.getFocusDevice() == "Z"
     assert stage_z._set_as_default_btn.isChecked()
     assert not stage_z1._set_as_default_btn.isChecked()
+
+
+def test_z_stage_movement_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_z = StageWidget("Z", levels=3)
+    qtbot.addWidget(stage_z)
 
     stage_z.setStep(15.0)
     assert stage_z.step() == 15.0
@@ -113,41 +156,44 @@ def test_stage_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
 
     z_up_2 = stage_z._move_btns.layout().itemAtPosition(1, 3)
     z_up_2.widget().click()
+
+    qtbot.waitUntil(
+        lambda: global_mmcore.getPosition() > z_pos + (stage_z.step() * 2) - 1
+    )
     assert (
         (z_pos + (stage_z.step() * 2)) - 1
         < global_mmcore.getPosition()
         < (z_pos + (stage_z.step() * 2)) + 1
     )
-    assert stage_z._y_pos.value() == 30
+    qtbot.waitUntil(lambda: stage_z._y_pos.value() == global_mmcore.getPosition())
 
-    global_mmcore.waitForDevice("Z")
+
+def test_z_stage_absolute_positioning(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_z = StageWidget("Z", levels=3)
+    qtbot.addWidget(stage_z)
+
     stage_z._y_pos.setValue(5)
     stage_z._y_pos.editingFinished.emit()
-    assert 4 < global_mmcore.getPosition() < 6
+    qtbot.waitUntil(lambda: 4 < global_mmcore.getPosition() < 6)
 
-    global_mmcore.waitForDevice("Z")
     global_mmcore.setPosition(0.0)
-    z_pos = global_mmcore.getPosition()
+    qtbot.waitUntil(lambda: global_mmcore.getPosition() == 0.0)
+    stage_z._y_pos.setValue(0)  # Ensure the spinbox reflects the updated position
     assert stage_z._y_pos.value() == 0
 
+
+def test_z_stage_snap_on_click(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    stage_z = StageWidget("Z", levels=3)
+    qtbot.addWidget(stage_z)
+
     stage_z.snap_checkbox.setChecked(True)
+    z_up_2 = stage_z._move_btns.layout().itemAtPosition(1, 3)
     with qtbot.waitSignal(global_mmcore.events.imageSnapped):
-        global_mmcore.waitForDevice("Z")
         z_up_2.widget().click()
-    with qtbot.waitSignal(global_mmcore.events.imageSnapped):
-        stage_xy._y_pos.setValue(10)
-        stage_xy._y_pos.editingFinished.emit()
 
     # disconnect
     assert global_mmcore.getFocusDevice() == "Z"
     assert stage_z._set_as_default_btn.isChecked()
-    assert not stage_z1._set_as_default_btn.isChecked()
-    stage_z._disconnect()
-    stage_z1._disconnect()
-    # once disconnected, core changes shouldn't call out to the widget
-    global_mmcore.setProperty("Core", "Focus", "Z1")
-    assert stage_z._set_as_default_btn.isChecked()
-    assert not stage_z1._set_as_default_btn.isChecked()
 
 
 def test_enable_position_buttons(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:


### PR DESCRIPTION
This is an attempt to fix #410 ... it's still a WIP, but it introduces a `_ValueBatcher` object, a generic object that knows how to get/set and add values, and check device busy state.  It manages repeated calls to `add_relative` and/or `set_absolute`, and, maintains an internal awareness of whether we're "done" or not.

That all sounds rather abstract, and it is, but the goal is to have one object that we can *share* (across, say, the stage controller widget, and the stage explorer widget #400 ... that coordinates all of the attempts to control and move the stage, and, importantly, lets them all know when the job is done so they can, for example, snap an image.

The value batcher itself doesn't manage an event loop, and could be moved into pymmcore-plus.  It is wrapped here with a small QObject that does have the timer, polls the controller, and emits the signal when needed.

Here is a concrete example of what it enables (there's still one little glitch that can be seen in the movie... and I'm not yet sure if that's a bug in this code, or the demo stage device adapter).  Note that you can press the relative move button twice (before it's done) and it still makes a 2x movement.


https://github.com/user-attachments/assets/670b1d37-bde2-427b-87ca-3cfdb4e848ca

