### PR TITLE
fix: improve polygon widget resizing behavior

### DIFF
--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -687,7 +687,7 @@ class AffineState:
             S[0, 0] *= -1
         if flip_y:
             S[1, 1] *= -1
-        return R @ S  #  type: ignore
+        return R @ S
 
     def _pixel_config_is_identity(self) -> bool:
         return np.allclose(self.pixel_size_affine, (1.0, 0.0, 0.0, 0.0, 1.0, 0.0))

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol
 
 import useq
-from qtpy.QtCore import QPointF, Qt, QTimer, Signal
+from qtpy.QtCore import QPointF, Qt, Signal
 from qtpy.QtGui import (
     QBrush,
     QPainter,
@@ -604,9 +604,7 @@ class _PolygonWidget(QWidget):
 
     def resizeEvent(self, a0: QResizeEvent | None) -> None:
         super().resizeEvent(a0)
-        # Defer fitting to the next event loop iteration so the QGraphicsView's
-        # viewport has been resized before we call fitInView.
-        QTimer.singleShot(0, self._fit_view_to_items)
+        self._fit_view_to_items()
 
 
 class _ResizableStackedWidget(QStackedWidget):


### PR DESCRIPTION
I was using the `MDAWidget` together with the `ExplorerWidget` in `pymmcore-gui` and I've noticed that the `GridFromPolygon` are not well rendered in the grid tab of the `MDAWidget` if this widget is placed into a QScrollArea (as we do in `pymmcore-gui`).

This PR updates `QVBoxLayout` and `QSizePolicy.Policy` to make sure the polygon shape is always correctly displayed.

---

To reproduce on run:

```py
import useq
from pymmcore_plus import CMMCorePlus
from qtpy.QtWidgets import QApplication, QHBoxLayout, QScrollArea, QWidget

from pymmcore_widgets import MDAWidget

seq = useq.MDASequence(
    grid_plan=useq.GridFromPolygon(
        vertices=[(0, 0), (300, 0), (300, 700), (100, 100), (100, 300), (0, 300)],
        fov_height=100,
        fov_width=100,
        overlap=(10, 10),
    )
)

core = CMMCorePlus.instance()
core.loadSystemConfiguration()

app = QApplication([])

wdg = QWidget()
layout = QHBoxLayout(wdg)

mda1 = MDAWidget()
layout.addWidget(mda1)

mda2 = MDAWidget()
scroll = QScrollArea()
scroll.setWidget(mda2)
scroll.setWidgetResizable(True)
layout.addWidget(scroll)

mda1.setValue(seq)
mda2.setValue(seq)

wdg.show()
app.exec()
```

---
BEFORE (right `MDAWidget` is inside a `QScrollArea`)

https://github.com/user-attachments/assets/60a70ff7-7be5-400a-bc3f-3d2f6619274e

---
AFTER  (right `MDAWidget` is inside a `QScrollArea`)
<img width="1328" height="945" alt="Screenshot 2026-03-16 at 3 23 14 PM" src="https://github.com/user-attachments/assets/db3244a4-79bc-4a16-888b-a83575bb7141" />
