### PR TITLE
fix: change marker scaling from fixed to scene for better visualization

### DIFF
--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_position_marker.py
@@ -43,7 +43,7 @@ class StagePositionMarker(Compound):
             edge_color=Color(marker_symbol_color),
             size=marker_symbol_size,
             edge_width=marker_symbol_edge_width,
-            scaling="fixed",
+            scaling="scene",
         )
 
         super().__init__([self._marker, self._rect])


### PR DESCRIPTION
Currently the stage position marker does not rescale when zooming in or out of the canvas, unlike the rectangle indicator. This is because the marker visual was using `scaling="fixed"` which keeps the symbol at a constant screen-pixel size regardless of zoom. Setting `scaling="scene"` instead makes the marker size expressed in scene coordinates, so it scales with the camera zoom exactly like the rectangle FOV border.