### PR TITLE
fix: make position checkboxes uncheckable when using HCSWidget

### DIFF
--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -131,14 +131,14 @@ class CoreConnectedPositionTable(PositionTable):
 
     def setValue(self, value: Sequence[Position]) -> None:  # type: ignore [override]
         """Set the value of the positions table."""
+        super().setValue(value)
+        self._update_z_enablement()
+        self._update_autofocus_enablement()
         if isinstance(value, WellPlatePlan):
             self._plate_plan = value
             self._hcs.setValue(value)
             self._set_position_table_editable(False)
             value = tuple(value)
-        super().setValue(value)
-        self._update_z_enablement()
-        self._update_autofocus_enablement()
 
     # ----------------------- private methods -----------------------
 
@@ -271,16 +271,12 @@ class CoreConnectedPositionTable(PositionTable):
                     flags |= (
                         Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsUserCheckable
                     )
-                    # show the checkbox and set it to checked
-                    name_item.setCheckState(Qt.CheckState.Checked)
                 else:
                     # keep the name column enabled but NOT editable. We do not disable
                     # to keep available the "Move Stage to Selected Point" option
                     flags &= ~(
                         Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsUserCheckable
                     )
-                    # hide the checkbox
-                    name_item.setData(Qt.ItemDataRole.CheckStateRole, None)
                 name_item.setFlags(flags)
 
     def _on_sys_config_loaded(self) -> None:

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -268,11 +268,19 @@ class CoreConnectedPositionTable(PositionTable):
                 name_item = table.item(row, name_col)
                 flags = name_item.flags() | Qt.ItemFlag.ItemIsEnabled
                 if state:
-                    flags |= Qt.ItemFlag.ItemIsEditable
+                    flags |= (
+                        Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsUserCheckable
+                    )
+                    # show the checkbox and set it to checked
+                    name_item.setCheckState(Qt.CheckState.Checked)
                 else:
                     # keep the name column enabled but NOT editable. We do not disable
                     # to keep available the "Move Stage to Selected Point" option
-                    flags &= ~Qt.ItemFlag.ItemIsEditable
+                    flags &= ~(
+                        Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsUserCheckable
+                    )
+                    # hide the checkbox
+                    name_item.setData(Qt.ItemDataRole.CheckStateRole, None)
                 name_item.setFlags(flags)
 
     def _on_sys_config_loaded(self) -> None:

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -732,13 +732,10 @@ def test_core_mda_with_hcs_enable_disable(
     assert not table.isColumnHidden(z_btn_col)
     assert not table.isColumnHidden(z_col)
     assert not table.isColumnHidden(sub_seq_btn_col)
-    # name_col_checkbox is visible
+    # name_col_checkbox can be checked
     for row in range(table.rowCount()):
         item = table.item(row, name_col)
-        # checkable
         assert item.flags() & Qt.ItemFlag.ItemIsUserCheckable
-        # visible
-        assert item.checkState() == Qt.CheckState.Checked
     # all toolbar actions enabled
     assert all(action.isEnabled() for action in wdg.stage_positions.toolBar().actions())
     # include_z checkbox enabled
@@ -763,18 +760,10 @@ def test_core_mda_with_hcs_enable_disable(
     assert table.isColumnHidden(z_btn_col)
     assert table.isColumnHidden(z_col)
     assert table.isColumnHidden(sub_seq_btn_col)
-    # name_col_checkbox is hidden
+    # name_col_checkbox cannot be checked
     for row in range(table.rowCount()):
         item = table.item(row, name_col)
-        # uncheckable
-        assert item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable
-        # hidden
-        assert item.data(Qt.ItemDataRole.CheckStateRole) not in (
-            Qt.CheckState.Checked,
-            Qt.CheckState.Unchecked,
-            Qt.CheckState.PartiallyChecked,
-        )
-
+        assert not (item.flags() & Qt.ItemFlag.ItemIsUserCheckable)
     # all toolbar actions disabled but the move stage checkbox
     assert all(
         not action.isEnabled() for action in wdg.stage_positions.toolBar().actions()[1:]

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import useq
-from qtpy.QtCore import QTimer
+from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QMessageBox
 
 from pymmcore_widgets import HCSWizard
@@ -732,6 +732,13 @@ def test_core_mda_with_hcs_enable_disable(
     assert not table.isColumnHidden(z_btn_col)
     assert not table.isColumnHidden(z_col)
     assert not table.isColumnHidden(sub_seq_btn_col)
+    # name_col_checkbox is visible
+    for row in range(table.rowCount()):
+        item = table.item(row, name_col)
+        # checkable
+        assert item.flags() & Qt.ItemFlag.ItemIsUserCheckable
+        # visible
+        assert item.checkState() == Qt.CheckState.Checked
     # all toolbar actions enabled
     assert all(action.isEnabled() for action in wdg.stage_positions.toolBar().actions())
     # include_z checkbox enabled
@@ -756,6 +763,18 @@ def test_core_mda_with_hcs_enable_disable(
     assert table.isColumnHidden(z_btn_col)
     assert table.isColumnHidden(z_col)
     assert table.isColumnHidden(sub_seq_btn_col)
+    # name_col_checkbox is hidden
+    for row in range(table.rowCount()):
+        item = table.item(row, name_col)
+        # uncheckable
+        assert item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable
+        # hidden
+        assert item.data(Qt.ItemDataRole.CheckStateRole) not in (
+            Qt.CheckState.Checked,
+            Qt.CheckState.Unchecked,
+            Qt.CheckState.PartiallyChecked,
+        )
+
     # all toolbar actions disabled but the move stage checkbox
     assert all(
         not action.isEnabled() for action in wdg.stage_positions.toolBar().actions()[1:]


### PR DESCRIPTION
We currently make the position table non-modifiable when we add the position list using the `HCSWIdget`. However, we do not disable the checkboxes. Since removing a position (unchecking the checkbox) would modify the `WellPlatePlan`, we should disable the checkboxes as well.

<img width="582" alt="Screenshot 2025-05-17 at 12 56 16 PM" src="https://github.com/user-attachments/assets/a234001f-63d8-4cf5-af29-2c3d1fc1272f" />
