### PR TITLE
Core log widget: Remove single-shot Timer

### DIFF
--- a/src/pymmcore_widgets/_log.py
+++ b/src/pymmcore_widgets/_log.py
@@ -10,7 +10,6 @@ from qtpy.QtCore import (
     QFileSystemWatcher,
     QObject,
     QSize,
-    QTimer,
     QTimerEvent,
     QUrl,
     Signal,
@@ -181,13 +180,6 @@ class CoreLogWidget(QWidget):
         self._clear_btn.clicked.connect(self.clear)
         self._log_btn.clicked.connect(self._open_native)
         self._reader.start()
-
-        # scroll left to begin
-        def _scroll_left() -> None:
-            if sb := self._log_view.horizontalScrollBar():
-                sb.setValue(0)
-
-        QTimer.singleShot(0, _scroll_left)
 
     def clear(self) -> None:
         """Clear the log view."""


### PR DESCRIPTION
I can't tell what purpose this serves, as if you set the widget in the core log example to a fixed size then the widget is scrolled to the left as it should be. As such I want to remove it because it's vulnerable to RuntimeErrors where the C++ object gets deleted on the main thread before the timer goes off. If there is an actual example where this is necessary we can add it back in (along with a comment that explains it!)