### PR TITLE
fix: update how QQuantityLineEdit displays time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    'pymmcore-plus[cli] >=0.14.0',
+    'pymmcore-plus[cli] >=0.15.4',
     'qtpy >=2.0',
     'superqt[quantity,cmap,iconify] >=0.7.1',
     'useq-schema >=0.8.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     'vispy >=0.15.0',
     "pyopengl >=3.1.9; platform_system == 'Darwin'",
     "shapely>=2.0.7",
+    "humanize>=4.12.3",
 ]
 
 [project.optional-dependencies]

--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -501,10 +501,16 @@ class QTimeLineEdit(QQuantityLineEdit):
                 parts.append(f"{minutes} min")
         else:
             # seconds only (may be fractional)
+            # for sub-second values, show millisecond precision so we don't
+            # round small durations to 0 (e.g., 0.01 s -> "0.010 s"). For
+            # values >= 1s show one decimal unless it's an integer.
             if abs(seconds - round(seconds)) < 1e-6:
                 parts.append(f"{round(seconds):.0f} s")
             else:
-                parts.append(f"{seconds:.1f} s")
+                if seconds < 1.0:
+                    parts.append(f"{seconds:.3f} s")
+                else:
+                    parts.append(f"{seconds:.1f} s")
 
         text = " ".join(parts)
 

--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -500,6 +500,9 @@ class QTimeLineEdit(QQuantityLineEdit):
         """Set the text value."""
         if value is None:
             value = ""
+        # Validate the input first - this will raise ValueError for invalid values
+        if value and self._validator.text_to_quant(value) is None:
+            raise ValueError(f"Invalid value: {value!r}")
         # Use the parent's parent setText to bypass QQuantityLineEdit.setText
         # which would re-format our humanized text using pint
         super(QQuantityLineEdit, self).setText(value)

--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -444,8 +444,7 @@ class QQuantityLineEdit(QLineEdit):
 
     def quantity(self) -> pint.Quantity | int | float:
         # prefer the validator's parser which understands compound
-        # value+unit pairs (e.g., "1 h 1 min"). Fall back to
-        # parse_expression for backward compatibility.
+        # value+unit pairs (e.g., "1 h 1 min").
         q = self._validator.text_to_quant(self.text())
         if q is not None:
             return q
@@ -468,9 +467,9 @@ class QTimeLineEdit(QQuantityLineEdit):
         return q.to("second").magnitude  # type: ignore
 
     def setValue(self, value: float | str | timedelta) -> None:
-        # handle string input (like default values)
+        # handle string input
         if isinstance(value, str):
-            super(QQuantityLineEdit, self).setText(value)
+            self.setText(value)
             self._last_val = value
             return
 
@@ -478,9 +477,7 @@ class QTimeLineEdit(QQuantityLineEdit):
         if isinstance(value, timedelta):
             value = value.total_seconds()
 
-        # use humanize to format seconds into human-readable text
-        # precisedelta gives exact values like "1 hr and 16 min" that can be
-        # parsed back accurately
+        # use humanize to format seconds into human-readable text (e.g. "1 h and 3 min")
         td = timedelta(seconds=value)
         text = humanize.precisedelta(td, minimum_unit="seconds")
 
@@ -499,7 +496,7 @@ class QTimeLineEdit(QQuantityLineEdit):
         for long_form, short_form in abbreviations.items():
             text = text.replace(long_form, short_form)
 
-        super(QQuantityLineEdit, self).setText(text)
+        self.setText(text)
         self._last_val = text
 
 

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -33,11 +33,26 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 try:
-    from pint import Quantity
+    import humanize
 
     def _format_duration(duration: float) -> str:
-        d = Quantity(duration, "s").to_compact()
-        return f"{d:.1f~#P}" if d else ""
+        if not duration:
+            return ""
+        formatted = humanize.precisedelta(int(duration), minimum_unit="seconds")
+        abbreviations = {
+            " seconds": " s",
+            " second": " s",
+            " minutes": " min",
+            " minute": " min",
+            " hours": " h",
+            " hour": " h",
+            " days": " d",
+            " day": " d",
+        }
+        for full, abbrev in abbreviations.items():
+            formatted = formatted.replace(full, abbrev)
+
+        return formatted  # type: ignore
 
 except ImportError:  # pragma: no cover
 

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -223,14 +223,15 @@ def test_qtime_line_edit_formatting(qtbot: QtBot) -> None:
         (5.5, "5.5 s"),  # Decimal seconds
         (30, "30 s"),  # Seconds under 1 minute
         (60, "1 min"),  # Exact 1 minute
-        (75, "1.2 min"),  # Decimal minutes
+        (75, "1 min 15 s"),  # 1 minute 15 seconds
         (300, "5 min"),  # Integer minutes
         (3600, "1 h"),  # Exact 1 hour
-        (3660, "61 min"),  # 1 hour 1 minute - show as minutes for clarity
+        (3660, "1 h 1 min"),  # 1 hour 1 minute
         (7200, "2 h"),  # 2 hours
-        (7320, "122 min"),  # 2 hours 2 minutes - can show as hours since > 2h
+        (7320, "2 h 2 min"),  # 2 hours 2 minutes
         (86400, "1 d"),  # 1 day
-        (90000, "1.0 d"),  # 1.04 days
+        (90000, "1 d 1 h"),  # 1 day + 1 hour
+        (4600, "1 h 16 min"),  # 1 hour 16 minutes
         ("200 min", "200 min"),
     ]
 
@@ -242,7 +243,7 @@ def test_qtime_line_edit_formatting(qtbot: QtBot) -> None:
 
     # Test with timedelta objects
     wdg.setValue(timedelta(seconds=2990))
-    assert wdg.text() == "49.8 min"
+    assert wdg.text() == "49 min 50 s"
 
     # Test with string input (should pass through unchanged)
     wdg.setValue("0 s")

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -211,6 +211,44 @@ def test_qquant_line_edit(qtbot: QtBot) -> None:
     assert wdg.text() == "1.0 s"
 
 
+def test_qtime_line_edit_formatting(qtbot: QtBot) -> None:
+    """Test that QTimeLineEdit formats time values in human-readable units."""
+    wdg = QTimeLineEdit()
+    qtbot.addWidget(wdg)
+
+    # Test formatting of different time values
+    test_cases = [
+        # (input_seconds, expected_display)
+        (5, "5 s"),  # Integer seconds
+        (5.5, "5.5 s"),  # Decimal seconds
+        (30, "30 s"),  # Seconds under 1 minute
+        (60, "1 min"),  # Exact 1 minute
+        (75, "1.2 min"),  # Decimal minutes
+        (300, "5 min"),  # Integer minutes
+        (3600, "1 h"),  # Exact 1 hour
+        (3660, "61 min"),  # 1 hour 1 minute - show as minutes for clarity
+        (7200, "2 h"),  # 2 hours
+        (7320, "122 min"),  # 2 hours 2 minutes - can show as hours since > 2h
+        (86400, "1 d"),  # 1 day
+        (90000, "1.0 d"),  # 1.04 days
+        ("200 min", "200 min"),
+    ]
+
+    for seconds, expected in test_cases:
+        wdg.setValue(seconds)
+        assert wdg.text() == expected, (
+            f"Failed for {seconds}s: got '{wdg.text()}', expected '{expected}'"
+        )
+
+    # Test with timedelta objects
+    wdg.setValue(timedelta(seconds=2990))
+    assert wdg.text() == "49.8 min"
+
+    # Test with string input (should pass through unchanged)
+    wdg.setValue("0 s")
+    assert wdg.text() == "0 s"
+
+
 def test_position_table(qtbot: QtBot):
     wdg = PositionTable()
     qtbot.addWidget(wdg)

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -216,22 +216,22 @@ def test_qtime_line_edit_formatting(qtbot: QtBot) -> None:
     wdg = QTimeLineEdit()
     qtbot.addWidget(wdg)
 
-    # Test formatting of different time values
+    # Test formatting of different time values (using abbreviated humanize output)
     test_cases = [
         # (input_seconds, expected_display)
         (5, "5 s"),  # Integer seconds
-        (5.5, "5.5 s"),  # Decimal seconds
+        (5.5, "5.50 s"),  # Decimal seconds
         (30, "30 s"),  # Seconds under 1 minute
         (60, "1 min"),  # Exact 1 minute
-        (75, "1 min 15 s"),  # 1 minute 15 seconds
+        (75, "1 min and 15 s"),  # 1 minute 15 seconds
         (300, "5 min"),  # Integer minutes
         (3600, "1 h"),  # Exact 1 hour
-        (3660, "1 h 1 min"),  # 1 hour 1 minute
+        (3660, "1 h and 1 min"),  # 1 hour 1 minute
         (7200, "2 h"),  # 2 hours
-        (7320, "2 h 2 min"),  # 2 hours 2 minutes
+        (7320, "2 h and 2 min"),  # 2 hours 2 minutes
         (86400, "1 d"),  # 1 day
-        (90000, "1 d 1 h"),  # 1 day + 1 hour
-        (4600, "1 h 16 min"),  # 1 hour 16 minutes
+        (90000, "1 d and 1 h"),  # 1 day + 1 hour
+        (4600, "1 h, 16 min and 40 s"),  # 1 hour 16 minutes 40 seconds
         ("200 min", "200 min"),
     ]
 
@@ -243,9 +243,9 @@ def test_qtime_line_edit_formatting(qtbot: QtBot) -> None:
 
     # Test with timedelta objects
     wdg.setValue(timedelta(seconds=2990))
-    assert wdg.text() == "49 min 50 s"
+    assert wdg.text() == "49 min and 50 s"
 
-    # Test with string input (should pass through unchanged)
+    # Test with string input (should pass though unchanged)
     wdg.setValue("0 s")
     assert wdg.text() == "0 s"
 


### PR DESCRIPTION
This PR fixes #398 by improving time value parsing, formatting, and displaying in the `QQuantityLineEdit` (mainly improves formatting of time values into human-readable units).

<img width="575" height="371" alt="Screenshot 2025-08-19 at 5 07 10 PM" src="https://github.com/user-attachments/assets/42fe3d91-75cb-4626-a341-e7812119dc64" />

closes #398.