### PR TITLE
fix: fix pyside6 tests

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from pytestqt.qtbot import QtBot
+    from qtpy.QtCore import SignalInstance
+
+
+@contextmanager
+def wait_signal(
+    qtbot: QtBot, signal: SignalInstance, timeout: int = 2000
+) -> Iterator[None]:
+    """Context manager to wait for a signal.
+
+    In some (as of yet understood) cases, qtbot.waitSignal() causes segfaults with
+    PySide6.  Using manual polling like this seems to work around the issue.
+    """
+    mock = Mock()
+    signal.connect(mock)
+    try:
+        yield
+        qtbot.waitUntil(lambda: mock.call_count > 0, timeout=timeout)
+    finally:
+        signal.disconnect(mock)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from pymmcore_plus import CMMCorePlus
+from pymmcore_plus._accumulator import DeviceAccumulator
 from pymmcore_plus.core import _mmcore_plus
 
 if TYPE_CHECKING:
@@ -22,6 +23,11 @@ def global_mmcore() -> Iterator[CMMCorePlus]:
     mmc.loadSystemConfiguration(TEST_CONFIG)
     with patch.object(_mmcore_plus, "_instance", mmc):
         yield mmc
+    # FIXME: would be better if this wasn't needed, or was fixed upstream
+    DeviceAccumulator._CACHE.clear()
+    mmc.reset()
+    mmc.__del__()
+    del mmc
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_image_preview.py
+++ b/tests/test_image_preview.py
@@ -5,6 +5,8 @@ from pymmcore_plus import CMMCorePlus
 
 from pymmcore_widgets import ImagePreview
 
+from ._utils import wait_signal
+
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
@@ -16,11 +18,11 @@ def test_image_preview(qtbot: "QtBot"):
     qtbot.addWidget(widget)
     assert widget._mmc is mmcore
 
-    with qtbot.waitSignal(mmcore.events.imageSnapped):
+    with wait_signal(qtbot, mmcore.events.imageSnapped):
         mmcore.snap()
     img = widget._canvas.render()
 
-    with qtbot.waitSignal(mmcore.events.imageSnapped):
+    with wait_signal(qtbot, mmcore.events.imageSnapped):
         mmcore.snap()
     img2 = widget._canvas.render()
 

--- a/tests/test_live_button.py
+++ b/tests/test_live_button.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from qtpy.QtCore import QSize
 
 from pymmcore_widgets.control._live_button_widget import LiveButton
+from tests._utils import wait_signal
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -22,22 +23,22 @@ def test_live_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert live_btn.icon_color_off == "magenta"
 
     # test from direct mmcore signals
-    with qtbot.waitSignal(global_mmcore.events.continuousSequenceAcquisitionStarted):
+    with wait_signal(qtbot, global_mmcore.events.continuousSequenceAcquisitionStarted):
         global_mmcore.startContinuousSequenceAcquisition(0)
     assert live_btn.text() == "Stop"
 
-    with qtbot.waitSignal(global_mmcore.events.sequenceAcquisitionStopped):
+    with wait_signal(qtbot, global_mmcore.events.sequenceAcquisitionStopped):
         global_mmcore.stopSequenceAcquisition()
     assert not global_mmcore.isSequenceRunning()
     assert live_btn.text() == "Live"
 
     # test when button is pressed
-    with qtbot.waitSignal(global_mmcore.events.continuousSequenceAcquisitionStarted):
+    with wait_signal(qtbot, global_mmcore.events.continuousSequenceAcquisitionStarted):
         live_btn.click()
     assert live_btn.text() == "Stop"
     assert global_mmcore.isSequenceRunning()
 
-    with qtbot.waitSignal(global_mmcore.events.sequenceAcquisitionStopped):
+    with wait_signal(qtbot, global_mmcore.events.sequenceAcquisitionStopped):
         live_btn.click()
     assert not global_mmcore.isSequenceRunning()
     assert live_btn.text() == "Live"

--- a/tests/test_shutter_widget.py
+++ b/tests/test_shutter_widget.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from pymmcore_widgets.control._shutter_widget import GRAY, GREEN, ShuttersWidget
+from tests._utils import wait_signal
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -47,7 +48,7 @@ def test_shutter_widget_propertyChanged(qtbot: QtBot, global_mmcore: CMMCorePlus
     mmc = global_mmcore
     shutter, _, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         mmc.setProperty("Shutter", "State", False)
 
     assert not shutter.shutter_button.isEnabled()
@@ -64,7 +65,7 @@ def test_shutter_widget_autoShutterSet(qtbot: QtBot, global_mmcore: CMMCorePlus)
     mmc = global_mmcore
     shutter, state_dev_shutter, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignal(mmc.events.autoShutterSet):
+    with wait_signal(qtbot, mmc.events.autoShutterSet):
         mmc.setAutoShutter(False)
     assert shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
@@ -79,11 +80,9 @@ def test_shutter_widget_configSet(qtbot: QtBot, global_mmcore: CMMCorePlus):
     mmc = global_mmcore
     shutter, state_dev_shutter, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignals(
-        [
-            mmc.events.configSet,
-            mmc.events.propertyChanged,
-        ]
+    with (
+        wait_signal(qtbot, mmc.events.configSet),
+        wait_signal(qtbot, mmc.events.propertyChanged),
     ):
         mmc.setConfig("Channel", "DAPI")
         mmc.setShutterOpen("Multi Shutter", True)
@@ -102,24 +101,24 @@ def test_shutter_widget_SequenceAcquisition(qtbot: QtBot, global_mmcore: CMMCore
     mmc = global_mmcore
     shutter, state_dev_shutter, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignal(mmc.events.configSet):
+    with wait_signal(qtbot, mmc.events.configSet):
         mmc.setConfig("Channel", "DAPI")
 
-    with qtbot.waitSignal(mmc.events.continuousSequenceAcquisitionStarted):
+    with wait_signal(qtbot, mmc.events.continuousSequenceAcquisitionStarted):
         mmc.startContinuousSequenceAcquisition()
     assert shutter.shutter_button.text() == "Shutter opened"
     assert not shutter.shutter_button.isEnabled()
 
-    with qtbot.waitSignal(mmc.events.autoShutterSet):
+    with wait_signal(qtbot, mmc.events.autoShutterSet):
         mmc.setAutoShutter(False)
     assert shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
     assert multi_shutter.shutter_button.isEnabled()
     assert shutter.shutter_button.text() == "Shutter opened"
 
-    with qtbot.waitSignal(mmc.events.autoShutterSet):
+    with wait_signal(qtbot, mmc.events.autoShutterSet):
         mmc.setAutoShutter(True)
-    with qtbot.waitSignal(mmc.events.sequenceAcquisitionStopped):
+    with wait_signal(qtbot, mmc.events.sequenceAcquisitionStopped):
         mmc.stopSequenceAcquisition()
     assert not shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
@@ -133,13 +132,13 @@ def test_shutter_widget_autoshutter(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
     assert multi_shutter.autoshutter_checkbox.isChecked()
 
-    with qtbot.waitSignal(mmc.events.autoShutterSet):
+    with wait_signal(qtbot, mmc.events.autoShutterSet):
         multi_shutter.autoshutter_checkbox.setChecked(False)
     assert shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
     assert multi_shutter.shutter_button.isEnabled()
 
-    with qtbot.waitSignal(mmc.events.autoShutterSet):
+    with wait_signal(qtbot, mmc.events.autoShutterSet):
         multi_shutter.autoshutter_checkbox.setChecked(True)
     assert not shutter.shutter_button.isEnabled()
     assert state_dev_shutter.shutter_button.isEnabled()
@@ -151,37 +150,37 @@ def test_shutter_widget_button(qtbot: QtBot, global_mmcore: CMMCorePlus):
     mmc = global_mmcore
     shutter, state_dev_shutter, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignal(mmc.events.configSet):
+    with wait_signal(qtbot, mmc.events.configSet):
         mmc.setConfig("Channel", "DAPI")
 
-    with qtbot.waitSignal(mmc.events.autoShutterSet):
+    with wait_signal(qtbot, mmc.events.autoShutterSet):
         multi_shutter.autoshutter_checkbox.setChecked(False)
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         shutter.shutter_button.click()
     assert shutter.shutter_button.text() == "Shutter closed"
     assert not mmc.getShutterOpen("Shutter")
     assert mmc.getProperty("Shutter", "State") == "0"
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         shutter.shutter_button.click()
     assert shutter.shutter_button.text() == "Shutter opened"
     assert mmc.getShutterOpen("Shutter")
     assert mmc.getProperty("Shutter", "State") == "1"
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         state_dev_shutter.shutter_button.click()
     assert state_dev_shutter.shutter_button.text() == "StateDev Shutter opened"
     assert mmc.getShutterOpen("StateDev Shutter")
     assert mmc.getProperty("StateDev", "Label") == "State-1"
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         state_dev_shutter.shutter_button.click()
     assert state_dev_shutter.shutter_button.text() == "StateDev Shutter closed"
     assert not mmc.getShutterOpen("StateDev Shutter")
     assert mmc.getProperty("StateDev", "Label") == "State-1"
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         multi_shutter.shutter_button.click()
     assert multi_shutter.shutter_button.text() == "Multi Shutter opened"
     assert mmc.getShutterOpen("Multi Shutter")
@@ -217,10 +216,10 @@ def test_shutter_widget_setters(qtbot: QtBot, global_mmcore: CMMCorePlus):
     shutter.button_text_closed = "C"
     assert shutter.button_text_closed == "C"
 
-    with qtbot.waitSignal(mmc.events.continuousSequenceAcquisitionStarted):
+    with wait_signal(qtbot, mmc.events.continuousSequenceAcquisitionStarted):
         mmc.startContinuousSequenceAcquisition()
     assert shutter.shutter_button.text() == "O"
-    with qtbot.waitSignal(mmc.events.sequenceAcquisitionStopped):
+    with wait_signal(qtbot, mmc.events.sequenceAcquisitionStopped):
         mmc.stopSequenceAcquisition()
     assert shutter.shutter_button.text() == "C"
 
@@ -230,7 +229,7 @@ def test_shutter_widget_UserWarning(qtbot: QtBot, global_mmcore: CMMCorePlus):
     _, _, multi_shutter = _make_shutters(qtbot)
 
     assert multi_shutter.shutter_button.text() == "Multi Shutter closed"
-    with qtbot.waitSignal(mmc.events.systemConfigurationLoaded):
+    with wait_signal(qtbot, mmc.events.systemConfigurationLoaded):
         with pytest.warns(UserWarning):
             mmc.loadSystemConfiguration("MMConfig_demo.cfg")
             assert multi_shutter.shutter_button.text() == "None"
@@ -241,11 +240,14 @@ def test_multi_shutter_state_changed(qtbot: QtBot, global_mmcore: CMMCorePlus):
     mmc = global_mmcore
     shutter, shutter1, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignals([mmc.events.propertyChanged, mmc.events.configSet]):
+    with (
+        wait_signal(qtbot, mmc.events.propertyChanged),
+        wait_signal(qtbot, mmc.events.configSet),
+    ):
         mmc.setProperty("Core", "Shutter", "Multi Shutter")
         mmc.setConfig("Channel", "DAPI")
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         mmc.setProperty("Multi Shutter", "State", "0")
 
     assert mmc.getProperty("Multi Shutter", "State") == "0"
@@ -254,7 +256,7 @@ def test_multi_shutter_state_changed(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert multi_shutter.shutter_button.text() == "Multi Shutter closed"
     assert shutter.shutter_button.text() == "Shutter closed"
 
-    with qtbot.waitSignal(mmc.events.propertyChanged):
+    with wait_signal(qtbot, mmc.events.propertyChanged):
         mmc.setProperty("Multi Shutter", "State", "1")
 
     assert mmc.getProperty("Multi Shutter", "State") == "1"
@@ -268,7 +270,10 @@ def test_on_shutter_device_changed(qtbot: QtBot, global_mmcore: CMMCorePlus):
     mmc = global_mmcore
     shutter, shutter1, multi_shutter = _make_shutters(qtbot)
 
-    with qtbot.waitSignals([mmc.events.propertyChanged, mmc.events.configSet]):
+    with (
+        wait_signal(qtbot, mmc.events.propertyChanged),
+        wait_signal(qtbot, mmc.events.configSet),
+    ):
         mmc.setProperty("Core", "Shutter", "Multi Shutter")
         mmc.setConfig("Channel", "DAPI")
 
@@ -277,7 +282,10 @@ def test_on_shutter_device_changed(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert shutter.shutter_button.isEnabled()
     assert shutter1.shutter_button.isEnabled()
 
-    with qtbot.waitSignals([mmc.events.propertyChanged, mmc.events.configSet]):
+    with (
+        wait_signal(qtbot, mmc.events.propertyChanged),
+        wait_signal(qtbot, mmc.events.configSet),
+    ):
         mmc.setProperty("Core", "Shutter", "Shutter")
         mmc.setConfig("Channel", "DAPI")
 

--- a/tests/test_snap_button_widget.py
+++ b/tests/test_snap_button_widget.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from qtpy.QtCore import QSize
 
 from pymmcore_widgets.control._snap_button_widget import SnapButton
+from tests._utils import wait_signal
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -21,11 +22,9 @@ def test_snap_button_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
 
     global_mmcore.startContinuousSequenceAcquisition(0)
 
-    with qtbot.waitSignals(
-        [
-            global_mmcore.events.sequenceAcquisitionStopped,
-            global_mmcore.events.imageSnapped,
-        ]
+    with (
+        wait_signal(qtbot, global_mmcore.events.sequenceAcquisitionStopped),
+        wait_signal(qtbot, global_mmcore.events.imageSnapped),
     ):
         snap_btn.click()
         assert not global_mmcore.isSequenceRunning()


### PR DESCRIPTION
closes #454

looks like there are specifically some things in pytestqt's qtbot.waitSignal that are interacting poorly with the new signals.  This fixes the tests, and allows them to work for pyside6.9 again.  It doesn't preclude the possibility that the new signals have some additional "gotchas" that we need to look out for still.  but does allow us to "unskip" again in pymmcore-plus here: https://github.com/pymmcore-plus/pymmcore-plus/blob/692c2e0e2aedfeaeaf7339f8ff72b86d4811dc86/src/pymmcore_plus/core/_mmcore_plus.py#L2545-L2549