### PR TITLE
fix: synchronize loaded MDA channel group

### DIFF
--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -51,6 +51,7 @@ class ChannelTable(DataTableWidget):
         # These will change in on_group_changed... so we store the current values.
         self._groups: Mapping[str, Sequence[str]] = {}
         self._config_column: ColumnInfo = self.CONFIG
+        self._loaded_group_warning: str | None = None
 
         # when a new row is inserted, call _on_rows_inserted
         # to update the new values from the _group_combo
@@ -74,6 +75,9 @@ class ChannelTable(DataTableWidget):
             self._group_combo.clear()
             for group_name in groups:
                 self._group_combo.addItem(group_name)
+
+        if self._loaded_group_warning and self._loaded_group_warning in groups:
+            self._set_loaded_group_warning(None)
 
         # update the to show the combobox if there are more than one group
         toolbar = self.toolBar()
@@ -118,16 +122,51 @@ class ChannelTable(DataTableWidget):
             An Iterable of [useq.Channels](https://pymmcore-plus.github.io/useq-schema/schema/axes/#useq.Channel).
         """
         _values = []
+        groups: set[str] = set()
         for v in value:
             if not isinstance(v, useq.Channel):  # pragma: no cover
                 raise TypeError(f"Expected useq.Channel, got {type(v)}")
+            if v.group:
+                groups.add(v.group)
             _values.append(v.model_dump(exclude_unset=True))
+
+        # When loading an MDA sequence, sync the selected group first so the config
+        # column is rebuilt with the correct preset choices before row data are set.
+        if len(groups) == 1:
+            group = next(iter(groups))
+            if group in self._groups:
+                with signals_blocked(self._group_combo):
+                    self._group_combo.setCurrentText(group)
+                self._on_group_changed()
+                self._set_loaded_group_warning(None)
+            else:
+                self._set_loaded_group_warning(group)
+        else:
+            self._set_loaded_group_warning(None)
+
         super().setValue(_values)
 
     # ------------------- Private API -------------------
 
+    def _set_loaded_group_warning(self, group: str | None) -> None:
+        self._loaded_group_warning = group
+        if group:
+            msg = (
+                f"Loaded sequence uses channel group '{group}', but it is not "
+                "available in the current Micro-Manager configuration."
+            )
+            self._group_combo.setToolTip(msg)
+            self._group_combo.setStyleSheet(
+                "QComboBox { border: 1px solid #c2410c; background: #fff7ed; }"
+            )
+        else:
+            self._group_combo.setToolTip("")
+            self._group_combo.setStyleSheet("")
+
     def _on_group_changed(self) -> None:
         group = self._group_combo.currentText()
+        if self._loaded_group_warning and group == self._loaded_group_warning:
+            self._set_loaded_group_warning(None)
         table = self.table()
 
         # set the group column values

--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -135,7 +135,7 @@ class ChannelTable(DataTableWidget):
                 with signals_blocked(self._group_combo):
                     self._group_combo.setCurrentText(group)
                 self._on_group_changed()
-            else:
+            elif self._groups:
                 warnings.warn(
                     f"Loaded sequence uses channel group '{group}', but it is not "
                     "available in the current Micro-Manager configuration.",

--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
@@ -51,7 +52,6 @@ class ChannelTable(DataTableWidget):
         # These will change in on_group_changed... so we store the current values.
         self._groups: Mapping[str, Sequence[str]] = {}
         self._config_column: ColumnInfo = self.CONFIG
-        self._loaded_group_warning: str | None = None
 
         # when a new row is inserted, call _on_rows_inserted
         # to update the new values from the _group_combo
@@ -75,9 +75,6 @@ class ChannelTable(DataTableWidget):
             self._group_combo.clear()
             for group_name in groups:
                 self._group_combo.addItem(group_name)
-
-        if self._loaded_group_warning and self._loaded_group_warning in groups:
-            self._set_loaded_group_warning(None)
 
         # update the to show the combobox if there are more than one group
         toolbar = self.toolBar()
@@ -138,31 +135,19 @@ class ChannelTable(DataTableWidget):
                 with signals_blocked(self._group_combo):
                     self._group_combo.setCurrentText(group)
                 self._on_group_changed()
-                self._set_loaded_group_warning(None)
             else:
-                self._set_loaded_group_warning(group)
-        else:
-            self._set_loaded_group_warning(None)
+                warnings.warn(
+                    f"Loaded sequence uses channel group '{group}', but it is not "
+                    "available in the current Micro-Manager configuration.",
+                    stacklevel=2,
+                )
 
         super().setValue(_values)
 
     # ------------------- Private API -------------------
 
-    def _set_loaded_group_warning(self, group: str | None) -> None:
-        self._loaded_group_warning = group
-        if group:
-            msg = (
-                f"Loaded sequence uses channel group '{group}', but it is not "
-                "available in the current Micro-Manager configuration."
-            )
-            self._group_combo.setToolTip(msg)
-        else:
-            self._group_combo.setToolTip("")
-
     def _on_group_changed(self) -> None:
         group = self._group_combo.currentText()
-        if self._loaded_group_warning and group == self._loaded_group_warning:
-            self._set_loaded_group_warning(None)
         table = self.table()
 
         # set the group column values

--- a/src/pymmcore_widgets/useq_widgets/_channels.py
+++ b/src/pymmcore_widgets/useq_widgets/_channels.py
@@ -156,12 +156,8 @@ class ChannelTable(DataTableWidget):
                 "available in the current Micro-Manager configuration."
             )
             self._group_combo.setToolTip(msg)
-            self._group_combo.setStyleSheet(
-                "QComboBox { border: 1px solid #c2410c; background: #fff7ed; }"
-            )
         else:
             self._group_combo.setToolTip("")
-            self._group_combo.setStyleSheet("")
 
     def _on_group_changed(self) -> None:
         group = self._group_combo.currentText()

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -94,10 +94,8 @@ def test_channel_table_warns_when_loaded_group_is_missing(qtbot: QtBot):
 
     assert table._loaded_group_warning == "MissingGroup"
     assert "MissingGroup" in table._group_combo.toolTip()
-    assert "border" in table._group_combo.styleSheet()
 
     table.setChannelGroups({"Channel": ["DAPI"], "MissingGroup": ["Preset"]})
 
     assert table._loaded_group_warning is None
     assert table._group_combo.toolTip() == ""
-    assert table._group_combo.styleSheet() == ""

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 import useq
 from qtpy.QtWidgets import QComboBox
 
@@ -82,7 +83,6 @@ def test_channel_table_syncs_loaded_group(qtbot: QtBot):
     assert table._group_combo.currentText() == "LightPath"
     assert table.value()[0].group == "LightPath"
     assert table.value()[0].config == "Cy5"
-    assert table._loaded_group_warning is None
 
 
 def test_channel_table_warns_when_loaded_group_is_missing(qtbot: QtBot):
@@ -90,12 +90,5 @@ def test_channel_table_warns_when_loaded_group_is_missing(qtbot: QtBot):
     qtbot.addWidget(table)
     table.setChannelGroups({"Channel": ["DAPI"]})
 
-    table.setValue([useq.Channel(group="MissingGroup", config="Preset")])
-
-    assert table._loaded_group_warning == "MissingGroup"
-    assert "MissingGroup" in table._group_combo.toolTip()
-
-    table.setChannelGroups({"Channel": ["DAPI"], "MissingGroup": ["Preset"]})
-
-    assert table._loaded_group_warning is None
-    assert table._group_combo.toolTip() == ""
+    with pytest.warns(UserWarning, match="MissingGroup"):
+        table.setValue([useq.Channel(group="MissingGroup", config="Preset")])

--- a/tests/test_channel_widget.py
+++ b/tests/test_channel_widget.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import useq
 from qtpy.QtWidgets import QComboBox
 
 from pymmcore_widgets._util import block_core
 from pymmcore_widgets.control._channel_widget import ChannelWidget
 from pymmcore_widgets.control._presets_widget import NO_MATCH, PresetsWidget
+from pymmcore_widgets.useq_widgets import ChannelTable
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -68,3 +70,34 @@ def test_channel_widget(qtbot: QtBot, global_mmcore: CMMCorePlus):
     assert isinstance(wdg.channel_wdg, PresetsWidget)
     assert len(wdg.channel_wdg.allowedValues()) == 1
     assert global_mmcore.getChannelGroup() == "Channels"
+
+
+def test_channel_table_syncs_loaded_group(qtbot: QtBot):
+    table = ChannelTable()
+    qtbot.addWidget(table)
+    table.setChannelGroups({"Channel": ["DAPI"], "LightPath": ["GFP", "Cy5"]})
+
+    table.setValue([useq.Channel(group="LightPath", config="Cy5")])
+
+    assert table._group_combo.currentText() == "LightPath"
+    assert table.value()[0].group == "LightPath"
+    assert table.value()[0].config == "Cy5"
+    assert table._loaded_group_warning is None
+
+
+def test_channel_table_warns_when_loaded_group_is_missing(qtbot: QtBot):
+    table = ChannelTable()
+    qtbot.addWidget(table)
+    table.setChannelGroups({"Channel": ["DAPI"]})
+
+    table.setValue([useq.Channel(group="MissingGroup", config="Preset")])
+
+    assert table._loaded_group_warning == "MissingGroup"
+    assert "MissingGroup" in table._group_combo.toolTip()
+    assert "border" in table._group_combo.styleSheet()
+
+    table.setChannelGroups({"Channel": ["DAPI"], "MissingGroup": ["Preset"]})
+
+    assert table._loaded_group_warning is None
+    assert table._group_combo.toolTip() == ""
+    assert table._group_combo.styleSheet() == ""

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -140,6 +140,7 @@ MDA_ZT = useq.MDASequence(
 
 def test_mda_wdg(qtbot: QtBot):
     wdg = MDASequenceWidget()
+    wdg.channels.setChannelGroups({"Channel": ["DAPI", "FITC"]})
     qtbot.addWidget(wdg)
     wdg.show()
 


### PR DESCRIPTION
## Summary

When loading MDA channels, synchronize the selected channel group before setting the channel table row values.

This ensures the config/preset column is rebuilt with the correct preset choices before row data are applied. If the loaded sequence references a channel group that is not available in the current Micro-Manager configuration, the widget now emits a Python warning instead of silently showing mismatched presets.

## Background

This came from loading saved MDA settings on a TiEclipse configuration where the channel group/preset did not restore correctly at application startup/load time.

## Validation

- python -m ruff check src/pymmcore_widgets/useq_widgets/_channels.py tests/test_channel_widget.py tests/test_channel_group_widget.py
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_channel_widget.py tests/test_channel_group_widget.py -q: 4 passed
- python -m compileall -q src/pymmcore_widgets/useq_widgets/_channels.py