### PR TITLE
fix: don't check isinstance in stage controller

### DIFF
--- a/src/pymmcore_widgets/control/_q_stage_controller.py
+++ b/src/pymmcore_widgets/control/_q_stage_controller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import weakref
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from pymmcore_plus import AbstractChangeAccumulator, CMMCorePlus, core
 from qtpy.QtCore import QObject, QTimerEvent, Signal
@@ -85,9 +85,8 @@ class QStageMoveAccumulator(QObject):
                 self._timer_id = None
 
             if self.snap_on_finish:
-                core = getattr(self._accum, "_mmcore", None)
-                if isinstance(core, CMMCorePlus):
-                    core.snapImage()
+                if (core := getattr(self._accum, "_mmcore", None)) is not None:
+                    cast("CMMCorePlus", core).snapImage()
                 self.snap_on_finish = False
 
             self.moveFinished.emit()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,19 @@
+import re
+from pathlib import Path
+
+import pymmcore_widgets
+
+
+def test_no_direct_isinstance() -> None:
+    # grep the entire codebase for `isinstance(obj, CMMCorePlus)`
+    # and ensure that it is not used directly.
+    ROOT = Path(pymmcore_widgets.__file__).parent
+    for path in ROOT.rglob("*.py"):
+        content = path.read_text(encoding="utf-8")
+        if match := re.search(r"isinstance\s*\(\s*[^,]+,\s*CMMCorePlus", content):
+            line_no = content.count("\n", 0, match.start()) + 1
+            raise AssertionError(
+                f"Direct isinstance check for CMMCorePlus found in {path} at line "
+                f"{line_no}.\n Use structural checks instead... or open an issue to "
+                "discuss."
+            )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pymmcore_widgets
 
+ISINSTANCE_RE = re.compile(r"isinstance\s*\(\s*[^,]+,\s*CMMCore", re.MULTILINE)
+
 
 def test_no_direct_isinstance() -> None:
     # grep the entire codebase for `isinstance(obj, CMMCorePlus)`
@@ -10,7 +12,7 @@ def test_no_direct_isinstance() -> None:
     ROOT = Path(pymmcore_widgets.__file__).parent
     for path in ROOT.rglob("*.py"):
         content = path.read_text(encoding="utf-8")
-        if match := re.search(r"isinstance\s*\(\s*[^,]+,\s*CMMCore", content):
+        if match := ISINSTANCE_RE.search(content):
             line_no = content.count("\n", 0, match.start()) + 1
             raise AssertionError(
                 f"Direct isinstance check for CMMCore[Plus] found in {path} at line "

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,10 +10,10 @@ def test_no_direct_isinstance() -> None:
     ROOT = Path(pymmcore_widgets.__file__).parent
     for path in ROOT.rglob("*.py"):
         content = path.read_text(encoding="utf-8")
-        if match := re.search(r"isinstance\s*\(\s*[^,]+,\s*CMMCorePlus", content):
+        if match := re.search(r"isinstance\s*\(\s*[^,]+,\s*CMMCore", content):
             line_no = content.count("\n", 0, match.start()) + 1
             raise AssertionError(
-                f"Direct isinstance check for CMMCorePlus found in {path} at line "
+                f"Direct isinstance check for CMMCore[Plus] found in {path} at line "
                 f"{line_no}.\n Use structural checks instead... or open an issue to "
                 "discuss."
             )


### PR DESCRIPTION
related to https://github.com/pymmcore-plus/pymmcore-plus/issues/486 and  https://github.com/pymmcore-plus/pymmcore-remote/pull/11 

this is the one place we've found so far that actually checks isinstance instead of a structural check like hasattr, etc...
this one is trivial, and was an overly explicit catch of a possibly null weakref.  This change should allow pymmcore-widgets to be used with pymmcore-remote.  

Test added to prevent regressions.  

cc @gselzer.  let me know if you have a preferred alternative approach