### PR TITLE
feat: use useq-schema GridFromPolygon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.35.4
     hooks:
       - id: typos
         args: [--force-exclude] # omitting --write-changes
@@ -29,4 +29,4 @@ repos:
         files: "^src/"
         additional_dependencies:
           - pymmcore-plus >=0.15.0
-          - useq-schema >=0.5.0
+          - useq-schema >=0.8.0

--- a/examples/temp/grid_from_polygon.py
+++ b/examples/temp/grid_from_polygon.py
@@ -1,0 +1,37 @@
+import useq
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QApplication
+
+from pymmcore_widgets import MDAWidget
+
+mmc = CMMCorePlus.instance()
+mmc.loadSystemConfiguration()
+
+app = QApplication([])
+
+poly1 = useq.GridFromPolygon(
+    vertices=[(-400, 0), (1000, -500), (500, 1200), (0, 100)],
+    fov_height=100,
+    fov_width=100,
+    overlap=(10, 10),
+)
+poly2 = useq.GridFromPolygon(
+    vertices=[(0, 0), (300, 0), (300, 100), (100, 100), (100, 300), (0, 300)],
+    fov_height=100,
+    fov_width=100,
+    overlap=(10, 10),
+)
+pos1 = useq.AbsolutePosition(
+    x=1, y=2, z=3, name="pos1", sequence=useq.MDASequence(grid_plan=poly1)
+)
+pos2 = useq.AbsolutePosition(
+    x=4, y=5, z=6, name="pos2", sequence=useq.MDASequence(grid_plan=poly2)
+)
+
+seq = useq.MDASequence(stage_positions=[pos1, pos2])
+
+m = MDAWidget()
+m.setValue(seq)
+m.show()
+
+app.exec()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     'pymmcore-plus[cli] >=0.14.0',
     'qtpy >=2.0',
     'superqt[quantity,cmap,iconify] >=0.7.1',
-    'useq-schema >=0.7.3',
+    'useq-schema >=0.8.0',
     'vispy >=0.15.0',
     "pyopengl >=3.1.9; platform_system == 'Darwin'",
     "shapely>=2.0.7",

--- a/src/pymmcore_widgets/_util.py
+++ b/src/pymmcore_widgets/_util.py
@@ -4,7 +4,6 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import useq
 from psygnal import SignalInstance
 from pymmcore_plus import CMMCorePlus
 from qtpy.QtCore import QEvent, QMarginsF, QObject, Qt
@@ -142,20 +141,6 @@ def block_core(obj: Any) -> AbstractContextManager:
     if isinstance(obj, SignalInstance):
         return obj.blocked()
     raise TypeError(f"Cannot block signals for {obj}")
-
-
-def cast_grid_plan(
-    grid: dict | useq.GridRowsColumns | useq.GridWidthHeight | useq.GridFromEdges,
-) -> useq.GridRowsColumns | useq.GridWidthHeight | useq.GridFromEdges | None:
-    """Get the grid type from the grid_plan."""
-    if not grid or isinstance(grid, useq.RandomPoints):
-        return None
-    if isinstance(grid, dict):
-        _grid = useq.MDASequence(grid_plan=grid).grid_plan
-        if isinstance(_grid, useq.RelativePosition):  # pragma: no cover
-            raise ValueError("Grid plan cannot be a single Relative position.")
-        return None if isinstance(_grid, useq.RandomPoints) else _grid
-    return grid
 
 
 def fov_kwargs(core: CMMCorePlus) -> dict:

--- a/src/pymmcore_widgets/control/_rois/roi_model.py
+++ b/src/pymmcore_widgets/control/_rois/roi_model.py
@@ -106,7 +106,7 @@ class ROI:
             if type(self) is not RectangleROI:
                 if len(self.vertices) < 3:
                     return None
-                return useq.GridFromPolygon(  # type: ignore[no-any-return]
+                return useq.GridFromPolygon(
                     vertices=list(self.vertices),
                     fov_width=fov_w,
                     fov_height=fov_h,

--- a/src/pymmcore_widgets/control/_rois/roi_model.py
+++ b/src/pymmcore_widgets/control/_rois/roi_model.py
@@ -1,118 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import Any
 from uuid import UUID, uuid4
 
 import numpy as np
 import useq
 import useq._grid
-from pydantic import Field, PrivateAttr
-from shapely import Polygon, box, prepared
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-
-
-class GridFromPolygon(useq._grid._GridPlan[useq.AbsolutePosition]):
-    vertices: Annotated[
-        list[tuple[float, float]],
-        Field(
-            min_length=3,
-            description="List of points that define the polygon",
-            frozen=True,
-        ),
-    ]
-
-    def num_positions(self) -> int:
-        """Return the number of positions in the grid."""
-        if self.fov_width is None or self.fov_height is None:
-            raise ValueError("fov_width and fov_height must be set")
-        return len(
-            self._cached_tiles(
-                fov=(self.fov_width, self.fov_height), overlap=self.overlap
-            )
-        )
-
-    def iter_grid_positions(
-        self,
-        fov_width: float | None = None,
-        fov_height: float | None = None,
-        *,
-        order: useq.OrderMode | None = None,
-    ) -> Iterator[useq.AbsolutePosition]:
-        """Iterate over all grid positions, given a field of view size."""
-        try:
-            pos = self._cached_tiles(
-                fov=(
-                    fov_width or self.fov_width or 1,
-                    fov_height or self.fov_height or 1,
-                ),
-                overlap=self.overlap,
-                order=order,
-            )
-        except ValueError:
-            pos = []
-        for x, y in pos:
-            yield useq.AbsolutePosition(x=x, y=y)
-
-    @cached_property
-    def poly(self) -> Polygon:
-        """Return the polygon vertices as a list of (x, y) tuples."""
-        return Polygon(self.vertices)
-
-    @cached_property
-    def prepared_poly(self) -> prepared.PreparedGeometry:
-        """Return the prepared polygon for faster intersection tests."""
-        return prepared.prep(self.poly)
-
-    _poly_cache: dict[tuple, list[tuple[float, float]]] = PrivateAttr(
-        default_factory=dict
-    )
-
-    def _cached_tiles(
-        self,
-        *,
-        fov: tuple[float, float],
-        overlap: tuple[float, float],
-        order: useq.OrderMode | None = None,
-    ) -> list[tuple[float, float]]:
-        """Compute an ordered list of (x, y) stage positions that cover the ROI."""
-        # Compute grid spacing and half-extents
-        mode = useq.OrderMode(order) if order is not None else self.mode
-        key = (fov, overlap, mode)
-
-        if key not in self._poly_cache:
-            w, h = fov
-            dx = w * (1 - overlap[0])
-            dy = h * (1 - overlap[1])
-            half_w, half_h = w / 2, h / 2
-
-            # Expand bounds to ensure full coverage
-            minx, miny, maxx, maxy = self.poly.bounds
-            minx -= half_w
-            miny -= half_h
-            maxx += half_w
-            maxy += half_h
-
-            # Determine grid dimensions
-            n_cols = int(np.ceil((maxx - minx) / dx))
-            n_rows = int(np.ceil((maxy - miny) / dy))
-
-            # Generate grid positions
-            positions: list[tuple[float, float]] = []
-            prepared_poly = self.prepared_poly
-
-            for r, c in mode.generate_indices(n_rows, n_cols):
-                x = c + minx + (c + 0.5) * dx + half_w
-                y = maxy - (r + 0.5) * dy - half_h
-                tile = box(x - half_w, y - half_h, x + half_w, y + half_h)
-                if prepared_poly.intersects(tile):
-                    positions.append((x, y))
-
-            self._poly_cache[key] = positions
-        return self._poly_cache[key]
 
 
 @dataclass(eq=False)
@@ -212,8 +106,8 @@ class ROI:
             if type(self) is not RectangleROI:
                 if len(self.vertices) < 3:
                     return None
-                return GridFromPolygon(
-                    vertices=self.vertices,
+                return useq.GridFromPolygon(  # type: ignore[no-any-return]
+                    vertices=list(self.vertices),
                     fov_width=fov_w,
                     fov_height=fov_h,
                 )

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -30,11 +30,7 @@ from pymmcore_widgets.useq_widgets._column_info import (
     TextColumn,
     parse_timedelta,
 )
-from pymmcore_widgets.useq_widgets._positions import (
-    MDAButton,
-    QFileDialog,
-    _MDAPopup,
-)
+from pymmcore_widgets.useq_widgets._positions import MDAButton, QFileDialog, _MDAPopup
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -416,15 +412,14 @@ def test_grid_plan_widget(qtbot: QtBot) -> None:
     qtbot.addWidget(wdg)
     wdg.show()
 
-    with pytest.raises(ValueError):
-        wdg.setMode("polygon")
-    assert isinstance(wdg.value(), useq.GridFromPolygon)
     wdg.setMode("bounds")
     assert isinstance(wdg.value(), useq.GridFromEdges)
     wdg.setMode("number")
     assert isinstance(wdg.value(), useq.GridRowsColumns)
     wdg.setMode("area")
     assert isinstance(wdg.value(), useq.GridWidthHeight)
+    wdg.setMode("polygon")
+    assert isinstance(wdg.value(), useq.GridFromPolygon)
 
     plan = useq.GridRowsColumns(rows=3, columns=3, mode="spiral", overlap=10)
     with qtbot.waitSignal(wdg.valueChanged):


### PR DESCRIPTION
Add `GridFromPolygon` from `useq-schema`.

This PR replace the local `GridFromPolygon` logic and uses the `GridFromPolygon` form uses-schema.

It also updates `MDAWidget` to be able to show (but not really edit) a `GridFromPolygon`.

https://github.com/user-attachments/assets/38699fc6-abd7-45c0-a081-023d8e17e5fb