### PR TITLE
fix: Guard against NIDAQ adapter reporting excessive states in property browser

### DIFF
--- a/src/pymmcore_widgets/device_properties/_property_widget.py
+++ b/src/pymmcore_widgets/device_properties/_property_widget.py
@@ -356,9 +356,12 @@ def _get_allowed_values(mmc: CMMCorePlus, device: str, prop: str) -> tuple[str, 
     # Special handling for state device Label/State properties
     if mmc.getDeviceType(device) == DeviceType.StateDevice:
         if prop == LABEL:
-            return mmc.getStateLabels(device)
+            with contextlib.suppress(RuntimeError):
+                return mmc.getStateLabels(device)
         if prop == STATE:
             n_states = mmc.getNumberOfStates(device)
+            if n_states > 1024:  # guard against adapters reporting INT_MAX
+                return ()
             return tuple(str(i) for i in range(n_states))
 
     return ()


### PR DESCRIPTION
Limit the state count to 1024 for the NIDAQ digital output adapter to prevent the property browser from hanging due to excessive state reporting. Suppress RuntimeError when retrieving state labels to enhance stability.
Tested on napari-micromanager with a PCIe NIDAQ (NI-6353)