### PR TITLE
fix: increase spin range of StageWidget

### DIFF
--- a/src/pymmcore_widgets/control/_stage_widget.py
+++ b/src/pymmcore_widgets/control/_stage_widget.py
@@ -81,8 +81,8 @@ class MoveStageSpinBox(QDoubleSpinBox):
     def __init__(
         self,
         label: str,
-        minimum: float = -99999,
-        maximum: float = 99999,
+        minimum: float = -10000000,
+        maximum: float = 10000000,
         *args: Any,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
The spin boxes in the `StageWidget` are currently limited to a ±99999 range. This PR increases the range as in #402.

closes #403.