### PR TITLE
Catch missing core

### DIFF
--- a/src/pymmcore_widgets/config_presets/_group_preset_widget/_add_first_preset_widget.py
+++ b/src/pymmcore_widgets/config_presets/_group_preset_widget/_add_first_preset_widget.py
@@ -27,11 +27,12 @@ class AddFirstPresetWidget(QDialog):
         group: str,
         dev_prop_val_list: list,
         *,
+        mmcore: CMMCorePlus | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
 
-        self._mmc = CMMCorePlus.instance()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._group = group
         self._dev_prop_val_list = dev_prop_val_list
 

--- a/src/pymmcore_widgets/config_presets/_group_preset_widget/_add_group_widget.py
+++ b/src/pymmcore_widgets/config_presets/_group_preset_widget/_add_group_widget.py
@@ -30,9 +30,11 @@ if TYPE_CHECKING:
 class AddGroupWidget(QDialog):
     """Widget to create a new group."""
 
-    def __init__(self, *, parent: QWidget | None = None) -> None:
+    def __init__(
+        self, *, mmcore: CMMCorePlus | None = None, parent: QWidget | None = None
+    ) -> None:
         super().__init__(parent=parent)
-        self._mmc = CMMCorePlus.instance()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._mmc.events.systemConfigurationLoaded.connect(self._update_filter)
 
         self._create_gui()
@@ -93,7 +95,9 @@ class AddGroupWidget(QDialog):
         self._filter_text.setPlaceholderText("Filter by device or property name...")
         self._filter_text.textChanged.connect(self._update_filter)
 
-        self._prop_table = DevicePropertyTable(enable_property_widgets=False)
+        self._prop_table = DevicePropertyTable(
+            mmcore=self._mmc, enable_property_widgets=False
+        )
         self._prop_table.setRowsCheckable(True)
         self._device_filters = DeviceTypeFilters()
         self._device_filters.filtersChanged.connect(self._update_filter)
@@ -175,7 +179,7 @@ class AddGroupWidget(QDialog):
         if hasattr(self, "_first_preset_wdg"):
             self._first_preset_wdg.close()  # type: ignore
         self._first_preset_wdg = AddFirstPresetWidget(
-            group, dev_prop_val_list, parent=self
+            group, dev_prop_val_list, mmcore=self._mmc, parent=self
         )
         self._first_preset_wdg.show()
 

--- a/src/pymmcore_widgets/config_presets/_group_preset_widget/_add_preset_widget.py
+++ b/src/pymmcore_widgets/config_presets/_group_preset_widget/_add_preset_widget.py
@@ -24,10 +24,16 @@ from ._cfg_table import _CfgTable
 class AddPresetWidget(QDialog):
     """A widget to add presets to a specified group."""
 
-    def __init__(self, group: str, *, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        group: str,
+        *,
+        mmcore: CMMCorePlus | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent=parent)
 
-        self._mmc = CMMCorePlus.instance()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._group = group
 
         self._create_gui()

--- a/src/pymmcore_widgets/config_presets/_group_preset_widget/_edit_group_widget.py
+++ b/src/pymmcore_widgets/config_presets/_group_preset_widget/_edit_group_widget.py
@@ -23,9 +23,15 @@ from pymmcore_widgets.device_properties._device_type_filter import DeviceTypeFil
 class EditGroupWidget(QDialog):
     """Widget to edit the specified Group."""
 
-    def __init__(self, group: str, *, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        group: str,
+        *,
+        mmcore: CMMCorePlus | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent=parent)
-        self._mmc = CMMCorePlus.instance()
+        self._mmc = mmcore or CMMCorePlus.instance()
 
         self._group = group
 
@@ -88,7 +94,9 @@ class EditGroupWidget(QDialog):
         self._filter_text.setPlaceholderText("Filter by device or property name...")
         self._filter_text.textChanged.connect(self._update_filter)
 
-        self._prop_table = DevicePropertyTable(enable_property_widgets=False)
+        self._prop_table = DevicePropertyTable(
+            mmcore=self._mmc, enable_property_widgets=False
+        )
         self._prop_table.setRowsCheckable(True)
         self._prop_table.checkGroup(self._group)
         self._device_filters = DeviceTypeFilters()

--- a/src/pymmcore_widgets/config_presets/_group_preset_widget/_edit_preset_widget.py
+++ b/src/pymmcore_widgets/config_presets/_group_preset_widget/_edit_preset_widget.py
@@ -27,11 +27,16 @@ class EditPresetWidget(QDialog):
     """A widget to edit a specified group's presets."""
 
     def __init__(
-        self, group: str, preset: str, *, parent: QWidget | None = None
+        self,
+        group: str,
+        preset: str,
+        *,
+        mmcore: CMMCorePlus | None = None,
+        parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
 
-        self._mmc = CMMCorePlus.instance()
+        self._mmc = mmcore or CMMCorePlus.instance()
         self._group = group
         self._preset = preset
 

--- a/src/pymmcore_widgets/config_presets/_group_preset_widget/_group_preset_table_widget.py
+++ b/src/pymmcore_widgets/config_presets/_group_preset_widget/_group_preset_table_widget.py
@@ -274,7 +274,7 @@ class GroupPresetTableWidget(QGroupBox):
 
     def _add_group(self) -> None:
         self._close_if_hasattr()
-        self._add_group_wdg = AddGroupWidget(parent=self)
+        self._add_group_wdg = AddGroupWidget(mmcore=self._mmc, parent=self)
         self._add_group_wdg.show()
 
     def _delete_group(self) -> None:
@@ -316,7 +316,7 @@ class GroupPresetTableWidget(QGroupBox):
         row = next(iter(selected_rows))
         group = self.table_wdg.item(row, 0).text()
         self._close_if_hasattr()
-        self._edit_group_wdg = EditGroupWidget(group, parent=self)
+        self._edit_group_wdg = EditGroupWidget(group, mmcore=self._mmc, parent=self)
         self._edit_group_wdg.show()
 
     def _add_preset(self) -> None:
@@ -332,7 +332,7 @@ class GroupPresetTableWidget(QGroupBox):
             return
 
         self._close_if_hasattr()
-        self._add_preset_wdg = AddPresetWidget(group, parent=self)
+        self._add_preset_wdg = AddPresetWidget(group, mmcore=self._mmc, parent=self)
         self._add_preset_wdg.show()
 
     def _delete_preset(self) -> None:
@@ -381,7 +381,9 @@ class GroupPresetTableWidget(QGroupBox):
         if isinstance(wdg, PresetsWidget):
             preset = wdg._combo.currentText()
         self._close_if_hasattr()
-        self._edit_preset_wgd = EditPresetWidget(group, preset, parent=self)
+        self._edit_preset_wgd = EditPresetWidget(
+            group, preset, mmcore=self._mmc, parent=self
+        )
         self._edit_preset_wgd.show()
 
     def _save_cfg(self) -> None:

--- a/src/pymmcore_widgets/config_presets/_objectives_pixel_configuration_widget.py
+++ b/src/pymmcore_widgets/config_presets/_objectives_pixel_configuration_widget.py
@@ -241,7 +241,7 @@ class ObjectivesPixelConfigurationWidget(QDialog):
 
         self._mmc = mmcore or CMMCorePlus.instance()
 
-        self.objective_device = guess_objective_or_prompt(parent=self)
+        self.objective_device = guess_objective_or_prompt(self._mmc, parent=self)
 
         self._create_wdg()
 
@@ -319,7 +319,7 @@ class ObjectivesPixelConfigurationWidget(QDialog):
                     item.setStyleSheet("font-weight: bold;")
 
     def _on_sys_cfg_loaded(self) -> None:
-        self.objective_device = guess_objective_or_prompt(parent=self)
+        self.objective_device = guess_objective_or_prompt(self._mmc, parent=self)
         self._rebuild()
 
     def _on_px_set(self, value: float) -> None:

--- a/src/pymmcore_widgets/config_presets/_pixel_configuration_widget.py
+++ b/src/pymmcore_widgets/config_presets/_pixel_configuration_widget.py
@@ -558,7 +558,7 @@ class _PropertySelector(QWidget):
         self._filter_text.textChanged.connect(self._update_filter)
 
         self._prop_table = DevicePropertyTable(
-            connect_core=False, enable_property_widgets=False
+            mmcore=self._mmc, connect_core=False, enable_property_widgets=False
         )
         self._prop_table.setRowsCheckable(True)
 

--- a/src/pymmcore_widgets/control/_objective_widget.py
+++ b/src/pymmcore_widgets/control/_objective_widget.py
@@ -40,7 +40,7 @@ class ObjectivesWidget(QWidget):
         super().__init__(parent=parent)
         self._mmc = mmcore or CMMCorePlus.instance()
         self._objective_device = objective_device or guess_objective_or_prompt(
-            parent=self
+            self._mmc, parent=self
         )
         self._combo = self._create_objective_combo(objective_device)
 
@@ -66,7 +66,9 @@ class ObjectivesWidget(QWidget):
             self._objective_device = None
         if len(loaded) > 1:
             if not self._objective_device:
-                self._objective_device = guess_objective_or_prompt(parent=self)
+                self._objective_device = guess_objective_or_prompt(
+                    self._mmc, parent=self
+                )
             self._combo.setParent(QWidget())
             self._combo = self._create_objective_combo(self._objective_device)
             self.layout().addWidget(self._combo)

--- a/src/pymmcore_widgets/control/_rois/_vispy.py
+++ b/src/pymmcore_widgets/control/_rois/_vispy.py
@@ -46,13 +46,9 @@ class RoiPolygon(Compound):
         self._handles.set_data(pos=vertices)
 
         centers: list[tuple[float, float]] = []
-        try:
-            if (grid := self._roi.create_grid_plan()) is not None:
-                for p in grid:
-                    centers.append((p.x, p.y))
-        except Exception as e:
-            raise
-            print(e)
+        if (grid := self._roi.create_grid_plan()) is not None:
+            for p in grid:
+                centers.append((p.x, p.y))
 
         if centers and (fov_size := self._roi.fov_size):
             edges = []

--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -431,7 +431,6 @@ class StageExplorer(QWidget):
     def _on_poll_stage_action(self, checked: bool) -> None:
         """Set the poll stage position property based on the state of the action."""
         self._stage_pos_marker.visible = checked
-        print("Stage position marker visible:", self._stage_pos_marker.visible)
         self._poll_stage_position = checked
         if checked:
             self._timer_id = self.startTimer(20)

--- a/tests/test_group_preset_widget.py
+++ b/tests/test_group_preset_widget.py
@@ -203,7 +203,7 @@ def test_delete_group(global_mmcore: CMMCorePlus, qtbot: QtBot):
 
 
 def test_add_preset(global_mmcore: CMMCorePlus, qtbot: QtBot):
-    add_prs = AddPresetWidget("Channel")
+    add_prs = AddPresetWidget("Channel", mmcore=global_mmcore)
     qtbot.addWidget(add_prs)
     gp = GroupPresetTableWidget()
     qtbot.addWidget(gp)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,20 @@
+from __future__ import annotations
+
 import re
+from inspect import signature
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import QWidget
 
 import pymmcore_widgets
+
+if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from pytestqt.qtbot import QtBot
 
 ISINSTANCE_RE = re.compile(r"isinstance\s*\(\s*[^,]+,\s*CMMCore", re.MULTILINE)
 
@@ -19,3 +32,49 @@ def test_no_direct_isinstance() -> None:
                 f"{line_no}.\n Use structural checks instead... or open an issue to "
                 "discuss."
             )
+
+
+PUBLIC_WIDGETS = [
+    obj
+    for name, obj in vars(pymmcore_widgets).items()
+    if isinstance(obj, type) and issubclass(obj, QWidget)
+]
+
+
+@pytest.mark.parametrize("widget_cls", PUBLIC_WIDGETS)
+def test_using_existing_mmcore(
+    qtbot: QtBot, widget_cls: type, core_instance_mock: Mock
+) -> None:
+    instance = CMMCorePlus()
+    instance.loadSystemConfiguration()
+
+    ARGS = {
+        "group": "Channel",
+        "shutter_device": "LED Shutter",
+        "device": "XY",
+        "device_label": "Camera",
+        "prop_name": "BitDepth",
+    }
+
+    kwargs: dict = {}
+    for param in signature(widget_cls).parameters.values():
+        if param.name == "mmcore" or param.annotation == "CMMCorePlus | None":
+            kwargs[param.name] = instance
+        if param.default is param.empty and param.kind in (
+            param.POSITIONAL_OR_KEYWORD,
+            param.POSITIONAL_ONLY,
+        ):
+            if param.name not in ARGS:
+                pytest.skip(f"{param.name!r} is a required positional argument")
+            kwargs[param.name] = ARGS[param.name]
+
+    core_instance_mock.reset_mock()
+    widget = widget_cls(**kwargs)
+    if core_instance_mock.call_count:
+        kwargs = core_instance_mock.call_args.kwargs
+        raise AssertionError(
+            f"While creating {widget_cls.__name__!r}, the CMMCorePlus.instance() "
+            f"method was called by {kwargs['filename']}:{kwargs['lineno']}. "
+            "Ensure that CMMCorePlus instances are propagated through subwidgets."
+        )
+    qtbot.addWidget(widget)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -42,7 +42,7 @@ PUBLIC_WIDGETS = [
 
 
 @pytest.mark.parametrize("widget_cls", PUBLIC_WIDGETS)
-def test_using_existing_mmcore(
+def test_widget_creation_propagates_core_instance(
     qtbot: QtBot, widget_cls: type, core_instance_mock: Mock
 ) -> None:
     instance = CMMCorePlus()


### PR DESCRIPTION
This follows up on #463, adding a test that catches a number of additional missed cases where the core wasn't passed through