### PR TITLE
fix: fix test failing because of PySide6

### DIFF
--- a/src/pymmcore_widgets/hcs/_well_calibration_widget.py
+++ b/src/pymmcore_widgets/hcs/_well_calibration_widget.py
@@ -46,6 +46,11 @@ class Mode(NamedTuple):
     points: int
     icon: QIcon | None = None
 
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Mode):
+            return NotImplemented
+        return (self.text, self.points) == (value.text, value.points)
+
 
 # mapping of Circular well -> [Modes]
 MODES: dict[bool, list[Mode]] = {
@@ -90,15 +95,7 @@ class _CalibrationModeWidget(QComboBox):
 
     def currentMode(self) -> Mode:
         """Return the selected calibration mode."""
-        data = self.itemData(self.currentIndex(), COMBO_ROLE)
-        # needed because data in PySide6 is a list with 3 elements
-        # (text, points, icon) when retrieving a NamedTuple stored via setItemData
-        if isinstance(data, Mode):
-            return data
-        elif isinstance(data, (list, tuple)) and len(data) == 3:
-            return Mode(*data)
-        else:
-            raise ValueError(f"Invalid data for mode: {data}")
+        return Mode(*self.itemData(self.currentIndex(), COMBO_ROLE))
 
 
 class _CalibrationTable(QTableWidget):

--- a/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
+++ b/src/pymmcore_widgets/useq_widgets/_well_plate_widget.py
@@ -374,7 +374,6 @@ class WellPlateView(ResizingGraphicsView):
 
     def selectedIndices(self) -> tuple[tuple[int, int], ...]:
         """Return the indices of the selected wells."""
-        # tuple of tuple(item.data(DATA_INDEX)) because PySide6 returns lists
         return tuple(
             sorted(tuple(item.data(DATA_INDEX)) for item in self._selected_items)
         )
@@ -392,7 +391,6 @@ class WellPlateView(ResizingGraphicsView):
         select = set()
         deselect = set()
         for item in self._well_items.values():
-            # tuple required because PySide6 returns lists
             if tuple(item.data(DATA_INDEX)) in _indices:
                 select.add(item)
             else:

--- a/tests/hcs/test_well_calibration_widget.py
+++ b/tests/hcs/test_well_calibration_widget.py
@@ -8,6 +8,7 @@ import pytest
 from pymmcore_widgets.hcs._well_calibration_widget import (
     COMBO_ROLE,
     MODES,
+    Mode,
     WellCalibrationWidget,
 )
 
@@ -56,17 +57,15 @@ def test_well_calibration_widget_modes(
     assert wdg.circularWell() == circular
     # get the modes form the combobox
     combo = wdg._calibration_mode_wdg
-    modes = [combo.itemData(i, COMBO_ROLE) for i in range(combo.count())]
+    modes = [Mode(*combo.itemData(i, COMBO_ROLE)) for i in range(combo.count())]
     # make sure the modes are correct
-    expected = [(mode.text, mode.points) for mode in MODES[circular]]
-    actual = [(m[0], m[1]) for m in modes]
-    assert actual == expected
+    assert modes == MODES[circular]
     # make sure that the correct number of rows are displayed when the mode is changed
     for idx, mode in enumerate(modes):
         # set the mode
         combo.setCurrentIndex(idx)
         # get the number of rows
-        assert wdg._table.rowCount() == mode[1]
+        assert wdg._table.rowCount() == mode.points
 
 
 def test_well_calibration_widget_positions(


### PR DESCRIPTION
Not yet sure this is the best fix for the tests failing on PySide6 but I open the PR to check. 

I think is from v6.10 released in November, before that it was working.

after that we should `ci(dependabot)` PRs.