### PR TITLE
test: fix flaky objective widget test under parallel execution

### DIFF
--- a/tests/test_objective_widget.py
+++ b/tests/test_objective_widget.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock, call, patch
 
 import pytest
-from qtpy.QtWidgets import QDialog
+from qtpy.QtWidgets import QApplication, QDialog
 
 from pymmcore_widgets._util import ComboMessageBox
 from pymmcore_widgets.control._objective_widget import ObjectivesWidget
@@ -20,6 +20,8 @@ def test_objective_widget_changes_objective(global_mmcore: CMMCorePlus, qtbot: Q
 
     start_z = 100.0
     global_mmcore.setPosition("Z", start_z)
+    # Flush any pending async signals before connecting the mock
+    QApplication.processEvents()
     stage_mock = Mock()
     obj_wdg._mmc.events.stagePositionChanged.connect(stage_mock)
 


### PR DESCRIPTION
## Summary
- Flush pending Qt async signals with `QApplication.processEvents()` before connecting the stage mock in `test_objective_widget_changes_objective`
- Fixes a race condition where `setPosition("Z", start_z)` emits `stagePositionChanged` asynchronously, and the signal sometimes arrives after the mock is connected, adding a spurious `call('Z', 100.0)` that breaks the expected call sequence

## Test plan
- [x] Verified fix by running `pytest tests/test_objective_widget.py -n 6` 10 times consecutively (all passed)
- [x] Full test suite passes with `pytest -n 6` (335 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)