### PR TITLE
[WIP] feat: use useq-schema  GridFromPolygon + add grid overlap/acq mode

### DIFF
--- a/src/pymmcore_widgets/control/_rois/_vispy.py
+++ b/src/pymmcore_widgets/control/_rois/_vispy.py
@@ -47,7 +47,11 @@ class RoiPolygon(Compound):
 
         centers: list[tuple[float, float]] = []
         try:
-            if (grid := self._roi.create_grid_plan()) is not None:
+            if (
+                grid := self._roi.create_grid_plan(
+                    overlap=self._roi.fov_overlap, mode=self._roi.acq_mode
+                )
+            ) is not None:
                 for p in grid:
                     centers.append((p.x, p.y))
         except Exception as e:

--- a/src/pymmcore_widgets/control/_rois/roi_manager.py
+++ b/src/pymmcore_widgets/control/_rois/roi_manager.py
@@ -157,7 +157,7 @@ class SceneROIManager(QObject):
         return [
             self.roi_model.index(row).internalPointer()
             for row in range(self.roi_model.rowCount())
-    ]
+        ]
 
     def delete_selected_rois(self) -> None:
         """Delete the selected ROIs from the model."""

--- a/src/pymmcore_widgets/control/_rois/roi_manager.py
+++ b/src/pymmcore_widgets/control/_rois/roi_manager.py
@@ -152,6 +152,13 @@ class SceneROIManager(QObject):
             index.internalPointer() for index in self.selection_model.selectedIndexes()
         ]
 
+    def all_rois(self) -> list[ROI]:
+        """Return a list of all ROIs."""
+        return [
+            self.roi_model.index(row).internalPointer()
+            for row in range(self.roi_model.rowCount())
+    ]
+
     def delete_selected_rois(self) -> None:
         """Delete the selected ROIs from the model."""
         for roi in self.selected_rois():

--- a/src/pymmcore_widgets/control/_rois/roi_model.py
+++ b/src/pymmcore_widgets/control/_rois/roi_model.py
@@ -106,7 +106,7 @@ class ROI:
             if type(self) is not RectangleROI:
                 if len(self.vertices) < 3:
                     return None
-                return useq.GridFromPolygon(
+                return useq.GridFromPolygon(  # type: ignore # until new useq-schema
                     vertices=list(self.vertices),
                     fov_width=fov_w,
                     fov_height=fov_h,

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -429,7 +429,6 @@ class StageExplorer(QWidget):
     def _on_poll_stage_action(self, checked: bool) -> None:
         """Set the poll stage position property based on the state of the action."""
         self._stage_pos_marker.visible = checked
-        print("Stage position marker visible:", self._stage_pos_marker.visible)
         self._poll_stage_position = checked
         if checked:
             self._timer_id = self.startTimer(20)

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -339,7 +339,7 @@ class StageExplorer(QWidget):
             self._stage_pos_marker.set_marker_visible(pi.show_marker)
 
     def _on_scan_action(self) -> None:
-        """Scan the selected ROIs."""
+        """Scan the selected ROI."""
         if not (active_rois := self.roi_manager.selected_rois()):
             return
         active_roi = active_rois[0]
@@ -581,7 +581,7 @@ class StageExplorerToolbar(QToolBar):
         self.addSeparator()
         self.scan_action = self.addAction(
             QIconifyIcon("ph:path-duotone", color=GRAY),
-            "Scan Selected ROIs",
+            "Scan Selected ROI",
         )
 
 

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -291,6 +291,28 @@ class StageExplorer(QWidget):
         x_bounds, y_bounds, *_ = get_vispy_scene_bounds(visuals)
         self._stage_viewer.view.camera.set_range(x=x_bounds, y=y_bounds, margin=margin)
 
+    def rois_to_useq_positions(self) -> list[useq.AbsolutePosition] | None:
+        if not (rois := self.roi_manager.all_rois()):
+            return None
+
+        positions: list[useq.AbsolutePosition] = []
+        for idx, roi in enumerate(rois):
+            if plan := roi.create_grid_plan(*self._fov_w_h()):
+                p: useq.AbsolutePosition = next(iter(plan.iter_grid_positions()))
+                pos = useq.AbsolutePosition(
+                    name=f"ROI_{idx}",
+                    x=p.x,
+                    y=p.y,
+                    z=p.z,
+                    sequence=useq.MDASequence(grid_plan=plan),
+                )
+                positions.append(pos)
+
+        if not positions:
+            return None
+
+        return positions
+
     # -----------------------------PRIVATE METHODS------------------------------------
 
     # ACTIONS ----------------------------------------------------------------------

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -344,9 +344,7 @@ class StageExplorer(QWidget):
             return
         active_roi = active_rois[0]
         if plan := active_roi.create_grid_plan(*self._fov_w_h()):
-            # for now, we expand the grid plan to a list of positions because
-            # useq grid_plan= doesn't yet support our custom polygon ROIs
-            seq = useq.MDASequence(stage_positions=list(plan))
+            seq = useq.MDASequence(grid_plan=plan)
             if not self._mmc.mda.is_running():
                 self._our_mda_running = True
                 self._mmc.run_mda(seq)

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -469,8 +469,7 @@ class _BoundsWidget(QWidget):
 #     def setValue(self, plan: useq.GridFromPolygon) -> None:
 #         self._polygon = plan
 #         self._ax.clear()
-#         plan.plot(axes=self._ax)       # <— direct reuse
-#         self._ax.set_aspect("equal") # usually desirable for XY
+#         plan.plot(axes=self._ax)
 #         self._canvas.draw_idle()
 
 

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -585,8 +585,8 @@ class _PolygonWidget(QWidget):
             centers.append((float(x), float(y)))
         return centers
 
-    def resizeEvent(self, ev: QResizeEvent) -> None:
-        super().resizeEvent(ev)
+    def resizeEvent(self, a0: QResizeEvent | None) -> None:
+        super().resizeEvent(a0)
         self._fit_view_to_items()
 
 
@@ -595,10 +595,10 @@ class _ResizableStackedWidget(QStackedWidget):
         super().__init__(parent=parent)
         self.currentChanged.connect(self.onCurrentChanged)
 
-    def addWidget(self, wdg: QWidget | None) -> int:
-        if wdg is not None:
-            wdg.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Ignored)
-        return super().addWidget(wdg)  # type: ignore [no-any-return]
+    def addWidget(self, w: QWidget | None) -> int:
+        if w is not None:
+            w.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Ignored)
+        return super().addWidget(w)  # type: ignore [no-any-return]
 
     def onCurrentChanged(self, idx: int) -> None:
         for i in range(self.count()):

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -440,16 +440,16 @@ class _BoundsWidget(QWidget):
 class _PolygonWidget(QWidget):
     """QWidget that draws a useq.GridFromPolygon similar to its matplotlib `plot()`."""
 
-    VERTEX_RADIUS = 0.12
-    CENTER_RADIUS = 0.12
-    POLY_PEN = QPen(Qt.GlobalColor.darkMagenta, 0.08)
+    VERTEX_RADIUS = 0
+    CENTER_RADIUS = 0
+    POLY_PEN = QPen(Qt.GlobalColor.darkMagenta)
     POLY_BRUSH = QBrush(Qt.BrushStyle.NoBrush)
-    BB_PEN = QPen(Qt.GlobalColor.darkGray, 0.08, Qt.PenStyle.DashLine)
+    BB_PEN = QPen(Qt.GlobalColor.darkGray, 0, Qt.PenStyle.DashLine)
     VERTEX_PEN = QPen(Qt.GlobalColor.magenta, 0)
     VERTEX_BRUSH = QBrush(Qt.GlobalColor.magenta)
     CENTER_PEN = QPen(Qt.GlobalColor.darkGreen, 0)
     CENTER_BRUSH = QBrush(Qt.GlobalColor.darkGreen)
-    FOV_PEN = QPen(Qt.GlobalColor.darkGray, 0.08)
+    FOV_PEN = QPen(Qt.GlobalColor.darkGray)
     FOV_BRUSH = QBrush(Qt.BrushStyle.NoBrush)
 
     def __init__(self, show_fovs: bool = True, show_centers: bool = True) -> None:
@@ -491,12 +491,17 @@ class _PolygonWidget(QWidget):
         if not self._polygon and plan is None:
             return
 
+        fw, fh = plan.fov_width or 0, plan.fov_height or 0
+        pen_size = int(fw * 0.04) if fw > 0 else 1
+        self.VERTEX_RADIUS = self.CENTER_RADIUS = pen_size
+
         self._polygon = plan
         poly = self._polygon.poly
         verts: list[tuple[float, float]] = list(self._polygon.vertices or [])
 
         # draw polygon outline
         poly_item = self._make_polygon_item(poly)
+        self.POLY_PEN.setWidth(pen_size)
         poly_item.setPen(self.POLY_PEN)
         poly_item.setBrush(self.POLY_BRUSH)
         self.scene.addItem(poly_item)
@@ -508,16 +513,17 @@ class _PolygonWidget(QWidget):
         # draw dashed bounding box
         min_x, min_y, max_x, max_y = poly.bounds
         bb = QGraphicsRectItem(min_x, min_y, max_x - min_x, max_y - min_y)
+        self.BB_PEN.setWidth(pen_size)
         bb.setPen(self.BB_PEN)
         self.scene.addItem(bb)
 
         # draw grid centers and FOV rectangles
         centers = self._compute_centers(self._polygon)
-        fw, fh = plan.fov_width or 0, plan.fov_height or 0
         if fw > 0 and fh > 0:
             hw, hh = fw / 2.0, fh / 2.0
             for cx, cy in centers:
                 rect = QGraphicsRectItem(cx - hw, cy - hh, fw, fh)
+                self.FOV_PEN.setWidth(pen_size)
                 rect.setPen(self.FOV_PEN)
                 rect.setBrush(self.FOV_BRUSH)
                 self.scene.addItem(rect)

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -493,8 +493,9 @@ class _PolygonWidget(QWidget):
     # below this size.
     MAX_FOV_PIXELS = 50
 
-    def __init__(self, show_fovs: bool = True, show_centers: bool = True) -> None:
+    def __init__(self) -> None:
         super().__init__()
+
         self._polygon: useq.GridFromPolygon | None = None
 
         self.scene = QGraphicsScene()

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -606,6 +606,7 @@ class _PolygonWidget(QWidget):
         d = 2 * r
         ell = self.scene.addEllipse(x - r, y - r, d, d, pen, brush)
         ell = cast("QGraphicsEllipseItem", ell)
+        ell.setZValue(1.0)
         return ell
 
     def _fit_view_to_items(self, pad: float = 0.01) -> None:

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -29,10 +29,7 @@ if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
     GridPlan: TypeAlias = (
-        useq.GridFromEdges
-        | useq.GridRowsColumns
-        | useq.GridWidthHeight
-        | useq.GridFromPolygon
+        useq.GridFromEdges | useq.GridRowsColumns | useq.GridWidthHeight
     )
 
     class ValueWidget(Protocol, QWidget):  # pyright: ignore
@@ -58,7 +55,6 @@ class Mode(Enum):
     NUMBER = "number"
     AREA = "area"
     BOUNDS = "bounds"
-    POLYGON = "polygon"
 
     def __str__(self) -> str:
         return self.value
@@ -74,8 +70,6 @@ class Mode(Enum):
             return cls.BOUNDS
         elif isinstance(plan, useq.GridWidthHeight):
             return cls.AREA
-        elif isinstance(plan, useq.GridFromPolygon):
-            return cls.POLYGON
         raise TypeError(f"Unknown grid plan type: {type(plan)}")  # pragma: no cover
 
 
@@ -83,7 +77,6 @@ _MODE_TO_USEQ: dict[Mode, type[GridPlan]] = {
     Mode.NUMBER: useq.GridRowsColumns,
     Mode.BOUNDS: useq.GridFromEdges,
     Mode.AREA: useq.GridWidthHeight,
-    Mode.POLYGON: useq.GridFromPolygon,
 }
 
 

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -311,7 +311,7 @@ class GridPlanWidget(QScrollArea):
         if (val := self.value()) is None:
             return  # pragma: no cover
         if isinstance(val, useq.GridFromPolygon):
-            self.polygon_wdg._redraw(val)
+            self.polygon_wdg.setValue(val)
         self.valueChanged.emit(val)
 
 
@@ -435,6 +435,43 @@ class _BoundsWidget(QWidget):
         self.top.setValue(plan.top)
         self.right.setValue(plan.right)
         self.bottom.setValue(plan.bottom)
+
+
+# class _PolygonWidget(QWidget):
+#     def __init__(self, parent=None):
+#         from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as Canvas
+#         from matplotlib.figure import Figure
+
+#         super().__init__(parent)
+
+#         self._fig = Figure(constrained_layout=True)
+#         self._ax = self._fig.add_subplot(111)
+#         self._canvas = Canvas(self._fig)
+
+#         self._polygon: useq.GridFromPolygon | None = None
+
+#         lay = QVBoxLayout(self)
+#         lay.setContentsMargins(0, 0, 0, 0)
+#         lay.addWidget(self._canvas)
+
+#     def value(self) -> dict[str, Any]:
+#         vertices = self._polygon.vertices if self._polygon else []
+#         convex_hull = self._polygon.convex_hull if self._polygon else False
+#         offset = self._polygon.offset if self._polygon else 0
+#         if not vertices:
+#             return {
+#                 "vertices": [(0, 0), (0, 0), (0, 0)],
+#                 "convex_hull": False,
+#                 "offset": 0,
+#             }
+#         return {"vertices": vertices, "convex_hull": convex_hull, "offset": offset}
+
+#     def setValue(self, plan: useq.GridFromPolygon) -> None:
+#         self._polygon = plan
+#         self._ax.clear()
+#         plan.plot(axes=self._ax)       # <— direct reuse
+#         self._ax.set_aspect("equal") # usually desirable for XY
+#         self._canvas.draw_idle()
 
 
 class _PolygonWidget(QWidget):

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -29,7 +29,10 @@ if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
     GridPlan: TypeAlias = (
-        useq.GridFromEdges | useq.GridRowsColumns | useq.GridWidthHeight
+        useq.GridFromEdges
+        | useq.GridRowsColumns
+        | useq.GridWidthHeight
+        | useq.GridFromPolygon
     )
 
     class ValueWidget(Protocol, QWidget):  # pyright: ignore
@@ -55,6 +58,7 @@ class Mode(Enum):
     NUMBER = "number"
     AREA = "area"
     BOUNDS = "bounds"
+    POLYGON = "polygon"
 
     def __str__(self) -> str:
         return self.value
@@ -70,6 +74,8 @@ class Mode(Enum):
             return cls.BOUNDS
         elif isinstance(plan, useq.GridWidthHeight):
             return cls.AREA
+        elif isinstance(plan, useq.GridFromPolygon):
+            return cls.POLYGON
         raise TypeError(f"Unknown grid plan type: {type(plan)}")  # pragma: no cover
 
 
@@ -77,6 +83,7 @@ _MODE_TO_USEQ: dict[Mode, type[GridPlan]] = {
     Mode.NUMBER: useq.GridRowsColumns,
     Mode.BOUNDS: useq.GridFromEdges,
     Mode.AREA: useq.GridWidthHeight,
+    Mode.POLYGON: useq.GridFromPolygon,
 }
 
 

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -438,13 +438,13 @@ class _BoundsWidget(QWidget):
 
 
 class _PolygonWidget(QWidget):
-    """QWidget that draws a useq.GridFromPolygon similar to its matplotlib `plot()`."""
+    """QWidget that draws a useq.GridFromPolygon."""
 
     VERTEX_RADIUS = 0
     CENTER_RADIUS = 0
     POLY_PEN = QPen(Qt.GlobalColor.darkMagenta)
     POLY_BRUSH = QBrush(Qt.BrushStyle.NoBrush)
-    BB_PEN = QPen(Qt.GlobalColor.darkGray, 0, Qt.PenStyle.DashLine)
+    BB_PEN = QPen(Qt.GlobalColor.darkGray, 0, Qt.PenStyle.DotLine)
     VERTEX_PEN = QPen(Qt.GlobalColor.magenta, 0)
     VERTEX_BRUSH = QBrush(Qt.GlobalColor.magenta)
     CENTER_PEN = QPen(Qt.GlobalColor.darkGreen, 0)
@@ -519,6 +519,20 @@ class _PolygonWidget(QWidget):
 
         # draw grid centers and FOV rectangles
         centers = self._compute_centers(self._polygon)
+
+        # connect centers
+        if len(centers) >= 2:
+            path = QPainterPath(QPointF(*centers[0]))
+            for x, y in centers[1:]:
+                path.lineTo(x, y)
+            path_item = QGraphicsPathItem(path)
+            path_pen = QPen(self.CENTER_PEN)
+            path_pen.setWidth(pen_size)
+            path_pen.setStyle(Qt.PenStyle.DashLine)
+            path_item.setPen(path_pen)
+            path_item.setZValue(0.5)
+            self.scene.addItem(path_item)
+
         if fw > 0 and fh > 0:
             hw, hh = fw / 2.0, fh / 2.0
             for cx, cy in centers:

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -633,7 +633,6 @@ class _PolygonWidget(QWidget):
         # larger than MAX_FOV_PIXELS. If they are, scale the view down.
         try:
             current_scale = float(self.view.transform().m11())
-            print(current_scale)
         except Exception:
             current_scale = 1.0
         if self._polygon is not None:

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -152,10 +152,6 @@ class MDAButton(QWidget):
         self.setValue(None)
 
     def _on_click(self) -> None:
-
-        from rich import print
-        print(self._value)
-
         dialog = _MDAPopup(self._value, self)
         if dialog.exec():
             self.setValue(dialog.mda_tabs.value())

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import useq
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.figure import Figure
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -72,20 +70,6 @@ class _MDAPopup(QDialog):
                 break
             par = par.parent()
 
-        # if the grid plan is a GridFromPolygon, replace the grid plan tab with an
-        # empty tab where we show the result of GridFromPolygon.plot()
-        if value and (gp := value.grid_plan) and isinstance(gp, useq.GridFromPolygon):
-            self.mda_tabs.removeTab(self.mda_tabs.indexOf(self.mda_tabs.grid_plan))
-            self.mda_tabs.addTab(
-                _PolygonViewer(parent=self, polygon=gp),  # Pass the correct parameter
-                "Polygon Viewer",
-                checked=True,
-            )
-            # hide the checkbox
-            self.mda_tabs._cboxes[-1].setVisible(False)
-            # remove grid plan from value
-            value = value.replace(grid_plan=None)
-
         # set the value if provided
         if value:
             self.mda_tabs.setValue(value)
@@ -99,29 +83,6 @@ class _MDAPopup(QDialog):
         layout = QVBoxLayout(self)
         layout.addWidget(self.mda_tabs)
         layout.addWidget(self._btns)
-
-
-class _PolygonViewer(QWidget):
-    """A Simple widget to display the useq.GridFromPolygon."""
-
-    def __init__(
-        self,
-        parent: QWidget | None,
-        polygon: useq.GridFromPolygon,
-    ) -> None:
-        super().__init__(parent)
-
-        # create a matplotlib figure and canvas
-        self.plot_widget = FigureCanvas(Figure())
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.plot_widget)
-
-        # plot the polygon using the provided plot method
-        ax = self.plot_widget.figure.subplots()
-        ax.clear()
-        polygon.plot(axes=ax, hide_axes=True)
-        self.plot_widget.draw()
 
 
 class MDAButton(QWidget):

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -30,7 +30,12 @@ from pymmcore_widgets.useq_widgets._column_info import (
     TextColumn,
     parse_timedelta,
 )
-from pymmcore_widgets.useq_widgets._positions import MDAButton, QFileDialog, _MDAPopup
+from pymmcore_widgets.useq_widgets._positions import (
+    MDAButton,
+    QFileDialog,
+    _MDAPopup,
+    _PolygonViewer,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -552,3 +557,22 @@ def test_autofocus_with_z_plans(qtbot: QtBot) -> None:
 
     assert wdg.af_axis.isEnabled()
     assert wdg.stage_positions.af_per_position.isEnabled()
+
+
+def test_mda_popup_with_polygon(qtbot: QtBot) -> None:
+    polygon = useq.GridFromPolygon(
+        vertices=[(-10, 0), (12, -5), (10, 20), (0, 10)],
+        fov_height=1,
+        fov_width=1,
+    )
+    seq = useq.MDASequence(channels=["DAPI", "GFP"], grid_plan=polygon)
+    pop = _MDAPopup(seq)
+    qtbot.addWidget(pop)
+    # assert grid plan tab is hidden
+    assert pop.mda_tabs.grid_plan.isHidden()
+    # get the _polygon viewer
+    polygon = pop.mda_tabs.children()[0].widget(3)
+    # make sure it is a _PolygonViewer
+    assert isinstance(polygon, _PolygonViewer)
+    # make sure the plot is visible
+    assert polygon.plot_widget.figure is not None

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -587,4 +587,5 @@ def test_mda_popup_with_polygon(qtbot: QtBot) -> None:
     gp = pop.mda_tabs.grid_plan
     assert pop.mda_tabs.isChecked(gp)
     assert gp._mode_btn_group.checkedButton().text() == "Polygon"
-    assert gp.polygon_wdg.plot_widget.figure is not None
+    assert gp.polygon_wdg.scene is not None
+    assert gp.polygon_wdg.scene.items()

--- a/x.py
+++ b/x.py
@@ -6,16 +6,15 @@ from pymmcore_widgets import MDAWidget
 app = QApplication([])
 
 poly = useq.GridFromPolygon(
-    vertices=[(-400, 0), (1500, -500), (500, 1900), (0, 100)],
-    # vertices=[(0, 0), (300, 0), (300, 100), (100, 100), (100, 300), (0, 300)],
+    # vertices=[(-400, 0), (1000, -500), (500, 1200), (0, 100)],
+    vertices=[(0, 0), (300, 0), (300, 100), (100, 100), (100, 300), (0, 300)],
     fov_height=100,
     fov_width=100,
     overlap=(10, 10),
     # convex_hull=True
 )
 pos = useq.AbsolutePosition(x=1, y=2, z=3, sequence=useq.MDASequence(grid_plan=poly))
-# seq = useq.MDASequence(grid_plan=poly, stage_positions=[pos])
-seq = useq.MDASequence(grid_plan=poly)
+seq = useq.MDASequence(stage_positions=[pos])
 
 m = MDAWidget()
 m.setValue(seq)

--- a/x.py
+++ b/x.py
@@ -1,0 +1,23 @@
+import useq
+from qtpy.QtWidgets import QApplication
+
+from pymmcore_widgets import MDAWidget
+
+app = QApplication([])
+
+poly = useq.GridFromPolygon(
+    # vertices=[(0, 0), (10, -5), (12, 15), (0, 8)],
+    vertices=[(-4, 0), (5, -5), (5, 9), (0, 10)],
+    fov_height=1,
+    fov_width=1,
+    overlap=(0.1, 0.1)
+)
+pos = useq.AbsolutePosition(
+    x=1, y=2, z=3, sequence=useq.MDASequence(grid_plan=poly))
+seq = useq.MDASequence(grid_plan=poly, stage_positions=[pos])
+
+m = MDAWidget()
+m.setValue(seq)
+m.show()
+
+app.exec()

--- a/x.py
+++ b/x.py
@@ -6,15 +6,16 @@ from pymmcore_widgets import MDAWidget
 app = QApplication([])
 
 poly = useq.GridFromPolygon(
-    # vertices=[(0, 0), (10, -5), (12, 15), (0, 8)],
-    vertices=[(-4, 0), (5, -5), (5, 9), (0, 10)],
-    fov_height=1,
-    fov_width=1,
-    overlap=(0.1, 0.1)
+    vertices=[(-400, 0), (1500, -500), (500, 1900), (0, 100)],
+    # vertices=[(0, 0), (300, 0), (300, 100), (100, 100), (100, 300), (0, 300)],
+    fov_height=100,
+    fov_width=100,
+    overlap=(10, 10),
+    # convex_hull=True
 )
-pos = useq.AbsolutePosition(
-    x=1, y=2, z=3, sequence=useq.MDASequence(grid_plan=poly))
-seq = useq.MDASequence(grid_plan=poly, stage_positions=[pos])
+pos = useq.AbsolutePosition(x=1, y=2, z=3, sequence=useq.MDASequence(grid_plan=poly))
+# seq = useq.MDASequence(grid_plan=poly, stage_positions=[pos])
+seq = useq.MDASequence(grid_plan=poly)
 
 m = MDAWidget()
 m.setValue(seq)

--- a/x.py
+++ b/x.py
@@ -5,16 +5,26 @@ from pymmcore_widgets import MDAWidget
 
 app = QApplication([])
 
-poly = useq.GridFromPolygon(
-    # vertices=[(-400, 0), (1000, -500), (500, 1200), (0, 100)],
+poly1 = useq.GridFromPolygon(
+    vertices=[(-400, 0), (1000, -500), (500, 1200), (0, 100)],
+    fov_height=100,
+    fov_width=100,
+    overlap=(10, 10),
+)
+poly2 = useq.GridFromPolygon(
     vertices=[(0, 0), (300, 0), (300, 100), (100, 100), (100, 300), (0, 300)],
     fov_height=100,
     fov_width=100,
     overlap=(10, 10),
-    # convex_hull=True
 )
-pos = useq.AbsolutePosition(x=1, y=2, z=3, sequence=useq.MDASequence(grid_plan=poly))
-seq = useq.MDASequence(stage_positions=[pos])
+pos1 = useq.AbsolutePosition(
+    x=1, y=2, z=3, name="pos1", sequence=useq.MDASequence(grid_plan=poly1)
+)
+pos2 = useq.AbsolutePosition(
+    x=4, y=5, z=6, name="pos2", sequence=useq.MDASequence(grid_plan=poly2)
+)
+
+seq = useq.MDASequence(stage_positions=[pos1, pos2])
 
 m = MDAWidget()
 m.setValue(seq)

--- a/x.py
+++ b/x.py
@@ -1,7 +1,11 @@
 import useq
+from pymmcore_plus import CMMCorePlus
 from qtpy.QtWidgets import QApplication
 
 from pymmcore_widgets import MDAWidget
+
+mmc = CMMCorePlus.instance()
+mmc.loadSystemConfiguration()
 
 app = QApplication([])
 


### PR DESCRIPTION
## Add `GridFromPolygon` from `useq-schema`.

This can work only after I will create a PR to https://github.com/pymmcore-plus/useq-schema/pull/224 from my `useq-schema` branch: https://github.com/fdrgsp/useq-schema/tree/useq-polygon.

This PR replace the local `GridFromPolygon` logic and uses the `GridFromPolygon` form uses-schema.

It also updates `MDAWidget` to be able to receive a GridFromPolygon (I think mainly useful in position subsequences).

https://github.com/user-attachments/assets/38699fc6-abd7-45c0-a081-023d8e17e5fb


## Add grid overlap and acquisition order to scan menu of `StageExplorer`

https://github.com/user-attachments/assets/1702ec4b-51d9-45d3-8cf5-1e276d9f143a

