### PR TITLE
fix: remove magenta from preset widget and use <no match> key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    'pymmcore-plus[cli] >=0.14.0',
+    'pymmcore-plus[cli] >=0.15.4',
     'qtpy >=2.0',
     'superqt[quantity,cmap,iconify] >=0.7.1',
     'useq-schema >=0.8.0',

--- a/src/pymmcore_widgets/config_presets/_objectives_pixel_configuration_widget.py
+++ b/src/pymmcore_widgets/config_presets/_objectives_pixel_configuration_widget.py
@@ -316,7 +316,7 @@ class ObjectivesPixelConfigurationWidget(QDialog):
                     item.setStyleSheet("")
                 else:
                     item.setReadOnly(True)
-                    item.setStyleSheet("color:magenta")
+                    item.setStyleSheet("font-weight: bold;")
 
     def _on_sys_cfg_loaded(self) -> None:
         self.objective_device = guess_objective_or_prompt(parent=self)

--- a/src/pymmcore_widgets/control/_channel_group_widget.py
+++ b/src/pymmcore_widgets/control/_channel_group_widget.py
@@ -59,8 +59,7 @@ class ChannelGroupWidget(QComboBox):
             self.adjustSize()
             if ch_group := self._mmc.getChannelGroup():
                 # remove NO_MATCH if it exists
-                no_match_index = self.findText(NO_MATCH)
-                if no_match_index >= 0:
+                if (no_match_index := self.findText(NO_MATCH)) >= 0:
                     self.removeItem(no_match_index)
                 self.setCurrentText(ch_group)
             else:
@@ -76,8 +75,7 @@ class ChannelGroupWidget(QComboBox):
         with signals_blocked(self):
             if value:
                 # remove NO_MATCH if it exists
-                no_match_index = self.findText(NO_MATCH)
-                if no_match_index >= 0:
+                if (no_match_index := self.findText(NO_MATCH)) >= 0:
                     self.removeItem(no_match_index)
                 self.setCurrentText(value)
             else:

--- a/src/pymmcore_widgets/control/_channel_group_widget.py
+++ b/src/pymmcore_widgets/control/_channel_group_widget.py
@@ -58,15 +58,9 @@ class ChannelGroupWidget(QComboBox):
             self.addItems(self._mmc.getAvailableConfigGroups())
             self.adjustSize()
             if ch_group := self._mmc.getChannelGroup():
-                # remove NO_MATCH if it exists
-                if (no_match_index := self.findText(NO_MATCH)) >= 0:
-                    self.removeItem(no_match_index)
                 self.setCurrentText(ch_group)
             else:
-                # add NO_MATCH if not already there
-                current_items = [self.itemText(i) for i in range(self.count())]
-                if NO_MATCH not in current_items:
-                    self.addItem(NO_MATCH)
+                self.addItem(NO_MATCH)
                 self.setCurrentText(NO_MATCH)
 
     def _on_property_changed(self, device: str, property: str, value: str) -> None:
@@ -80,7 +74,7 @@ class ChannelGroupWidget(QComboBox):
                 self.setCurrentText(value)
             else:
                 # add NO_MATCH if not already there
-                current_items = [self.itemText(i) for i in range(self.count())]
+                current_items = {self.itemText(i) for i in range(self.count())}
                 if NO_MATCH not in current_items:
                     self.addItem(NO_MATCH)
                 self.setCurrentText(NO_MATCH)

--- a/src/pymmcore_widgets/control/_presets_widget.py
+++ b/src/pymmcore_widgets/control/_presets_widget.py
@@ -112,8 +112,7 @@ class PresetsWidget(QWidget):
                     break
             if _set_combo:
                 # remove NO_MATCH if it exists
-                no_match_index = self._combo.findText(NO_MATCH)
-                if no_match_index >= 0:
+                if (no_match_index := self._combo.findText(NO_MATCH)) >= 0:
                     self._combo.removeItem(no_match_index)
                 with signals_blocked(self._combo):
                     self._combo.setCurrentText(preset)

--- a/tests/test_channel_group_widget.py
+++ b/tests/test_channel_group_widget.py
@@ -22,18 +22,15 @@ def test_channel_group_widget(qtbot: QtBot):
 
     mmc.setProperty("Core", "ChannelGroup", "")
     assert not mmc.getChannelGroup()
-    assert ch.currentText() == "Camera"
-    assert ch.styleSheet() == "color: magenta;"
+    assert ch.currentText() == "<no match>"
 
     mmc.setChannelGroup("Channel")
     assert ch.currentText() == "Channel"
     assert mmc.getChannelGroup() == "Channel"
-    assert not ch.styleSheet()
 
     mmc.deleteConfigGroup("Channel")
     assert not mmc.getChannelGroup()
-    assert ch.currentText() == "Camera"
-    assert ch.styleSheet() == "color: magenta;"
+    assert ch.currentText() == "<no match>"
     assert "Channel" not in [ch.itemText(idx) for idx in range(ch.count())]
 
     mmc.defineConfig("test_group", "test_preset")
@@ -41,5 +38,5 @@ def test_channel_group_widget(qtbot: QtBot):
 
     ch._disconnect()
     mmc.setProperty("Core", "ChannelGroup", "LightPath")
-    assert ch.currentText() == "Camera"
+    assert ch.currentText() == "<no match>"
     assert mmc.getChannelGroup() == "LightPath"

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -6,7 +6,7 @@ from qtpy.QtWidgets import QComboBox
 
 from pymmcore_widgets._util import block_core
 from pymmcore_widgets.control._channel_widget import ChannelWidget
-from pymmcore_widgets.control._presets_widget import PresetsWidget
+from pymmcore_widgets.control._presets_widget import NO_MATCH, PresetsWidget
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -29,7 +29,7 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert wdg.channel_wdg.value() == "FITC"
 
     global_mmcore.setProperty("Emission", "Label", "Chroma-HQ700")
-    assert wdg.channel_wdg._combo.styleSheet() == "color: magenta;"
+    assert wdg.channel_wdg._combo.currentText() == NO_MATCH
 
     with qtbot.waitSignal(global_mmcore.events.channelGroupChanged):
         global_mmcore.setChannelGroup("")

--- a/tests/test_objective_pixel_config_widget.py
+++ b/tests/test_objective_pixel_config_widget.py
@@ -56,7 +56,7 @@ def test_pixel_size_table(qtbot: QtBot):
     assert cam_px.graphicsEffect().opacity() == 1.00
     assert img_px.text() == "0.2500"
     assert img_px.graphicsEffect().opacity() == 1.00
-    assert img_px.styleSheet() == "color:magenta"
+    assert img_px.styleSheet() == "font-weight: bold;"
 
     for r in range(table.rowCount()):
         _cam_px = table.cellWidget(r, CAMERA_PX_SIZE).text()
@@ -119,7 +119,7 @@ def test_change_img_pixel_size(qtbot: QtBot):
     _, _, mag, cam_px, img_px = _get_wdg(table)
     assert cam_px.text() == "10.00"
     assert mag.text() == str(10 / 1)
-    assert mag.styleSheet() == "color:magenta"
+    assert mag.styleSheet() == "font-weight: bold;"
     assert "Res40x" in mmc.getAvailablePixelSizeConfigs()
     assert mmc.getPixelSizeUmByID("Res40x") == 1
 

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -31,19 +31,16 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
 
         if group == "Camera":
             global_mmcore.setProperty("Camera", "Binning", "8")
-            assert wdg._combo.styleSheet() == "color: magenta;"
+            assert wdg._combo.currentText() == "<no match>"
             global_mmcore.setProperty("Camera", "Binning", "1")
-            assert wdg._combo.styleSheet() == ""
+            assert wdg._combo.currentText() != "<no match>"
 
             global_mmcore.setConfig("Camera", "HighRes")
             assert wdg._combo.currentText() == "HighRes"
-            assert wdg._combo.styleSheet() == ""
             global_mmcore.setProperty("Camera", "Binning", "2")
-            assert wdg._combo.currentText() == "HighRes"
-            assert wdg._combo.styleSheet() == "color: magenta;"
+            assert wdg._combo.currentText() == "<no match>"
             global_mmcore.setProperty("Camera", "BitDepth", "10")
             assert wdg._combo.currentText() == "MedRes"
-            assert wdg._combo.styleSheet() == ""
 
             warning_string = (
                 "'test' preset is missing the following properties:"


### PR DESCRIPTION
This PR implements the <no match> logic discussed in #411.


BEFORE
<img width="794" height="488" alt="Screenshot 2025-08-19 at 2 54 31 PM" src="https://github.com/user-attachments/assets/4ccd366d-0393-4e96-b3ca-92c34554c66d" />

AFTER
<img width="794" height="488" alt="Screenshot 2025-08-19 at 2 54 42 PM" src="https://github.com/user-attachments/assets/9f060768-0912-477e-8ce3-a0cb60be50e6" />

closes #411.
