### PR TITLE
fix: Disable preset combo scroll

### DIFF
--- a/src/pymmcore_widgets/control/_presets_widget.py
+++ b/src/pymmcore_widgets/control/_presets_widget.py
@@ -4,11 +4,20 @@ import warnings
 
 from pymmcore_plus import CMMCorePlus, DeviceType
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QBrush
+from qtpy.QtGui import QBrush, QWheelEvent
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QWidget
 from superqt.utils import signals_blocked
 
 from pymmcore_widgets._util import block_core
+
+
+class _PresetComboBox(QComboBox):
+    """A QComboBox tailored to selecting group presets."""
+
+    def wheelEvent(self, e: QWheelEvent | None) -> None:
+        # Scrolling over the combobox can easily lead to accidents, e.g. switching the
+        # objective lens.
+        pass
 
 
 class PresetsWidget(QWidget):
@@ -52,7 +61,7 @@ class PresetsWidget(QWidget):
         # since they must be all the same
         self.dev_prop = self._get_preset_dev_prop(self._group, self._presets[0])
 
-        self._combo = QComboBox()
+        self._combo = _PresetComboBox()
         self._combo.currentTextChanged.connect(self._update_tooltip)
         self._combo.addItems(self._presets)
         self._combo.setCurrentText(self._mmc.getCurrentConfig(self._group))

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from qtpy.QtCore import QPoint, QPointF, Qt
+from qtpy.QtGui import QWheelEvent
 
 from pymmcore_widgets.control._presets_widget import PresetsWidget
 
@@ -79,3 +81,25 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
 
     global_mmcore.deleteConfigGroup("Camera")
     assert "Camera" not in global_mmcore.getAvailableConfigGroups()
+
+
+def test_preset_widget_no_scroll(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
+    # Test that the widget does not respond to scroll events when unfocused.
+    # It is easy to accidentally scroll the widget when trying to scroll the group
+    # preset window, which could lead to costly accidents (e.g. switching objectives)
+    wdg = PresetsWidget("Camera")
+    qtbot.addWidget(wdg)
+
+    previous = wdg._combo.currentText()
+    e = QWheelEvent(
+        QPointF(0, 0),  # pos
+        QPointF(0, 0),  # globalPos
+        QPoint(0, 0),  # pixelDelta
+        QPoint(0, -120),  # angleDelta
+        Qt.MouseButton.NoButton,  # buttons
+        Qt.KeyboardModifier.NoModifier,  # modifiers
+        Qt.ScrollPhase.NoScrollPhase,  # phase
+        False,  # inverted
+    )
+    wdg._combo.wheelEvent(e)
+    assert wdg._combo.currentText() == previous


### PR DESCRIPTION
Yesterday in the lab we accidentally ran into #372, which motivated me to fix the bug. I did see #307, however apparently that PR does not fix the problem.

This PR overrides the `wheelEvent` method to ignore `QWheelEvent`s on preset combo boxes, and adds a test ensuring as such.
