### PR TITLE
fix: Convert svg_path to posix

### DIFF
--- a/src/pymmcore_widgets/control/_stage_widget.py
+++ b/src/pymmcore_widgets/control/_stage_widget.py
@@ -62,14 +62,14 @@ class MoveStageButton(QPushButton):
             MoveStageButton {{
                 border: none;
                 width: 38px;
-                image: url({svg_path(glyph, color="rgb(0, 180, 0)")});
+                image: url({svg_path(glyph, color="rgb(0, 180, 0)").as_posix()});
                 font-size: 38px;
             }}
             MoveStageButton:hover:!pressed {{
-                image: url({svg_path(glyph, color="lime")});
+                image: url({svg_path(glyph, color="lime").as_posix()});
             }}
             MoveStageButton:pressed {{
-                image: url({svg_path(glyph, color="green")});
+                image: url({svg_path(glyph, color="green").as_posix()});
             }}
             """
         )


### PR DESCRIPTION
Have been running into #440 a fair bit lately. @bscott711 was on the right path with his fix, as it seems that qss does not like Windows paths (could not find an official reference for this with a quick search, but StackOverflow [suggests this](https://stackoverflow.com/a/26121846). The buttons now look normal on my machine.

Closes #440