### PR TITLE
feat: add joystick widget for virtual control with deflection signals

### DIFF
--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -1,0 +1,102 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "pymmcore-plus[simulate]>=0.17.3",
+#     "pymmcore-widgets[pyqt6]",
+# ]
+#
+# [tool.uv.sources]
+# pymmcore-widgets = { path = "../", editable = true }
+# ///
+import math
+import random
+
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.experimental.simulate import (
+    Line,
+    Point,
+    Rectangle,
+    Sample,
+)
+from qtpy.QtWidgets import QApplication
+
+from pymmcore_widgets import ImagePreview
+from pymmcore_widgets.control import StageJoystick
+
+random.seed(42)
+objects: list = []
+
+# Grid of points across a large area
+for x in range(-2000, 2001, 200):
+    for y in range(-2000, 2001, 200):
+        r = random.uniform(2, 8)
+        intensity = random.randint(80, 255)
+        objects.append(Point(x, y, intensity=intensity, radius=r))
+
+# Radial spokes from the origin
+for angle_deg in range(0, 360, 15):
+    angle = math.radians(angle_deg)
+    length = random.uniform(500, 1500)
+    x2 = length * math.cos(angle)
+    y2 = length * math.sin(angle)
+    objects.append(Line((0, 0), (x2, y2), intensity=random.randint(60, 140)))
+
+# Concentric rings of rectangles
+for ring_r in (300, 600, 900, 1200, 1500):
+    n = max(6, ring_r // 100)
+    for i in range(n):
+        angle = 2 * math.pi * i / n
+        cx = ring_r * math.cos(angle)
+        cy = ring_r * math.sin(angle)
+        w = random.uniform(15, 50)
+        h = random.uniform(15, 50)
+        objects.append(
+            Rectangle(
+                (cx - w / 2, cy - h / 2),
+                width=w,
+                height=h,
+                intensity=random.randint(100, 220),
+                fill=random.choice([True, False]),
+            )
+        )
+
+# Scattered lines across the field
+for _ in range(80):
+    x1 = random.uniform(-2000, 2000)
+    y1 = random.uniform(-2000, 2000)
+    dx = random.uniform(-300, 300)
+    dy = random.uniform(-300, 300)
+    objects.append(
+        Line((x1, y1), (x1 + dx, y1 + dy), intensity=random.randint(50, 180))
+    )
+
+# Diagonal grid lines
+for offset in range(-2000, 2001, 250):
+    objects.append(Line((offset, -2000), (offset + 2000, 2000), intensity=40))
+    objects.append(Line((-2000, offset), (2000, offset + 2000), intensity=40))
+
+# Bright landmark clusters in each quadrant
+for qx, qy in [(800, 800), (-800, 800), (-800, -800), (800, -800)]:
+    for _ in range(15):
+        px = qx + random.gauss(0, 60)
+        py = qy + random.gauss(0, 60)
+        objects.append(Point(px, py, intensity=255, radius=random.uniform(3, 10)))
+
+sample = Sample(objects)
+
+app = QApplication([])
+core = CMMCorePlus.instance()
+core.loadSystemConfiguration()
+core.events.XYStagePositionChanged.connect(
+    lambda *args: print(f"Position changed: {args}")
+)
+with sample.patch(core):
+    prev = ImagePreview()
+    core.snapImage()
+    core.startContinuousSequenceAcquisition()
+    w = StageJoystick(core.getXYStageDevice(), mmcore=core)
+    w.setParent(prev)
+    w.resize(140, 140)
+    w.show()
+    prev.show()
+    app.exec()

--- a/src/pymmcore_widgets/control/__init__.py
+++ b/src/pymmcore_widgets/control/__init__.py
@@ -4,6 +4,7 @@ from ._camera_roi_widget import CameraRoiWidget
 from ._channel_group_widget import ChannelGroupWidget
 from ._channel_widget import ChannelWidget
 from ._exposure_widget import DefaultCameraExposureWidget, ExposureWidget
+from ._joystick import StageJoystick
 from ._live_button_widget import LiveButton
 from ._load_system_cfg_widget import ConfigurationWidget
 from ._objective_widget import ObjectivesWidget
@@ -26,5 +27,6 @@ __all__ = [
     "ShuttersWidget",
     "SnapButton",
     "StageExplorer",
+    "StageJoystick",
     "StageWidget",
 ]

--- a/src/pymmcore_widgets/control/_joystick.py
+++ b/src/pymmcore_widgets/control/_joystick.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from qtpy.QtCore import QPointF, QSize, Qt, QTimer, Signal
+from qtpy.QtGui import QBrush, QColor, QPainter, QPen, QRadialGradient
+from qtpy.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
+
+from pymmcore_widgets.control._q_stage_controller import QStageMoveAccumulator
+
+if TYPE_CHECKING:
+    from pymmcore_plus import CMMCorePlus
+    from qtpy.QtGui import QMouseEvent, QPaintEvent
+
+
+class JoystickWidget(QWidget):
+    """Virtual joystick pad. Emits normalized (dx, dy) in [-1, 1]."""
+
+    # TODO: arrow-key / accessibility support
+
+    deflectionChanged = Signal(float, float)  # dx, dy normalized
+    released = Signal()
+
+    def __init__(self, parent: QWidget | None = None, dead_zone: float = 0.05):
+        super().__init__(parent)
+        self._dead_zone = dead_zone
+        self._knob_pos = QPointF(0, 0)  # relative to center, in pixels
+        self._dragging = False
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+    # ---- geometry helpers ----
+
+    def sizeHint(self) -> QSize:
+        return QSize(140, 140)
+
+    @property
+    def _radius(self) -> float:
+        """Radius of the usable pad area."""
+        return float(min(self.width(), self.height())) / 2 - 6
+
+    @property
+    def _knob_radius(self) -> float:
+        return self._radius * 0.12
+
+    @property
+    def _center(self) -> QPointF:
+        return QPointF(self.width() / 2, self.height() / 2)
+
+    def _clamp_to_circle(self, pos: QPointF) -> QPointF:
+        """Clamp a point (relative to center) to the pad radius."""
+        r = self._radius - self._knob_radius
+        dist = math.hypot(pos.x(), pos.y())
+        if dist > r:
+            scale = r / dist
+            return QPointF(pos.x() * scale, pos.y() * scale)
+        return pos
+
+    def _normalized(self) -> tuple[float, float]:
+        r = self._radius - self._knob_radius
+        if r <= 0:
+            return (0.0, 0.0)
+        dx = self._knob_pos.x() / r
+        dy = -self._knob_pos.y() / r
+        mag = math.hypot(dx, dy)
+        if mag < self._dead_zone:
+            return (0.0, 0.0)
+        # remap [dead_zone, 1] → [0, 1] so there's no jump at the edge
+        scale = (mag - self._dead_zone) / (1.0 - self._dead_zone) / mag
+        return (dx * scale, dy * scale)
+
+    # ---- mouse handling ----
+
+    def mousePressEvent(self, ev: QMouseEvent) -> None:
+        if ev.button() == Qt.MouseButton.LeftButton:
+            self._dragging = True
+            self._update_knob(ev.position())
+        super().mousePressEvent(ev)
+
+    def mouseMoveEvent(self, ev: QMouseEvent) -> None:
+        if self._dragging:
+            self._update_knob(ev.position())
+        super().mouseMoveEvent(ev)
+
+    def mouseReleaseEvent(self, ev: QMouseEvent) -> None:
+        if ev.button() == Qt.MouseButton.LeftButton:
+            self._dragging = False
+            self._knob_pos = QPointF(0, 0)
+            self.update()
+            self.deflectionChanged.emit(0.0, 0.0)
+            self.released.emit()
+        super().mouseReleaseEvent(ev)
+
+    def _update_knob(self, global_pos: QPointF) -> None:
+        rel = global_pos - self._center
+        self._knob_pos = self._clamp_to_circle(rel)
+        self.update()
+        dx, dy = self._normalized()
+        self.deflectionChanged.emit(dx, dy)
+
+    # ---- painting ----
+
+    def paintEvent(self, ev: QPaintEvent) -> None:
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+        center = self._center
+        radius = self._radius
+        pal = self.palette()
+
+        # background
+        p.setPen(Qt.PenStyle.NoPen)
+        p.setBrush(QBrush(QColor(0, 0, 0)))
+        p.drawRect(self.rect())
+
+        # outer ring
+        ring_color = pal.mid().color()
+        p.setPen(QPen(ring_color, 2))
+        bg = pal.dark().color()
+        bg.setAlpha(180)
+        p.setBrush(QBrush(bg))
+        p.drawEllipse(center, radius, radius)
+
+        # crosshair
+        cross = pal.mid().color()
+        cross.setAlpha(120)
+        p.setPen(QPen(cross, 1, Qt.PenStyle.DashLine))
+        p.drawLine(center + QPointF(-radius, 0), center + QPointF(radius, 0))
+        p.drawLine(center + QPointF(0, -radius), center + QPointF(0, radius))
+
+        # knob
+        knob_center = center + self._knob_pos
+        kr = self._knob_radius
+        grad = QRadialGradient(knob_center, kr)
+        if self._dragging:
+            grad.setColorAt(0, QColor(100, 180, 255))
+            grad.setColorAt(1, QColor(40, 100, 200))
+        else:
+            fg = pal.windowText().color()
+            fg.setAlpha(200)
+            grad.setColorAt(0, fg)
+            fg.setAlpha(120)
+            grad.setColorAt(1, fg)
+        p.setPen(Qt.PenStyle.NoPen)
+        p.setBrush(QBrush(grad))
+        p.drawEllipse(knob_center, kr, kr)
+
+        p.end()
+
+
+class StageJoystick(QWidget):
+    """Joystick widget that drives an XY stage via QStageMoveAccumulator."""
+
+    # TODO: Z support via vertical slider or modifier-key+drag for focus.
+    # QStageMoveAccumulator already supports single-axis StageDevice.
+
+    def __init__(
+        self,
+        xy_device: str,
+        mmcore: CMMCorePlus | None = None,
+        max_um_per_sec: float = 500.0,
+        speed_exponent: float = 2.0,
+        tick_ms: int = 50,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(parent)
+        self._acc = QStageMoveAccumulator.for_device(xy_device, mmcore)
+        self._max_speed = max_um_per_sec
+        self._speed_exponent = speed_exponent
+        self._tick_ms = tick_ms
+        self._dx = 0.0
+        self._dy = 0.0
+
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(tick_ms)
+        self._tick_timer.timeout.connect(self._on_tick)
+
+        self._joystick = JoystickWidget(self)
+        self._joystick.deflectionChanged.connect(self._on_deflection)
+        self._joystick.released.connect(self._on_release)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._joystick)
+
+    @property
+    def max_um_per_sec(self) -> float:
+        return self._max_speed
+
+    @max_um_per_sec.setter
+    def max_um_per_sec(self, value: float) -> None:
+        self._max_speed = value
+
+    @property
+    def speed_exponent(self) -> float:
+        return self._speed_exponent
+
+    @speed_exponent.setter
+    def speed_exponent(self, value: float) -> None:
+        self._speed_exponent = value
+
+    def _on_deflection(self, dx: float, dy: float) -> None:
+        self._dx = dx
+        self._dy = dy
+        if not self._tick_timer.isActive() and (dx or dy):
+            self._tick_timer.start()
+
+    def _on_release(self) -> None:
+        self._tick_timer.stop()
+
+    def _on_tick(self) -> None:
+        mag = min(math.hypot(self._dx, self._dy), 1.0)
+        if mag < 0.05:
+            return
+        speed = mag**self._speed_exponent * self._max_speed
+        ux, uy = self._dx / mag, self._dy / mag
+        dt = self._tick_ms / 1000.0
+        self._acc.move_relative((ux * speed * dt, uy * speed * dt))


### PR DESCRIPTION
playing with a new way to move the stage.  A joystick pad that moves in a vector, with a given velocity, based on a clicked mouse position, relative to the origin.  With a quadratic response curve (more control towards the center)

https://github.com/user-attachments/assets/8de09aab-f692-43ee-8169-ca97247a6a71

