### PR TITLE
fix: correct image positioning and update stage position marker size

### DIFF
--- a/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
+++ b/src/pymmcore_widgets/control/_stage_explorer/_stage_explorer.py
@@ -297,6 +297,10 @@ class StageExplorer(QWidget):
         """Add an image to the scene at a give (x, y) stage position in microns."""
         # compute half-image shift from actual image dimensions so it's always
         # correct regardless of camera property changes.
+        # by default, vispy add the images from the bottom-left corner. We need to
+        # translate by -w/2 and -h/2 so the position corresponds to the center of the
+        # images. In addition, this makes sure the rotation (if any) is applied around
+        # the center of the image.
         h, w = image.shape[:2]
         half_img_shift = np.eye(4)
         half_img_shift[0:2, 3] = (-w / 2, -h / 2)


### PR DESCRIPTION
this uses the image itself as the source of truth for "image width/height" and updates _stage_pos_marker.  
For example, if the demo camera width/height prop changes, no ROI-changed signal is emitted... but the image size is indeed different