### PR TITLE
feat: add `QConfigGroupsModel`, a QAbstractItemModel to manage configs and presets

### DIFF
--- a/src/pymmcore_widgets/_icons.py
+++ b/src/pymmcore_widgets/_icons.py
@@ -1,23 +1,39 @@
 from __future__ import annotations
 
-from pymmcore_plus import DeviceType
+from pymmcore_plus import CMMCorePlus, DeviceType
+from superqt import QIconifyIcon
 
 ICONS: dict[DeviceType, str] = {
     DeviceType.Any: "mdi:devices",
-    DeviceType.AutoFocus: "mdi:auto-upload",
+    DeviceType.AutoFocus: "mdi:focus-auto",
     DeviceType.Camera: "mdi:camera",
-    DeviceType.Core: "mdi:checkbox-blank-circle-outline",
+    DeviceType.Core: "mdi:heart-cog-outline",
     DeviceType.Galvo: "mdi:mirror-variant",
     DeviceType.Generic: "mdi:dev-to",
     DeviceType.Hub: "mdi:hubspot",
     DeviceType.ImageProcessor: "mdi:image-auto-adjust",
-    DeviceType.Magnifier: "mdi:magnify-plus",
+    DeviceType.Magnifier: "mdi:magnify",
     DeviceType.Shutter: "mdi:camera-iris",
-    DeviceType.SignalIO: "mdi:signal",
+    DeviceType.SignalIO: "fa6-solid:wave-square",
     DeviceType.SLM: "mdi:view-comfy",
     DeviceType.Stage: "mdi:arrow-up-down",
     DeviceType.State: "mdi:state-machine",
-    DeviceType.Unknown: "mdi:dev-to",
+    DeviceType.Unknown: "mdi:question-mark-rhombus",
     DeviceType.XYStage: "mdi:arrow-all",
     DeviceType.Serial: "mdi:serial-port",
 }
+
+
+def get_device_icon(
+    device_type_or_name: DeviceType | str, color: str = "gray"
+) -> QIconifyIcon | None:
+    if isinstance(device_type_or_name, str):
+        try:
+            device_type = CMMCorePlus.instance().getDeviceType(device_type_or_name)
+        except Exception:
+            device_type = DeviceType.Unknown
+    else:
+        device_type = device_type_or_name
+    if icon_string := ICONS.get(device_type):
+        return QIconifyIcon(icon_string, color=color)
+    return None

--- a/src/pymmcore_widgets/config_presets/__init__.py
+++ b/src/pymmcore_widgets/config_presets/__init__.py
@@ -3,9 +3,11 @@
 from ._group_preset_widget._group_preset_table_widget import GroupPresetTableWidget
 from ._objectives_pixel_configuration_widget import ObjectivesPixelConfigurationWidget
 from ._pixel_configuration_widget import PixelConfigurationWidget
+from ._qmodel._config_model import QConfigGroupsModel
 
 __all__ = [
     "GroupPresetTableWidget",
     "ObjectivesPixelConfigurationWidget",
     "PixelConfigurationWidget",
+    "QConfigGroupsModel",
 ]

--- a/src/pymmcore_widgets/config_presets/_qmodel/_config_model.py
+++ b/src/pymmcore_widgets/config_presets/_qmodel/_config_model.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from copy import deepcopy
+from enum import IntEnum
+from typing import TYPE_CHECKING, Any, cast
+
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.model import ConfigGroup, ConfigPreset, Setting
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
+from qtpy.QtGui import QFont, QIcon
+from qtpy.QtWidgets import QMessageBox
+from superqt import QIconifyIcon
+
+from pymmcore_widgets._icons import ICONS
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from typing_extensions import Self
+
+NULL_INDEX = QModelIndex()
+
+
+class Col(IntEnum):
+    """Column indices for the ConfigTreeModel."""
+
+    Item = 0
+    Property = 1
+    Value = 2
+
+
+class _Node:
+    """Generic tree node that wraps a ConfigGroup, ConfigPreset, or Setting."""
+
+    def __init__(
+        self,
+        name: str,
+        payload: ConfigGroup | ConfigPreset | Setting | None = None,
+        parent: _Node | None = None,
+    ) -> None:
+        self.name = name
+        self.payload = payload
+        self.parent = parent
+        self.children: list[_Node] = []
+
+    # convenience ------------------------------------------------------------
+
+    def row_in_parent(self) -> int:
+        return -1 if self.parent is None else self.parent.children.index(self)
+
+    # type helpers -----------------------------------------------------------
+
+    @property
+    def is_group(self) -> bool:
+        return isinstance(self.payload, ConfigGroup)
+
+    @property
+    def is_preset(self) -> bool:
+        return isinstance(self.payload, ConfigPreset)
+
+    @property
+    def is_setting(self) -> bool:
+        return isinstance(self.payload, Setting)
+
+
+class QConfigGroupsModel(QAbstractItemModel):
+    """Three-level model: root → groups → presets → settings."""
+
+    @classmethod
+    def create_from_core(cls, core: CMMCorePlus) -> Self:
+        return cls(ConfigGroup.all_config_groups(core).values())
+
+    def __init__(self, groups: Iterable[ConfigGroup] | None = None) -> None:
+        super().__init__()
+        self._root = _Node("<root>", None)
+        if groups:
+            self._build_tree(groups)
+
+    # ------------------------------------------------------------------
+    # Public helpers used by the widget toolbar actions
+    # ------------------------------------------------------------------
+
+    def index_for_group(self, group_name: str) -> QModelIndex:
+        """Return the QModelIndex for the group with the given name."""
+        for i, node in enumerate(self._root.children):
+            if node.is_group and node.name == group_name:
+                return self.createIndex(i, 0, node)
+        return QModelIndex()
+
+    def index_for_preset(
+        self, group: QModelIndex | str, preset_name: str
+    ) -> QModelIndex:
+        """Return the QModelIndex for the preset with the given name in the group."""
+        if isinstance(group, QModelIndex):
+            if not self._is_group_index(group):
+                return QModelIndex()
+            group_index = group
+        else:
+            group_index = self.index_for_group(group)
+
+        if not self._is_group_index(group_index):
+            return QModelIndex()
+        parent_node = cast("_Node", group_index.internalPointer())
+        for i, node in enumerate(parent_node.children):
+            if node.is_preset and node.name == preset_name:
+                return self.createIndex(i, 0, node)
+        return QModelIndex()
+
+    # group-level -------------------------------------------------------------
+
+    def add_group(self, base_name: str = "Group") -> QModelIndex:
+        """Append a *new* empty group and return its QModelIndex."""
+        name = self._unique_child_name(self._root, base_name)
+        group = ConfigGroup(name=name)
+        node = _Node(name, group, self._root)
+        return self._insert_node(node, self._root, len(self._root.children))
+
+    def duplicate_group(
+        self, idx: QModelIndex, new_name: str | None = None
+    ) -> QModelIndex:
+        if not self._is_group_index(idx):
+            return QModelIndex()
+        node = cast("_Node", idx.internalPointer())
+        new_grp = deepcopy(node.payload)
+        assert isinstance(new_grp, ConfigGroup)
+        new_grp.name = new_name or self._unique_child_name(self._root, new_grp.name)
+        node = _Node(new_grp.name, new_grp, self._root)
+        # duplicate presets
+        for p in new_grp.presets.values():
+            child_node = _Node(p.name, p, node)
+            node.children.append(child_node)
+        return self._insert_node(node, self._root, idx.row() + 1)
+
+    # preset-level ------------------------------------------------------------
+
+    def add_preset(
+        self, group_idx: QModelIndex, base_name: str = "Preset"
+    ) -> QModelIndex:
+        if not self._is_group_index(group_idx):
+            return QModelIndex()
+        parent_node = cast("_Node", group_idx.internalPointer())
+        name = self._unique_child_name(parent_node, base_name)
+        preset = ConfigPreset(name)
+        node = _Node(name, preset, parent_node)
+        return self._insert_node(node, parent_node, len(parent_node.children))
+
+    def duplicate_preset(
+        self, idx: QModelIndex, new_name: str | None = None
+    ) -> QModelIndex:
+        if not self._is_preset_index(idx):
+            return QModelIndex()
+        parent_node = cast("_Node", idx.parent().internalPointer())
+        orig = cast("_Node", idx.internalPointer())
+        new_preset = deepcopy(orig.payload)
+        assert isinstance(new_preset, ConfigPreset)
+        new_preset.name = new_name or self._unique_child_name(
+            parent_node, new_preset.name
+        )
+        node = _Node(new_preset.name, new_preset, parent_node)
+        return self._insert_node(node, parent_node, idx.row() + 1)
+
+    # generic remove ----------------------------------------------------------
+
+    def remove(self, idx: QModelIndex) -> None:
+        if not idx.isValid():
+            return
+        node = cast("_Node", idx.internalPointer())
+        parent_node = node.parent
+        if parent_node is None:
+            return
+        self.beginRemoveRows(idx.parent(), idx.row(), idx.row())
+        parent_node.children.pop(idx.row())
+        self.endRemoveRows()
+
+    # ------------------------------------------------------------------
+    # Required Qt model overrides
+    # ------------------------------------------------------------------
+
+    # structure helpers -------------------------------------------------------
+
+    def _node(self, index: QModelIndex | None) -> _Node:
+        if (
+            index
+            and index.isValid()
+            and isinstance((node := index.internalPointer()), _Node)
+        ):
+            # return the node if index is valid
+            return node
+        # otherwise return the root node
+        return self._root
+
+    def python_object(
+        self, index: QModelIndex = NULL_INDEX
+    ) -> Mapping[str, ConfigGroup] | ConfigGroup | ConfigPreset | Setting | None:
+        """Return the Python object (ConfigGroup, ConfigPreset, or Setting) at index."""
+        node = self._node(index)
+        if node is self._root:
+            # return a copy of the root's children as a dict
+            return {n.name: cast("ConfigGroup", n.payload) for n in self._root.children}
+        return node.payload
+
+    def rowCount(self, parent: QModelIndex | None = None) -> int:
+        return len(self._node(parent).children)
+
+    def columnCount(self, _parent: QModelIndex | None = None) -> int:
+        return len(Col)
+
+    def index(
+        self, row: int, column: int = 0, parent: QModelIndex | None = None
+    ) -> QModelIndex:
+        parent_node = self._node(parent)
+        if 0 <= row < len(parent_node.children):
+            return self.createIndex(row, column, parent_node.children[row])
+        return QModelIndex()
+
+    def parent(self, child: QModelIndex) -> QModelIndex:
+        """Returns the parent of the model item with the given index.
+
+        If the item has no parent, an invalid QModelIndex is returned.
+        """
+        node = self._node(child)
+        if node is self._root or not (parent_node := node.parent):
+            return QModelIndex()
+        return self.createIndex(parent_node.row_in_parent(), 0, parent_node)
+
+    # data & editing ----------------------------------------------------------
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
+        node = self._node(index)
+        if node is self._root:
+            return None
+
+        if role == Qt.ItemDataRole.UserRole:
+            # return the node itself for easy access in views
+            return node.payload
+
+        if role == Qt.ItemDataRole.FontRole and index.column() == Col.Item:
+            f = QFont()
+            if node.is_group:
+                f.setBold(True)
+            return f
+
+        if role == Qt.ItemDataRole.DecorationRole and index.column() == Col.Item:
+            if node.is_group:
+                return QIcon.fromTheme("folder")
+            if node.is_preset:
+                return QIcon.fromTheme("document")
+            if node.is_setting:
+                setting = cast("Setting", node.payload)
+                with suppress(Exception):
+                    dtype = CMMCorePlus.instance().getDeviceType(setting.device_name)
+                    if icon_string := ICONS.get(dtype):
+                        return QIconifyIcon(icon_string, color="gray").pixmap(16, 16)
+
+                return QIcon.fromTheme("emblem-system")
+
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
+            # settings: show Device, Property, Value
+            if node.is_setting:
+                setting = cast("Setting", node.payload)
+                if index.column() == Col.Item:
+                    return setting.device_name
+                if index.column() == Col.Property:
+                    return setting.property_name
+                if index.column() == Col.Value:
+                    return setting.property_value
+                return None
+
+            # groups / presets: only show name
+            elif index.column() == Col.Item:
+                return node.name
+        return None
+
+    def flags(self, index: QModelIndex) -> Qt.ItemFlag:
+        node = self._node(index)
+        if node is self._root:
+            return Qt.ItemFlag.NoItemFlags
+
+        fl = Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled
+        if node.is_setting and index.column() == Col.Value:
+            fl |= Qt.ItemFlag.ItemIsEditable
+        elif not node.is_setting and index.column() == Col.Item:
+            fl |= Qt.ItemFlag.ItemIsEditable
+        return fl
+
+    def setData(
+        self,
+        index: QModelIndex,
+        value: Any,
+        role: int = Qt.ItemDataRole.EditRole,
+    ) -> bool:
+        node = self._node(index)
+        if node is self._root or role != Qt.ItemDataRole.EditRole:
+            return False
+
+        if node.is_setting and index.column() == Col.Value:
+            setting = cast("Setting", node.payload)
+            setting = Setting(
+                setting.device_name, setting.property_name, cast("str", value)
+            )
+            node.payload = setting
+            # also update the preset.settings list reference
+            # find node.parent.payload (ConfigPreset) and update list element
+            parent_preset = cast("ConfigPreset", node.parent.payload)  # type: ignore
+            for i, s in enumerate(parent_preset.settings):
+                if (
+                    s.device_name == setting.device_name
+                    and s.property_name == setting.property_name
+                ):
+                    parent_preset.settings[i] = setting
+                    break
+            self.dataChanged.emit(index, index, [role])
+            return True
+
+        new_name = str(value)
+        if new_name == node.name:
+            return True
+        if not new_name:
+            return False
+        if self._name_exists(node.parent, new_name):
+            QMessageBox.warning(
+                None, "Duplicate name", f"Name '{new_name}' already exists."
+            )
+            return False
+        node.name = new_name
+        if isinstance(node.payload, (ConfigGroup, ConfigPreset)):
+            node.payload.name = new_name  # keep dataclass in sync
+        self.dataChanged.emit(index, index, [role])
+        return True
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_tree(self, groups: Iterable[ConfigGroup]) -> None:
+        self._root.children.clear()
+        for g in groups:
+            gnode = _Node(g.name, g, self._root)
+            self._root.children.append(gnode)
+            for p in g.presets.values():
+                pnode = _Node(p.name, p, gnode)
+                gnode.children.append(pnode)
+                # add one child per Setting
+                for s in p.settings:
+                    snode = _Node(s.device_name, s, pnode)
+                    pnode.children.append(snode)
+
+    # ------------------------------------------------------------------
+    # Public mutator helpers
+    # ------------------------------------------------------------------
+
+    def update_preset_settings(
+        self, preset_idx: QModelIndex, settings: list[Setting]
+    ) -> None:
+        """Replace <preset> settings and update the tree safely.
+
+        We remove old Setting rows with beginRemoveRows/endRemoveRows,
+        then insert the new ones.  This guarantees attached views drop any
+        QModelIndex that referenced the old child nodes (avoiding the crash
+        seen when switching presets).
+        """
+        if not self._is_preset_index(preset_idx):
+            return
+
+        preset_node = cast("_Node", preset_idx.internalPointer())
+        preset: ConfigPreset = cast("ConfigPreset", preset_node.payload)
+
+        # --- mutate underlying dataclass ----------------------------------
+        preset.settings = list(settings)
+
+        # --- remove existing Setting rows ---------------------------------
+        old_row_count = len(preset_node.children)
+        if old_row_count:
+            self.beginRemoveRows(preset_idx, 0, old_row_count - 1)
+            preset_node.children.clear()
+            self.endRemoveRows()
+
+        # --- insert new Setting rows --------------------------------------
+        new_row_count = len(settings)
+        if new_row_count:
+            self.beginInsertRows(preset_idx, 0, new_row_count - 1)
+            for s in settings:
+                preset_node.children.append(_Node(s.device_name, s, preset_node))
+            self.endInsertRows()
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
+        if (
+            orientation == Qt.Orientation.Horizontal
+            and role == Qt.ItemDataRole.DisplayRole
+        ):
+            return Col(section).name if section < len(Col) else None
+        return super().headerData(section, orientation, role)
+
+    # name uniqueness ---------------------------------------------------------
+
+    @staticmethod
+    def _unique_child_name(parent: _Node, base: str) -> str:
+        names = {c.name for c in parent.children}
+        if base not in names:
+            return base
+        # try 'base copy' ... but then resort to 'base copy(n)' if needed
+        if (name := f"{base} copy") not in names:
+            return name
+        n = 1
+        while name in names:
+            name = f"{base} copy ({n})"
+            n += 1
+        return name
+
+    @staticmethod
+    def _name_exists(parent: _Node | None, name: str) -> bool:
+        return parent is not None and any(c.name == name for c in parent.children)
+
+    # convenience guards ------------------------------------------------------
+
+    @staticmethod
+    def _is_group_index(idx: QModelIndex) -> bool:
+        return idx.isValid() and cast("_Node", idx.internalPointer()).is_group
+
+    @staticmethod
+    def _is_preset_index(idx: QModelIndex) -> bool:
+        return idx.isValid() and cast("_Node", idx.internalPointer()).is_preset
+
+    # insertion ---------------------------------------------------------------
+
+    def _insert_node(self, node: _Node, parent_node: _Node, row: int) -> QModelIndex:
+        self.beginInsertRows(self._index_from_node(parent_node), row, row)
+        parent_node.children.insert(row, node)
+        if parent_node.is_group and node.is_preset:
+            # update the python model too
+            if isinstance((group := parent_node.payload), ConfigGroup):
+                # recreate group.presets so that node.name lands at row index:
+                presets = list(group.presets.values())
+                presets.insert(row, cast("ConfigPreset", node.payload))
+                group.presets = {p.name: p for p in presets}
+
+        elif parent_node.is_preset and node.is_setting:
+            # update the python model too
+            if isinstance((preset := parent_node.payload), ConfigPreset):
+                # recreate preset.settings so that node.name lands at row index:
+                settings = list(preset.settings)
+                settings.insert(row, cast("Setting", node.payload))
+                preset.settings = settings
+
+        self.endInsertRows()
+        return self.createIndex(row, 0, node)
+
+    def _index_from_node(self, node: _Node) -> QModelIndex:
+        if node is self._root:
+            return QModelIndex()
+        return self.createIndex(node.row_in_parent(), 0, node)
+
+    # external data API -------------------------------------------------------
+
+    def set_groups(self, groups: Iterable[ConfigGroup]) -> None:
+        self.beginResetModel()
+        self._build_tree(groups)
+        self.endResetModel()
+
+    def data_as_groups(self) -> list[ConfigGroup]:
+        """Return a *deep copy* of current configuration as dataclasses."""
+        return deepcopy([cast("ConfigGroup", n.payload) for n in self._root.children])

--- a/src/pymmcore_widgets/config_presets/_qmodel/_config_model.py
+++ b/src/pymmcore_widgets/config_presets/_qmodel/_config_model.py
@@ -1,22 +1,20 @@
 from __future__ import annotations
 
-from contextlib import suppress
 from copy import deepcopy
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
-from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.model import ConfigGroup, ConfigPreset, Setting
-from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 from qtpy.QtGui import QFont, QIcon
 from qtpy.QtWidgets import QMessageBox
-from superqt import QIconifyIcon
 
-from pymmcore_widgets._icons import ICONS
+from pymmcore_widgets._icons import get_device_icon
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable
 
+    from pymmcore_plus import CMMCorePlus
     from typing_extensions import Self
 
 NULL_INDEX = QModelIndex()
@@ -32,6 +30,29 @@ class Col(IntEnum):
 
 class _Node:
     """Generic tree node that wraps a ConfigGroup, ConfigPreset, or Setting."""
+
+    @classmethod
+    def create(
+        cls,
+        payload: ConfigGroup | ConfigPreset | Setting,
+        parent: _Node | None = None,
+        recursive: bool = True,
+    ) -> Self:
+        """Create a new _Node with the given name and payload."""
+        if isinstance(payload, Setting):
+            name = f"{payload.device_name}-{payload.property_name}"
+        else:
+            name = payload.name
+
+        node = cls(name, payload, parent)
+        if recursive:
+            if isinstance(payload, ConfigGroup):
+                for p in payload.presets.values():
+                    node.children.append(_Node.create(p, node))
+            elif isinstance(payload, ConfigPreset):
+                for s in payload.settings:
+                    node.children.append(_Node.create(s, node))
+        return node
 
     def __init__(
         self,
@@ -75,103 +96,7 @@ class QConfigGroupsModel(QAbstractItemModel):
         super().__init__()
         self._root = _Node("<root>", None)
         if groups:
-            self._build_tree(groups)
-
-    # ------------------------------------------------------------------
-    # Public helpers used by the widget toolbar actions
-    # ------------------------------------------------------------------
-
-    def index_for_group(self, group_name: str) -> QModelIndex:
-        """Return the QModelIndex for the group with the given name."""
-        for i, node in enumerate(self._root.children):
-            if node.is_group and node.name == group_name:
-                return self.createIndex(i, 0, node)
-        return QModelIndex()
-
-    def index_for_preset(
-        self, group: QModelIndex | str, preset_name: str
-    ) -> QModelIndex:
-        """Return the QModelIndex for the preset with the given name in the group."""
-        if isinstance(group, QModelIndex):
-            if not self._is_group_index(group):
-                return QModelIndex()
-            group_index = group
-        else:
-            group_index = self.index_for_group(group)
-
-        if not self._is_group_index(group_index):
-            return QModelIndex()
-        parent_node = cast("_Node", group_index.internalPointer())
-        for i, node in enumerate(parent_node.children):
-            if node.is_preset and node.name == preset_name:
-                return self.createIndex(i, 0, node)
-        return QModelIndex()
-
-    # group-level -------------------------------------------------------------
-
-    def add_group(self, base_name: str = "Group") -> QModelIndex:
-        """Append a *new* empty group and return its QModelIndex."""
-        name = self._unique_child_name(self._root, base_name)
-        group = ConfigGroup(name=name)
-        node = _Node(name, group, self._root)
-        return self._insert_node(node, self._root, len(self._root.children))
-
-    def duplicate_group(
-        self, idx: QModelIndex, new_name: str | None = None
-    ) -> QModelIndex:
-        if not self._is_group_index(idx):
-            return QModelIndex()
-        node = cast("_Node", idx.internalPointer())
-        new_grp = deepcopy(node.payload)
-        assert isinstance(new_grp, ConfigGroup)
-        new_grp.name = new_name or self._unique_child_name(self._root, new_grp.name)
-        node = _Node(new_grp.name, new_grp, self._root)
-        # duplicate presets
-        for p in new_grp.presets.values():
-            child_node = _Node(p.name, p, node)
-            node.children.append(child_node)
-        return self._insert_node(node, self._root, idx.row() + 1)
-
-    # preset-level ------------------------------------------------------------
-
-    def add_preset(
-        self, group_idx: QModelIndex, base_name: str = "Preset"
-    ) -> QModelIndex:
-        if not self._is_group_index(group_idx):
-            return QModelIndex()
-        parent_node = cast("_Node", group_idx.internalPointer())
-        name = self._unique_child_name(parent_node, base_name)
-        preset = ConfigPreset(name)
-        node = _Node(name, preset, parent_node)
-        return self._insert_node(node, parent_node, len(parent_node.children))
-
-    def duplicate_preset(
-        self, idx: QModelIndex, new_name: str | None = None
-    ) -> QModelIndex:
-        if not self._is_preset_index(idx):
-            return QModelIndex()
-        parent_node = cast("_Node", idx.parent().internalPointer())
-        orig = cast("_Node", idx.internalPointer())
-        new_preset = deepcopy(orig.payload)
-        assert isinstance(new_preset, ConfigPreset)
-        new_preset.name = new_name or self._unique_child_name(
-            parent_node, new_preset.name
-        )
-        node = _Node(new_preset.name, new_preset, parent_node)
-        return self._insert_node(node, parent_node, idx.row() + 1)
-
-    # generic remove ----------------------------------------------------------
-
-    def remove(self, idx: QModelIndex) -> None:
-        if not idx.isValid():
-            return
-        node = cast("_Node", idx.internalPointer())
-        parent_node = node.parent
-        if parent_node is None:
-            return
-        self.beginRemoveRows(idx.parent(), idx.row(), idx.row())
-        parent_node.children.pop(idx.row())
-        self.endRemoveRows()
+            self.set_groups(groups)
 
     # ------------------------------------------------------------------
     # Required Qt model overrides
@@ -179,60 +104,51 @@ class QConfigGroupsModel(QAbstractItemModel):
 
     # structure helpers -------------------------------------------------------
 
-    def _node(self, index: QModelIndex | None) -> _Node:
-        if (
-            index
-            and index.isValid()
-            and isinstance((node := index.internalPointer()), _Node)
-        ):
-            # return the node if index is valid
-            return node
-        # otherwise return the root node
-        return self._root
-
-    def python_object(
-        self, index: QModelIndex = NULL_INDEX
-    ) -> Mapping[str, ConfigGroup] | ConfigGroup | ConfigPreset | Setting | None:
-        """Return the Python object (ConfigGroup, ConfigPreset, or Setting) at index."""
-        node = self._node(index)
-        if node is self._root:
-            # return a copy of the root's children as a dict
-            return {n.name: cast("ConfigGroup", n.payload) for n in self._root.children}
-        return node.payload
-
     def rowCount(self, parent: QModelIndex | None = None) -> int:
-        return len(self._node(parent).children)
+        return len(self._node_from_index(parent).children)
 
     def columnCount(self, _parent: QModelIndex | None = None) -> int:
+        # In most subclasses, the number of columns is independent of the parent.
         return len(Col)
 
     def index(
         self, row: int, column: int = 0, parent: QModelIndex | None = None
     ) -> QModelIndex:
-        parent_node = self._node(parent)
+        """Return the index of the item specified by row, column and parent index."""
+        parent_node = self._node_from_index(parent)
         if 0 <= row < len(parent_node.children):
             return self.createIndex(row, column, parent_node.children[row])
-        return QModelIndex()
+        return QModelIndex()  # pragma: no cover
 
-    def parent(self, child: QModelIndex) -> QModelIndex:
-        """Returns the parent of the model item with the given index.
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+    @overload
+    def parent(self) -> QObject | None: ...
+    def parent(self, child: QModelIndex | None = None) -> QModelIndex | QObject | None:
+        """Return the parent of the model item with the given index.
 
         If the item has no parent, an invalid QModelIndex is returned.
         """
-        node = self._node(child)
+        if child is None:  # pragma: no cover
+            return None
+        node = self._node_from_index(child)
         if node is self._root or not (parent_node := node.parent):
-            return QModelIndex()
+            return QModelIndex()  # pragma: no cover
+
+        # A common convention used in models that expose tree data structures is that
+        # only items in the first column have children.
         return self.createIndex(parent_node.row_in_parent(), 0, parent_node)
 
     # data & editing ----------------------------------------------------------
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
-        node = self._node(index)
+        """Return the data stored for `role` for the item at `index`."""
+        node = self._node_from_index(index)
         if node is self._root:
             return None
 
+        # Qt.ItemDataRole.UserRole => return the original python object
         if role == Qt.ItemDataRole.UserRole:
-            # return the node itself for easy access in views
             return node.payload
 
         if role == Qt.ItemDataRole.FontRole and index.column() == Col.Item:
@@ -248,12 +164,9 @@ class QConfigGroupsModel(QAbstractItemModel):
                 return QIcon.fromTheme("document")
             if node.is_setting:
                 setting = cast("Setting", node.payload)
-                with suppress(Exception):
-                    dtype = CMMCorePlus.instance().getDeviceType(setting.device_name)
-                    if icon_string := ICONS.get(dtype):
-                        return QIconifyIcon(icon_string, color="gray").pixmap(16, 16)
-
-                return QIcon.fromTheme("emblem-system")
+                if icon := get_device_icon(setting.device_name, color="gray"):
+                    return icon.pixmap(16, 16)
+                return QIcon.fromTheme("emblem-system")  # pragma: no cover
 
         if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
             # settings: show Device, Property, Value
@@ -265,15 +178,59 @@ class QConfigGroupsModel(QAbstractItemModel):
                     return setting.property_name
                 if index.column() == Col.Value:
                     return setting.property_value
-                return None
-
             # groups / presets: only show name
             elif index.column() == Col.Item:
                 return node.name
-        return None
+
+        return None  # pragma: no cover
+
+    def setData(
+        self,
+        index: QModelIndex,
+        value: Any,
+        role: int = Qt.ItemDataRole.EditRole,
+    ) -> bool:
+        node = self._node_from_index(index)
+        if node is self._root or role != Qt.ItemDataRole.EditRole:
+            return False  # pragma: no cover
+
+        if node.is_setting:
+            if 0 > index.column() > 3:
+                return False  # pragma: no cover
+            dev, prop, val = list(cast("Setting", node.payload))
+
+            # update node in place  # FIXME ... this is hacky
+            args = [dev, prop, val]
+            args[index.column()] = str(value)
+            node.name = f"{args[0]}-{args[1]}"
+            node.payload = new_setting = Setting(*args)
+
+            # also update the parent preset.settings list reference
+            parent_preset = cast("ConfigPreset", node.parent.payload)  # type: ignore
+            for i, s in enumerate(parent_preset.settings):
+                if s[0:2] == (dev, prop):
+                    parent_preset.settings[i] = new_setting
+                    break
+        else:
+            new_name = str(value).strip()
+            if new_name == node.name or not new_name:
+                return False
+
+            if self._name_exists(node.parent, new_name):
+                QMessageBox.warning(
+                    None, "Duplicate name", f"Name '{new_name}' already exists."
+                )
+                return False
+
+            node.name = new_name
+            if isinstance(node.payload, (ConfigGroup, ConfigPreset)):
+                node.payload.name = new_name  # keep dataclass in sync
+
+        self.dataChanged.emit(index, index, [role])
+        return True
 
     def flags(self, index: QModelIndex) -> Qt.ItemFlag:
-        node = self._node(index)
+        node = self._node_from_index(index)
         if node is self._root:
             return Qt.ItemFlag.NoItemFlags
 
@@ -283,106 +240,6 @@ class QConfigGroupsModel(QAbstractItemModel):
         elif not node.is_setting and index.column() == Col.Item:
             fl |= Qt.ItemFlag.ItemIsEditable
         return fl
-
-    def setData(
-        self,
-        index: QModelIndex,
-        value: Any,
-        role: int = Qt.ItemDataRole.EditRole,
-    ) -> bool:
-        node = self._node(index)
-        if node is self._root or role != Qt.ItemDataRole.EditRole:
-            return False
-
-        if node.is_setting and index.column() == Col.Value:
-            setting = cast("Setting", node.payload)
-            setting = Setting(
-                setting.device_name, setting.property_name, cast("str", value)
-            )
-            node.payload = setting
-            # also update the preset.settings list reference
-            # find node.parent.payload (ConfigPreset) and update list element
-            parent_preset = cast("ConfigPreset", node.parent.payload)  # type: ignore
-            for i, s in enumerate(parent_preset.settings):
-                if (
-                    s.device_name == setting.device_name
-                    and s.property_name == setting.property_name
-                ):
-                    parent_preset.settings[i] = setting
-                    break
-            self.dataChanged.emit(index, index, [role])
-            return True
-
-        new_name = str(value)
-        if new_name == node.name:
-            return True
-        if not new_name:
-            return False
-        if self._name_exists(node.parent, new_name):
-            QMessageBox.warning(
-                None, "Duplicate name", f"Name '{new_name}' already exists."
-            )
-            return False
-        node.name = new_name
-        if isinstance(node.payload, (ConfigGroup, ConfigPreset)):
-            node.payload.name = new_name  # keep dataclass in sync
-        self.dataChanged.emit(index, index, [role])
-        return True
-
-    # ------------------------------------------------------------------
-    # Private helpers
-    # ------------------------------------------------------------------
-
-    def _build_tree(self, groups: Iterable[ConfigGroup]) -> None:
-        self._root.children.clear()
-        for g in groups:
-            gnode = _Node(g.name, g, self._root)
-            self._root.children.append(gnode)
-            for p in g.presets.values():
-                pnode = _Node(p.name, p, gnode)
-                gnode.children.append(pnode)
-                # add one child per Setting
-                for s in p.settings:
-                    snode = _Node(s.device_name, s, pnode)
-                    pnode.children.append(snode)
-
-    # ------------------------------------------------------------------
-    # Public mutator helpers
-    # ------------------------------------------------------------------
-
-    def update_preset_settings(
-        self, preset_idx: QModelIndex, settings: list[Setting]
-    ) -> None:
-        """Replace <preset> settings and update the tree safely.
-
-        We remove old Setting rows with beginRemoveRows/endRemoveRows,
-        then insert the new ones.  This guarantees attached views drop any
-        QModelIndex that referenced the old child nodes (avoiding the crash
-        seen when switching presets).
-        """
-        if not self._is_preset_index(preset_idx):
-            return
-
-        preset_node = cast("_Node", preset_idx.internalPointer())
-        preset: ConfigPreset = cast("ConfigPreset", preset_node.payload)
-
-        # --- mutate underlying dataclass ----------------------------------
-        preset.settings = list(settings)
-
-        # --- remove existing Setting rows ---------------------------------
-        old_row_count = len(preset_node.children)
-        if old_row_count:
-            self.beginRemoveRows(preset_idx, 0, old_row_count - 1)
-            preset_node.children.clear()
-            self.endRemoveRows()
-
-        # --- insert new Setting rows --------------------------------------
-        new_row_count = len(settings)
-        if new_row_count:
-            self.beginInsertRows(preset_idx, 0, new_row_count - 1)
-            for s in settings:
-                preset_node.children.append(_Node(s.device_name, s, preset_node))
-            self.endInsertRows()
 
     def headerData(
         self,
@@ -395,21 +252,163 @@ class QConfigGroupsModel(QAbstractItemModel):
             and role == Qt.ItemDataRole.DisplayRole
         ):
             return Col(section).name if section < len(Col) else None
-        return super().headerData(section, orientation, role)
+        return super().headerData(section, orientation, role)  # pragma: no cover
+
+    # ##################################################################
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def index_for_group(self, group_name: str) -> QModelIndex:
+        """Return the QModelIndex for the group with the given name."""
+        for i, node in enumerate(self._root.children):
+            if node.is_group and node.name == group_name:
+                return self.createIndex(i, 0, node)
+        return QModelIndex()
+
+    def index_for_preset(
+        self, group: QModelIndex | str, preset_name: str
+    ) -> QModelIndex:
+        """Return the QModelIndex for the preset with the given name in the group."""
+        if isinstance(group, QModelIndex):
+            group_index = group
+        else:
+            group_index = self.index_for_group(group)
+
+        group_node = self._node_from_index(group_index)
+        if not isinstance(group_node.payload, ConfigGroup):
+            return QModelIndex()
+
+        for i, node in enumerate(group_node.children):
+            if node.is_preset and node.name == preset_name:
+                return self.createIndex(i, 0, node)
+        return QModelIndex()
+
+    # group-level -------------------------------------------------------------
+
+    def add_group(self, base_name: str = "Group") -> QModelIndex:
+        """Append a *new* empty group and return its QModelIndex."""
+        name = self._unique_child_name(self._root, base_name)
+        group = ConfigGroup(name=name)
+        node = _Node.create(group, self._root)
+        return self._insert_node(node, self._root, len(self._root.children))
+
+    def duplicate_group(
+        self, idx: QModelIndex, new_name: str | None = None
+    ) -> QModelIndex:
+        node = self._node_from_index(idx)
+        if not isinstance((group := node.payload), ConfigGroup):
+            raise ValueError("Reference index is not a ConfigGroup.")
+
+        new_grp = deepcopy(group)
+        new_grp.name = new_name or self._unique_child_name(self._root, new_grp.name)
+        new_node = _Node.create(new_grp, self._root)
+        return self._insert_node(new_node, self._root, idx.row() + 1)
+
+    # preset-level ------------------------------------------------------------
+
+    def add_preset(
+        self, group_idx: QModelIndex, base_name: str = "Preset"
+    ) -> QModelIndex:
+        group_node = self._node_from_index(group_idx)
+        if not isinstance(group_node.payload, ConfigGroup):
+            raise ValueError("Reference index is not a ConfigGroup.")
+
+        name = self._unique_child_name(group_node, base_name)
+        preset = ConfigPreset(name)
+        node = _Node.create(preset, group_node)
+        return self._insert_node(node, group_node, len(group_node.children))
+
+    def duplicate_preset(
+        self, preset_index: QModelIndex, new_name: str | None = None
+    ) -> QModelIndex:
+        preset_node = self._node_from_index(preset_index)
+        if not isinstance((preset := preset_node.payload), ConfigPreset):
+            raise ValueError("Reference index is not a ConfigPreset.")
+        if not isinstance(group_node := preset_node.parent, _Node):
+            raise ValueError("Preset has no parent group.")  # pragma: no cover
+
+        preset = deepcopy(preset)
+        preset.name = new_name or self._unique_child_name(group_node, preset.name)
+        node = _Node.create(preset, group_node)
+        return self._insert_node(node, group_node, preset_index.row() + 1)
+
+    # generic remove ----------------------------------------------------------
+
+    def removeRows(
+        self,
+        row: int,
+        count: int,
+        parent: QModelIndex = NULL_INDEX,
+    ) -> bool:
+        """Remove `count` rows starting at `row` from the parent index."""
+        parent_node = self._node_from_index(parent)
+
+        # sanity-check the request
+        if count <= 0 or row < 0 or row + count > len(parent_node.children):
+            return False  # pragma: no cover
+
+        self.beginRemoveRows(parent, row, row + count - 1)
+
+        # drop the slice from the tree
+        del parent_node.children[row : row + count]
+
+        # keep the owning dataclass in sync with the new order
+        if isinstance((group := parent_node.payload), ConfigGroup):
+            group.presets = {
+                p.name: p
+                for n in parent_node.children
+                if isinstance((p := n.payload), ConfigPreset)
+            }
+        elif isinstance((preset := parent_node.payload), ConfigPreset):
+            preset.settings = [cast("Setting", n.payload) for n in parent_node.children]
+
+        self.endRemoveRows()
+        return True
+
+    def remove(self, idx: QModelIndex) -> None:
+        if idx.isValid():
+            self.removeRows(idx.row(), 1, idx.parent())
+
+    # ------------------------------------------------------------------
+    # Public mutator helpers
+    # ------------------------------------------------------------------
+
+    # TODO: feels like this should be replaced with a more canonical method...
+    def update_preset_settings(
+        self, preset_idx: QModelIndex, settings: list[Setting]
+    ) -> None:
+        """Replace settings for `preset_idx` and update the tree safely."""
+        preset_node = self._node_from_index(preset_idx)
+        if not isinstance((preset := preset_node.payload), ConfigPreset):
+            raise ValueError("Reference index is not a ConfigPreset.")
+
+        # --- remove existing Setting rows ---------------------------------
+        old_row_count = len(preset_node.children)
+        if old_row_count:
+            self.removeRows(0, old_row_count, preset_idx)
+
+        # --- mutate underlying dataclass ----------------------------------
+        preset.settings = list(settings)
+        if n_rows := len(preset.settings):
+            self.beginInsertRows(preset_idx, 0, n_rows - 1)
+            for s in preset.settings:
+                preset_node.children.append(_Node.create(s, preset_node))
+            self.endInsertRows()
 
     # name uniqueness ---------------------------------------------------------
 
     @staticmethod
-    def _unique_child_name(parent: _Node, base: str) -> str:
+    def _unique_child_name(parent: _Node, base: str, suffix: str = " copy") -> str:
         names = {c.name for c in parent.children}
         if base not in names:
             return base
         # try 'base copy' ... but then resort to 'base copy(n)' if needed
-        if (name := f"{base} copy") not in names:
+        if (name := f"{base}{suffix}") not in names:
             return name
         n = 1
         while name in names:
-            name = f"{base} copy ({n})"
+            name = f"{base}{suffix} ({n})"
             n += 1
         return name
 
@@ -417,17 +416,39 @@ class QConfigGroupsModel(QAbstractItemModel):
     def _name_exists(parent: _Node | None, name: str) -> bool:
         return parent is not None and any(c.name == name for c in parent.children)
 
-    # convenience guards ------------------------------------------------------
+    # external data API -------------------------------------------------------
+    #
+    # These methods deal with our internal python objects, rather than QModelIndex
 
-    @staticmethod
-    def _is_group_index(idx: QModelIndex) -> bool:
-        return idx.isValid() and cast("_Node", idx.internalPointer()).is_group
+    def set_groups(self, groups: Iterable[ConfigGroup]) -> None:
+        """Clear model and set new groups."""
+        self.beginResetModel()
+        self._root.children.clear()
+        for g in groups:
+            self._root.children.append(_Node.create(g, self._root))
+        self.endResetModel()
 
-    @staticmethod
-    def _is_preset_index(idx: QModelIndex) -> bool:
-        return idx.isValid() and cast("_Node", idx.internalPointer()).is_preset
+    def get_groups(self) -> list[ConfigGroup]:
+        """Return All ConfigGroups in the model."""
+        return deepcopy([cast("ConfigGroup", n.payload) for n in self._root.children])
+
+    def _node_from_index(self, index: QModelIndex | None) -> _Node:
+        if (
+            index
+            and index.isValid()
+            and isinstance((node := index.internalPointer()), _Node)
+        ):
+            # return the node if index is valid
+            return node
+        # otherwise return the root node
+        return self._root
 
     # insertion ---------------------------------------------------------------
+
+    # TODO: use this instead of _insert_node
+    # def insertRows(
+    #     self, row: int, count: int, parent: QModelIndex = NULL_INDEX
+    # ) -> bool: ...
 
     def _insert_node(self, node: _Node, parent_node: _Node, row: int) -> QModelIndex:
         self.beginInsertRows(self._index_from_node(parent_node), row, row)
@@ -455,14 +476,3 @@ class QConfigGroupsModel(QAbstractItemModel):
         if node is self._root:
             return QModelIndex()
         return self.createIndex(node.row_in_parent(), 0, node)
-
-    # external data API -------------------------------------------------------
-
-    def set_groups(self, groups: Iterable[ConfigGroup]) -> None:
-        self.beginResetModel()
-        self._build_tree(groups)
-        self.endResetModel()
-
-    def data_as_groups(self) -> list[ConfigGroup]:
-        """Return a *deep copy* of current configuration as dataclasses."""
-        return deepcopy([cast("ConfigGroup", n.payload) for n in self._root.children])

--- a/tests/test_config_groups_model.py
+++ b/tests/test_config_groups_model.py
@@ -231,3 +231,9 @@ def test_update_preset_settings(model: QConfigGroupsModel, qtbot: QtBot) -> None
 
     with pytest.raises(ValueError, match="Reference index is not a ConfigPreset."):
         model.update_preset_settings(QModelIndex(), new_settings)
+
+
+# def test_standard_item_model(
+#     model: QConfigGroupsModel, qtmodeltester: ModelTester
+# ) -> None:
+#     qtmodeltester.check(model)

--- a/tests/test_config_groups_model.py
+++ b/tests/test_config_groups_model.py
@@ -10,7 +10,7 @@ from qtpy.QtCore import QModelIndex, Qt
 from qtpy.QtGui import QFont, QIcon, QPixmap
 from qtpy.QtWidgets import QMessageBox
 
-from pymmcore_widgets.config_presets._qmodel._config_model import QConfigGroupsModel
+from pymmcore_widgets.config_presets import QConfigGroupsModel
 
 if TYPE_CHECKING:
     from pytestqt.modeltest import ModelTester

--- a/tests/test_config_groups_model.py
+++ b/tests/test_config_groups_model.py
@@ -1,8 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
 import pytest
 from pymmcore_plus import CMMCorePlus
-from pymmcore_plus.model import ConfigGroup
+from pymmcore_plus.model import ConfigGroup, ConfigPreset, Setting
+from qtpy.QtCore import QModelIndex, Qt
+from qtpy.QtGui import QFont, QIcon, QPixmap
+from qtpy.QtWidgets import QMessageBox
 
 from pymmcore_widgets.config_presets._qmodel._config_model import QConfigGroupsModel
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
 
 
 @pytest.fixture
@@ -19,18 +30,204 @@ def test_model_initialization() -> None:
     # not using the fixture here, as we want to test the model creation directly
     core = CMMCorePlus()
     core.loadSystemConfiguration()
-    python_info = ConfigGroup.all_config_groups(core)
-    model = QConfigGroupsModel(python_info.values())
+    python_info = list(ConfigGroup.all_config_groups(core).values())
+    model = QConfigGroupsModel(python_info)
 
     assert isinstance(model, QConfigGroupsModel)
     assert model.rowCount() > 0
     assert model.columnCount() == 3
 
     # original data is recovered intact
-    assert model.python_object() == python_info
+    assert model.get_groups() == python_info
+    assert model.data(QModelIndex()) is None
 
-    # we can also index deeper
-    for row, value in enumerate(python_info.values()):
-        assert model.python_object(model.index(row)) == value
 
-    assert not model.parent(model.index(3)).isValid()
+def test_model_basic_methods(model: QConfigGroupsModel) -> None:
+    """Test basic methods of the QConfigGroupsModel."""
+    assert model.flags(QModelIndex()) == Qt.ItemFlag.NoItemFlags
+
+    grp = model.index(0)
+    preset = model.index(0, 0, grp)
+    setting = model.index(0, 2, preset)
+
+    assert model.flags(grp) & Qt.ItemFlag.ItemIsEnabled
+    assert model.flags(preset) & Qt.ItemFlag.ItemIsEnabled
+    assert model.flags(setting) & Qt.ItemFlag.ItemIsEditable
+
+    assert model.headerData(0, Qt.Orientation.Horizontal) == "Item"
+    assert model.headerData(1, Qt.Orientation.Horizontal) == "Property"
+    assert model.headerData(2, Qt.Orientation.Horizontal) == "Value"
+
+
+@pytest.mark.parametrize(
+    "role, type",
+    [
+        (Qt.ItemDataRole.DisplayRole, str),
+        (Qt.ItemDataRole.EditRole, str),
+        (Qt.ItemDataRole.UserRole, (ConfigGroup, ConfigPreset, Setting)),
+        (Qt.ItemDataRole.FontRole, QFont),
+        (Qt.ItemDataRole.DecorationRole, (QIcon, QPixmap)),
+    ],
+)
+def test_model_data(model: QConfigGroupsModel, role: int, type: type) -> None:
+    grp0_index = model.index(0, 0)
+    preset0_index = model.index(0, 0, grp0_index)
+    setting0_dev_idx = model.index(0, 0, preset0_index)
+    setting0_prop_idx = model.index(0, 1, preset0_index)
+    setting0_value_idx = model.index(0, 2, preset0_index)
+
+    group_data = model.data(grp0_index, role)
+    assert isinstance(group_data, type)
+
+    preset_data = model.data(preset0_index, role)
+    assert isinstance(preset_data, type)
+
+    dev_name = model.data(setting0_dev_idx, role)
+    assert isinstance(dev_name, type)
+    if role == Qt.ItemDataRole.DisplayRole:
+        prop_name = model.data(setting0_prop_idx, role)
+        assert isinstance(prop_name, type)
+        prop_value = model.data(setting0_value_idx, role)
+        assert isinstance(prop_value, type)
+
+
+def test_model_set_data(model: QConfigGroupsModel, qtbot: QtBot) -> None:
+    """Test setting data in the model."""
+    grp0_index = model.index(0, 0)
+    preset0_index = model.index(0, 0, grp0_index)
+    setting0_dev_idx = model.index(0, 0, preset0_index)
+    setting0_prop_idx = model.index(0, 1, preset0_index)
+    setting0_value_idx = model.index(0, 2, preset0_index)
+
+    with qtbot.waitSignal(model.dataChanged):
+        assert model.setData(grp0_index, "NewGroupName")
+    with qtbot.waitSignal(model.dataChanged):
+        assert model.setData(preset0_index, "NewPresetName")
+    with qtbot.waitSignal(model.dataChanged):
+        assert model.setData(setting0_dev_idx, "NewDevice")
+    with qtbot.waitSignal(model.dataChanged):
+        assert model.setData(setting0_prop_idx, "NewProperty")
+    with qtbot.waitSignal(model.dataChanged):
+        assert model.setData(setting0_value_idx, "NewSettingValue")
+
+    group0 = model.get_groups()[0]
+    preset0 = next(iter(group0.presets.values()))
+    setting0 = preset0.settings[0]
+
+    assert group0.name == "NewGroupName"
+    assert preset0.name == "NewPresetName"
+    assert setting0.device_name == "NewDevice"
+    assert setting0.property_name == "NewProperty"
+    assert setting0.property_value == "NewSettingValue"
+
+    # setting to the same value should not change the model
+    current_name = grp0_index.data(Qt.ItemDataRole.EditRole)
+    assert model.setData(grp0_index, current_name) is False
+    # setting to an empty string should not change the model
+    assert model.setData(grp0_index, "") is False
+    # setting to a value that already exists should show a warning
+    existing_name = model.index(1).data(Qt.ItemDataRole.EditRole)  # next row down
+    with patch.object(QMessageBox, "warning") as mock_warning:
+        assert model.setData(grp0_index, existing_name) is False
+        mock_warning.assert_called_once()
+
+
+def test_index_queries(model: QConfigGroupsModel) -> None:
+    """Test index queries in the model."""
+    group0 = model.get_groups()[0]
+    # non-existent group returns an invalid index
+    assert not model.index_for_group("Python").isValid()
+    # existing group returns a valid index
+    group0_index = model.index_for_group(group0.name)
+    assert group0_index.isValid()
+
+    # non-existent preset returns an invalid index
+    preset0 = next(iter(group0.presets.values()))
+    assert not model.index_for_preset(group0.name, "NonExistentPreset").isValid()
+    # existing preset returns a valid index using group name
+    assert model.index_for_preset(group0.name, preset0.name).isValid()
+    # ... or using group_index
+    assert model.index_for_preset(group0_index, preset0.name).isValid()
+    # but not an invalid group index
+    invalid_group_index = QModelIndex()
+    assert not model.index_for_preset(invalid_group_index, preset0.name).isValid()
+
+
+def test_add_dupe_group(model: QConfigGroupsModel, qtbot: QtBot) -> None:
+    """Test adding a duplicate group."""
+    groups = {g.name for g in model.get_groups()}
+    grp0_index = model.index(0)
+    idx = model.add_group("New Group")
+    assert idx.isValid()
+    assert idx.data(Qt.ItemDataRole.DisplayRole) == "New Group"
+    idx2 = model.duplicate_group(grp0_index)
+    assert idx2.isValid()
+    model.duplicate_group(grp0_index)  # and again ... copy (1)
+
+    new_groups = {g.name for g in model.get_groups()}
+    assert new_groups - groups == {
+        "New Group",
+        grp0_index.data(Qt.ItemDataRole.DisplayRole) + " copy",
+        grp0_index.data(Qt.ItemDataRole.DisplayRole) + " copy (1)",
+    }
+
+    with pytest.raises(ValueError, match="Reference index is not a ConfigGroup."):
+        model.duplicate_group(QModelIndex())
+
+
+def test_add_dupe_preset(model: QConfigGroupsModel, qtbot: QtBot) -> None:
+    """Test adding a duplicate preset."""
+    grp0_index = model.index(0, 0)
+    preset0_index = model.index(0, 0, grp0_index)
+    idx = model.add_preset(grp0_index, "New Preset")
+    assert idx.isValid()
+    assert idx.data(Qt.ItemDataRole.DisplayRole) == "New Preset"
+
+    model.duplicate_preset(preset0_index)
+
+    new_presets = {p.name for p in model.get_groups()[0].presets.values()}
+    assert "New Preset" in new_presets
+    assert preset0_index.data(Qt.ItemDataRole.DisplayRole) + " copy" in new_presets
+
+    with pytest.raises(ValueError, match="Reference index is not a ConfigPreset."):
+        model.duplicate_preset(QModelIndex())
+
+    with pytest.raises(ValueError, match="Reference index is not a ConfigGroup."):
+        model.add_preset(QModelIndex(), "New Preset")
+
+
+def test_remove(model: QConfigGroupsModel, qtbot: QtBot) -> None:
+    """Test removing groups and presets."""
+    group_names = {x.name for x in model.get_groups()}
+    grp0_index = model.index(0)
+    grp0_name = grp0_index.data(Qt.ItemDataRole.DisplayRole)
+    assert grp0_name in group_names
+    model.remove(grp0_index)
+    assert grp0_name not in {x.name for x in model.get_groups()}
+
+
+def test_update_preset_settings(model: QConfigGroupsModel, qtbot: QtBot) -> None:
+    """Test updating preset settings."""
+    original_data = model.get_groups()
+    preset0 = next(iter(original_data[0].presets.values()))
+    assert len(preset0.settings) > 1
+    assert preset0.settings[0].device_name != "NewDevice"
+
+    grp0_index = model.index(0, 0)
+    preset0_index = model.index(0, 0, grp0_index)
+    new_settings = [
+        Setting(
+            device_name="NewDevice",
+            property_name="NewProperty",
+            property_value="NewValue",
+        )
+    ]
+    model.update_preset_settings(preset0_index, new_settings)
+
+    new_data = model.get_groups()
+    preset0_new = next(iter(new_data[0].presets.values()))
+    assert len(preset0_new.settings) == 1
+    assert preset0_new.settings == new_settings
+
+    with pytest.raises(ValueError, match="Reference index is not a ConfigPreset."):
+        model.update_preset_settings(QModelIndex(), new_settings)

--- a/tests/test_config_groups_model.py
+++ b/tests/test_config_groups_model.py
@@ -1,0 +1,36 @@
+import pytest
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.model import ConfigGroup
+
+from pymmcore_widgets.config_presets._qmodel._config_model import QConfigGroupsModel
+
+
+@pytest.fixture
+def model() -> QConfigGroupsModel:
+    """Fixture to create a QConfigGroupsModel instance."""
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    model = QConfigGroupsModel.create_from_core(core)
+    return model
+
+
+def test_model_initialization() -> None:
+    """Test the initialization of the QConfigGroupsModel."""
+    # not using the fixture here, as we want to test the model creation directly
+    core = CMMCorePlus()
+    core.loadSystemConfiguration()
+    python_info = ConfigGroup.all_config_groups(core)
+    model = QConfigGroupsModel(python_info.values())
+
+    assert isinstance(model, QConfigGroupsModel)
+    assert model.rowCount() > 0
+    assert model.columnCount() == 3
+
+    # original data is recovered intact
+    assert model.python_object() == python_info
+
+    # we can also index deeper
+    for row, value in enumerate(python_info.values()):
+        assert model.python_object(model.index(row)) == value
+
+    assert not model.parent(model.index(3)).isValid()

--- a/tests/test_config_groups_model.py
+++ b/tests/test_config_groups_model.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import QMessageBox
 from pymmcore_widgets.config_presets._qmodel._config_model import QConfigGroupsModel
 
 if TYPE_CHECKING:
+    from pytestqt.modeltest import ModelTester
     from pytestqt.qtbot import QtBot
 
 
@@ -233,7 +234,7 @@ def test_update_preset_settings(model: QConfigGroupsModel, qtbot: QtBot) -> None
         model.update_preset_settings(QModelIndex(), new_settings)
 
 
-# def test_standard_item_model(
-#     model: QConfigGroupsModel, qtmodeltester: ModelTester
-# ) -> None:
-#     qtmodeltester.check(model)
+def test_standard_item_model(
+    model: QConfigGroupsModel, qtmodeltester: ModelTester
+) -> None:
+    qtmodeltester.check(model)


### PR DESCRIPTION
pulling out from #446 ... this is the key model object that lets multiple views edit configuration groups and presets