### PR TITLE
fix: allow z before t in axis orders in MDASequenceWidget

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -44,7 +44,6 @@ AXES = "tpgcz"
 ALLOWED_ORDERS = {"".join(p) for x in range(1, 6) for p in permutations(AXES, x)}
 for x in list(ALLOWED_ORDERS):
     for first, second in (
-        ("t", "z"),  # t cannot come after z
         ("p", "g"),  # p cannot come after g
         ("p", "z"),  # p cannot come after z
         ("g", "z"),  # g cannot come after z

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -129,6 +129,14 @@ MDA_CP = useq.MDASequence(
     axis_order="tcpz",
 )
 
+MDA_ZT = useq.MDASequence(
+    time_plan=useq.TIntervalLoops(interval=timedelta(seconds=2), loops=100),
+    stage_positions=[(0, 0), (100, 100)],
+    channels=[{"config": "DAPI", "exposure": 42}, {"config": "FITC", "exposure": 20}],
+    z_plan=useq.ZRangeAround(range=4, step=0.5),
+    axis_order="pczt",
+)
+
 
 def test_mda_wdg(qtbot: QtBot):
     wdg = MDASequenceWidget()
@@ -143,6 +151,9 @@ def test_mda_wdg(qtbot: QtBot):
 
     wdg.setValue(MDA_CP)
     assert wdg.value().replace(metadata={}) == MDA_CP
+
+    wdg.setValue(MDA_ZT)
+    assert wdg.value().replace(metadata={}) == MDA_ZT
 
 
 @pytest.mark.parametrize("ext", ["json", "yaml", "foo"])


### PR DESCRIPTION
We do multi-plane single-molecule localization microscopy, so we perform long time-lapses at different z-positions at the same position. Currently, the MDASequenceWidget does not allow for "zt" axis order. This PR allows for a "zt" axis order. I have added a test as well.

This PR is similar in style as #489 

