### PR TITLE
feat: add software autofocus support to MDAWidget

### DIFF
--- a/src/pymmcore_widgets/mda/_autofocus.py
+++ b/src/pymmcore_widgets/mda/_autofocus.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter, sleep
+from typing import TYPE_CHECKING, Any, Protocol
+
+import numpy as np
+from pymmcore_plus import CMMCorePlus
+from pymmcore_plus._logger import logger
+from pymmcore_plus.mda import MDAEngine
+from qtpy.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+from useq import HardwareAutofocus, MDAEvent, MDASequence
+
+from pymmcore_widgets.useq_widgets._autofocus import (
+    PYMMCW_AUTOFOCUS_KEY,
+    PYMMCW_SOFTWARE_AUTOFOCUS_KEY,
+    AutofocusMode,
+    normalize_software_af_settings,
+)
+from pymmcore_widgets.useq_widgets._mda_sequence import PYMMCW_METADATA_KEY
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from pymmcore_plus.mda._protocol import PImagePayload
+
+
+@dataclass(frozen=True)
+class SoftwareAutofocusResult:
+    backend: str
+    best_z: float
+    start_z: float
+    best_score: float
+    elapsed_s: float
+    attempts: int
+
+    @property
+    def correction_um(self) -> float:
+        return self.best_z - self.start_z
+
+    def summary(self) -> str:
+        return (
+            f"{self.backend}: z {self.start_z:.3f} -> {self.best_z:.3f} um, "
+            f"score {self.best_score:.3f}, dt {self.elapsed_s:.2f} s"
+        )
+
+
+class AutofocusScorer(Protocol):
+    backend_id: str
+    display_name: str
+
+    def score(self, image: np.ndarray) -> float: ...
+
+
+class TenengradScorer:
+    backend_id = "tenengrad"
+    display_name = "Tenengrad"
+
+    def score(self, image: np.ndarray) -> float:
+        gx, gy = np.gradient(image.astype(np.float32, copy=False))
+        return float(np.mean(gx * gx + gy * gy))
+
+
+class LaplacianVarianceScorer:
+    backend_id = "laplacian_variance"
+    display_name = "Laplacian Variance"
+
+    def score(self, image: np.ndarray) -> float:
+        image = image.astype(np.float32, copy=False)
+        center = image[1:-1, 1:-1]
+        lap = (
+            -4 * center
+            + image[:-2, 1:-1]
+            + image[2:, 1:-1]
+            + image[1:-1, :-2]
+            + image[1:-1, 2:]
+        )
+        return float(lap.var())
+
+
+AUTOFOCUS_SCORERS: dict[str, AutofocusScorer] = {
+    scorer.backend_id: scorer
+    for scorer in (TenengradScorer(), LaplacianVarianceScorer())
+}
+
+
+def _coerce_2d(image: np.ndarray) -> np.ndarray:
+    if image.ndim == 2:
+        return image
+    if image.ndim == 3:
+        return image.mean(axis=-1)
+    return np.squeeze(image)
+
+
+def _center_crop(image: np.ndarray, crop_size_px: int | None) -> np.ndarray:
+    image = _coerce_2d(image)
+    if not crop_size_px or crop_size_px <= 0:
+        return image
+
+    height, width = image.shape[:2]
+    size = min(crop_size_px, height, width)
+    y0 = max((height - size) // 2, 0)
+    x0 = max((width - size) // 2, 0)
+    return image[y0 : y0 + size, x0 : x0 + size]
+
+
+def _z_positions(start_z: float, search_range_um: float, step_um: float) -> list[float]:
+    if step_um <= 0:
+        raise ValueError("step_um must be > 0")
+    if search_range_um <= 0:
+        return [start_z]
+    half_range = search_range_um / 2
+    n_steps = max(int(round(search_range_um / step_um)), 1)
+    positions = np.linspace(start_z - half_range, start_z + half_range, n_steps + 1)
+    return [float(x) for x in positions]
+
+
+def run_software_autofocus(
+    core: CMMCorePlus, settings: Any
+) -> SoftwareAutofocusResult:
+    options = normalize_software_af_settings(settings)
+    params = options["params"]
+    focus_device = core.getFocusDevice()
+    if not focus_device:
+        raise RuntimeError("No focus device is configured.")
+
+    scorer = AUTOFOCUS_SCORERS.get(options["backend"])
+    if scorer is None:
+        raise RuntimeError(f"Unknown autofocus backend: {options['backend']!r}")
+
+    start_z = float(core.getZPosition())
+    z_positions = _z_positions(
+        start_z=start_z,
+        search_range_um=float(params["search_range_um"]),
+        step_um=float(params["step_um"]),
+    )
+    exposure_ms = params.get("exposure_ms")
+    settle_s = max(float(params.get("settle_ms", 0.0)) / 1000.0, 0.0)
+    max_retries = max(int(params.get("max_retries", 1)), 1)
+    crop_size_px = int(params.get("crop_size_px", 0) or 0)
+
+    t0 = perf_counter()
+    best_score = float("-inf")
+    best_z = start_z
+    attempts = 0
+
+    previous_exposure = float(core.getExposure()) if exposure_ms is not None else None
+
+    try:
+        if exposure_ms is not None:
+            core.setExposure(float(exposure_ms))
+
+        for _retry_idx in range(max_retries):
+            attempts += 1
+            for z in z_positions:
+                core.setZPosition(z)
+                core.waitForDevice(focus_device)
+                if settle_s:
+                    sleep(settle_s)
+                core.snapImage()
+                image = np.asarray(core.getImage())
+                score = scorer.score(_center_crop(image, crop_size_px))
+                if score > best_score:
+                    best_score = score
+                    best_z = z
+    finally:
+        core.setZPosition(best_z)
+        core.waitForDevice(focus_device)
+        if previous_exposure is not None:
+            core.setExposure(previous_exposure)
+
+    return SoftwareAutofocusResult(
+        backend=scorer.display_name,
+        best_z=best_z,
+        start_z=start_z,
+        best_score=best_score,
+        elapsed_s=perf_counter() - t0,
+        attempts=attempts,
+    )
+
+
+class SoftwareAutofocusDialog(QDialog):
+    def __init__(
+        self,
+        settings: Any,
+        *,
+        test_callback: Callable[[dict[str, Any]], str] | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Software Autofocus")
+        self._test_callback = test_callback
+
+        self._backend = QComboBox()
+        for scorer in AUTOFOCUS_SCORERS.values():
+            self._backend.addItem(scorer.display_name, scorer.backend_id)
+
+        self._search_range = QDoubleSpinBox()
+        self._search_range.setRange(0.5, 500.0)
+        self._search_range.setDecimals(3)
+        self._search_range.setSuffix(" um")
+
+        self._step = QDoubleSpinBox()
+        self._step.setRange(0.05, 100.0)
+        self._step.setDecimals(3)
+        self._step.setSuffix(" um")
+
+        self._crop = QSpinBox()
+        self._crop.setRange(0, 4096)
+        self._crop.setSpecialValueText("Full frame")
+        self._crop.setSingleStep(64)
+        self._crop.setSuffix(" px")
+
+        self._exposure = QDoubleSpinBox()
+        self._exposure.setRange(0.0, 10000.0)
+        self._exposure.setDecimals(2)
+        self._exposure.setSpecialValueText("Current")
+        self._exposure.setSuffix(" ms")
+
+        self._settle = QDoubleSpinBox()
+        self._settle.setRange(0.0, 5000.0)
+        self._settle.setDecimals(1)
+        self._settle.setSuffix(" ms")
+
+        self._retries = QSpinBox()
+        self._retries.setRange(1, 10)
+
+        form = QFormLayout()
+        form.addRow("Backend", self._backend)
+        form.addRow("Search Range", self._search_range)
+        form.addRow("Step", self._step)
+        form.addRow("Crop", self._crop)
+        form.addRow("Exposure", self._exposure)
+        form.addRow("Settle", self._settle)
+        form.addRow("Retries", self._retries)
+
+        group = QGroupBox("Parameters")
+        group.setLayout(form)
+
+        self._status = QLabel("Ready.")
+        self._status.setWordWrap(True)
+
+        self._test_btn = QPushButton("Test on Current Position")
+        self._test_btn.setEnabled(test_callback is not None)
+        self._test_btn.clicked.connect(self._on_test_clicked)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+
+        buttons = QHBoxLayout()
+        buttons.addWidget(self._test_btn)
+        buttons.addStretch()
+        buttons.addWidget(button_box)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(group)
+        layout.addWidget(self._status)
+        layout.addLayout(buttons)
+
+        self.setValue(settings)
+
+    def value(self) -> dict[str, Any]:
+        exposure = float(self._exposure.value())
+        return {
+            "backend": str(self._backend.currentData()),
+            "params": {
+                "search_range_um": float(self._search_range.value()),
+                "step_um": float(self._step.value()),
+                "crop_size_px": int(self._crop.value()),
+                "exposure_ms": None if exposure <= 0 else exposure,
+                "settle_ms": float(self._settle.value()),
+                "max_retries": int(self._retries.value()),
+            },
+        }
+
+    def setValue(self, settings: Any) -> None:
+        value = normalize_software_af_settings(settings)
+        params = value["params"]
+        idx = self._backend.findData(value["backend"])
+        if idx >= 0:
+            self._backend.setCurrentIndex(idx)
+        self._search_range.setValue(float(params["search_range_um"]))
+        self._step.setValue(float(params["step_um"]))
+        self._crop.setValue(int(params["crop_size_px"] or 0))
+        self._exposure.setValue(float(params["exposure_ms"] or 0.0))
+        self._settle.setValue(float(params["settle_ms"]))
+        self._retries.setValue(int(params["max_retries"]))
+
+    def _on_test_clicked(self) -> None:
+        if self._test_callback is None:
+            return
+        settings = self.value()
+        self._status.setText("Running software autofocus...")
+        self.repaint()
+        try:
+            self._status.setText(self._test_callback(settings))
+        except Exception as e:
+            self._status.setText(f"Autofocus failed: {e}")
+
+
+class SoftwareAutofocusMDAEngine(MDAEngine):
+    def __init__(self, mmc: CMMCorePlus) -> None:
+        super().__init__(mmc)
+        self._af_mode = AutofocusMode.NONE
+        self._software_af_settings = normalize_software_af_settings(None)
+
+    def setup_sequence(self, sequence: MDASequence) -> dict | None:
+        af_meta = sequence.metadata.get(PYMMCW_METADATA_KEY, {}).get(
+            PYMMCW_AUTOFOCUS_KEY, {}
+        )
+        self._af_mode = AutofocusMode(str(af_meta.get("mode", AutofocusMode.NONE.value)))
+        self._software_af_settings = normalize_software_af_settings(
+            af_meta.get(PYMMCW_SOFTWARE_AUTOFOCUS_KEY)
+        )
+        meta = super().setup_sequence(sequence)
+        if self._af_mode is AutofocusMode.SOFTWARE:
+            self._af_was_engaged = False
+        return meta
+
+    def exec_event(self, event: MDAEvent) -> Iterable[PImagePayload | None]:
+        action = getattr(event, "action", None)
+        if (
+            self._af_mode is AutofocusMode.SOFTWARE
+            and isinstance(action, HardwareAutofocus)
+        ):
+            try:
+                result = run_software_autofocus(self.mmcore, self._software_af_settings)
+            except Exception as e:
+                logger.warning("Software autofocus failed. %s", e)
+                self._af_succeeded = False
+            else:
+                self._af_succeeded = True
+                p_idx = event.index.get("p", None)
+                self._z_correction[p_idx] = result.correction_um + self._z_correction.get(
+                    p_idx, 0.0
+                )
+                logger.info("Software autofocus succeeded: %s", result.summary())
+            return ()
+
+        return super().exec_event(event)

--- a/src/pymmcore_widgets/mda/_autofocus.py
+++ b/src/pymmcore_widgets/mda/_autofocus.py
@@ -136,6 +136,14 @@ def _software_af_channel_label(settings: dict[str, Any]) -> str:
     return f"{group} / {channel}"
 
 
+def _software_af_failure_label(settings: dict[str, Any]) -> str:
+    policy = settings.get("failure_policy", "continue_keep_z")
+    return {
+        "continue_keep_z": "Keep previous focus and continue",
+        "abort": "Abort acquisition",
+    }.get(str(policy), str(policy))
+
+
 def run_software_autofocus(
     core: CMMCorePlus, settings: Any
 ) -> SoftwareAutofocusResult:
@@ -242,6 +250,11 @@ class SoftwareAutofocusDialog(QDialog):
 
         self._channel_group = QComboBox()
         self._channel = QComboBox()
+        self._failure_policy = QComboBox()
+        self._failure_policy.addItem(
+            "Keep previous focus and continue", "continue_keep_z"
+        )
+        self._failure_policy.addItem("Abort acquisition", "abort")
 
         self._search_range = QDoubleSpinBox()
         self._search_range.setRange(0.5, 500.0)
@@ -282,6 +295,7 @@ class SoftwareAutofocusDialog(QDialog):
         form.addRow("Focus Channel", self._channel_mode)
         form.addRow("Channel Group", self._channel_group)
         form.addRow("Channel Preset", self._channel)
+        form.addRow("On Failure", self._failure_policy)
         form.addRow("Search Range", self._search_range)
         form.addRow("Step", self._step)
         form.addRow("Crop", self._crop)
@@ -325,6 +339,7 @@ class SoftwareAutofocusDialog(QDialog):
             "channel_mode": str(self._channel_mode.currentData()),
             "channel_group": self._selected_channel_group(),
             "channel": self._selected_channel(),
+            "failure_policy": str(self._failure_policy.currentData()),
             "params": {
                 "search_range_um": float(self._search_range.value()),
                 "step_um": float(self._step.value()),
@@ -344,6 +359,9 @@ class SoftwareAutofocusDialog(QDialog):
         idx = self._channel_mode.findData(value["channel_mode"])
         if idx >= 0:
             self._channel_mode.setCurrentIndex(idx)
+        idx = self._failure_policy.findData(value["failure_policy"])
+        if idx >= 0:
+            self._failure_policy.setCurrentIndex(idx)
         self._set_combo_to_value(self._channel_group, value["channel_group"])
         self._populate_channels()
         self._set_combo_to_value(self._channel, value["channel"])
@@ -440,6 +458,17 @@ class SoftwareAutofocusMDAEngine(MDAEngine):
             except Exception as e:
                 logger.warning("Software autofocus failed. %s", e)
                 self._af_succeeded = False
+                policy = self._software_af_settings.get("failure_policy")
+                if policy == "abort":
+                    raise RuntimeError(
+                        "Software autofocus failed and the failure policy is "
+                        f"'{_software_af_failure_label(self._software_af_settings)}'."
+                    ) from e
+                logger.warning(
+                    "Continuing acquisition with previous focus after autofocus "
+                    "failure (policy: %s).",
+                    _software_af_failure_label(self._software_af_settings),
+                )
             else:
                 self._af_succeeded = True
                 p_idx = event.index.get("p", None)

--- a/src/pymmcore_widgets/mda/_autofocus.py
+++ b/src/pymmcore_widgets/mda/_autofocus.py
@@ -128,6 +128,14 @@ def _z_positions(start_z: float, search_range_um: float, step_um: float) -> list
     return [float(x) for x in positions]
 
 
+def _software_af_channel_label(settings: dict[str, Any]) -> str:
+    if settings.get("channel_mode") != "fixed":
+        return "Current microscope state"
+    group = settings.get("channel_group") or "current group"
+    channel = settings.get("channel") or "current preset"
+    return f"{group} / {channel}"
+
+
 def run_software_autofocus(
     core: CMMCorePlus, settings: Any
 ) -> SoftwareAutofocusResult:
@@ -158,10 +166,25 @@ def run_software_autofocus(
     attempts = 0
 
     previous_exposure = float(core.getExposure()) if exposure_ms is not None else None
+    restore_group: str | None = None
+    restore_channel: str | None = None
 
     try:
         if exposure_ms is not None:
             core.setExposure(float(exposure_ms))
+
+        if options.get("channel_mode") == "fixed":
+            channel_group = options.get("channel_group") or core.getChannelGroup()
+            channel = options.get("channel")
+            if channel_group and channel:
+                restore_group = core.getChannelGroup() or None
+                if restore_group:
+                    try:
+                        restore_channel = core.getCurrentConfig(restore_group)
+                    except Exception:
+                        restore_channel = None
+                core.setConfig(str(channel_group), str(channel))
+                core.waitForSystem()
 
         for _retry_idx in range(max_retries):
             attempts += 1
@@ -179,6 +202,9 @@ def run_software_autofocus(
     finally:
         core.setZPosition(best_z)
         core.waitForDevice(focus_device)
+        if restore_group and restore_channel:
+            core.setConfig(restore_group, restore_channel)
+            core.waitForSystem()
         if previous_exposure is not None:
             core.setExposure(previous_exposure)
 
@@ -197,16 +223,25 @@ class SoftwareAutofocusDialog(QDialog):
         self,
         settings: Any,
         *,
+        core: CMMCorePlus | None = None,
         test_callback: Callable[[dict[str, Any]], str] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Software Autofocus")
+        self._core = core
         self._test_callback = test_callback
 
         self._backend = QComboBox()
         for scorer in AUTOFOCUS_SCORERS.values():
             self._backend.addItem(scorer.display_name, scorer.backend_id)
+
+        self._channel_mode = QComboBox()
+        self._channel_mode.addItem("Use current state", "current")
+        self._channel_mode.addItem("Force channel preset", "fixed")
+
+        self._channel_group = QComboBox()
+        self._channel = QComboBox()
 
         self._search_range = QDoubleSpinBox()
         self._search_range.setRange(0.5, 500.0)
@@ -238,8 +273,15 @@ class SoftwareAutofocusDialog(QDialog):
         self._retries = QSpinBox()
         self._retries.setRange(1, 10)
 
+        self._channel_mode.currentIndexChanged.connect(self._update_channel_widgets)
+        self._channel_group.currentIndexChanged.connect(self._populate_channels)
+        self._populate_channel_groups()
+
         form = QFormLayout()
         form.addRow("Backend", self._backend)
+        form.addRow("Focus Channel", self._channel_mode)
+        form.addRow("Channel Group", self._channel_group)
+        form.addRow("Channel Preset", self._channel)
         form.addRow("Search Range", self._search_range)
         form.addRow("Step", self._step)
         form.addRow("Crop", self._crop)
@@ -280,6 +322,9 @@ class SoftwareAutofocusDialog(QDialog):
         exposure = float(self._exposure.value())
         return {
             "backend": str(self._backend.currentData()),
+            "channel_mode": str(self._channel_mode.currentData()),
+            "channel_group": self._selected_channel_group(),
+            "channel": self._selected_channel(),
             "params": {
                 "search_range_um": float(self._search_range.value()),
                 "step_um": float(self._step.value()),
@@ -296,23 +341,73 @@ class SoftwareAutofocusDialog(QDialog):
         idx = self._backend.findData(value["backend"])
         if idx >= 0:
             self._backend.setCurrentIndex(idx)
+        idx = self._channel_mode.findData(value["channel_mode"])
+        if idx >= 0:
+            self._channel_mode.setCurrentIndex(idx)
+        self._set_combo_to_value(self._channel_group, value["channel_group"])
+        self._populate_channels()
+        self._set_combo_to_value(self._channel, value["channel"])
         self._search_range.setValue(float(params["search_range_um"]))
         self._step.setValue(float(params["step_um"]))
         self._crop.setValue(int(params["crop_size_px"] or 0))
         self._exposure.setValue(float(params["exposure_ms"] or 0.0))
         self._settle.setValue(float(params["settle_ms"]))
         self._retries.setValue(int(params["max_retries"]))
+        self._update_channel_widgets()
 
     def _on_test_clicked(self) -> None:
         if self._test_callback is None:
             return
         settings = self.value()
-        self._status.setText("Running software autofocus...")
+        self._status.setText(
+            f"Running software autofocus on {_software_af_channel_label(settings)}..."
+        )
         self.repaint()
         try:
             self._status.setText(self._test_callback(settings))
         except Exception as e:
             self._status.setText(f"Autofocus failed: {e}")
+
+    def _populate_channel_groups(self) -> None:
+        self._channel_group.clear()
+        current_group = self._core.getChannelGroup() if self._core else ""
+        if current_group:
+            self._channel_group.addItem(current_group, current_group)
+        if self._core:
+            for group in self._core.getAvailableConfigGroups():
+                if self._channel_group.findData(group) < 0:
+                    self._channel_group.addItem(group, group)
+        self._populate_channels()
+
+    def _populate_channels(self) -> None:
+        current_value = self._selected_channel()
+        self._channel.clear()
+        group = self._selected_channel_group()
+        if self._core and group:
+            for config in self._core.getAvailableConfigs(group):
+                self._channel.addItem(config, config)
+        self._set_combo_to_value(self._channel, current_value)
+        self._update_channel_widgets()
+
+    def _selected_channel_group(self) -> str | None:
+        value = self._channel_group.currentData()
+        return str(value) if value else None
+
+    def _selected_channel(self) -> str | None:
+        value = self._channel.currentData()
+        return str(value) if value else None
+
+    def _set_combo_to_value(self, combo: QComboBox, value: str | None) -> None:
+        if not value:
+            return
+        idx = combo.findData(value)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+
+    def _update_channel_widgets(self) -> None:
+        fixed = self._channel_mode.currentData() == "fixed"
+        self._channel_group.setEnabled(fixed)
+        self._channel.setEnabled(fixed)
 
 
 class SoftwareAutofocusMDAEngine(MDAEngine):

--- a/src/pymmcore_widgets/mda/_autofocus.py
+++ b/src/pymmcore_widgets/mda/_autofocus.py
@@ -5,7 +5,6 @@ from time import perf_counter, sleep
 from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
-from pymmcore_plus import CMMCorePlus
 from pymmcore_plus._logger import logger
 from pymmcore_plus.mda import MDAEngine
 from qtpy.QtWidgets import (
@@ -35,6 +34,7 @@ from pymmcore_widgets.useq_widgets._mda_sequence import PYMMCW_METADATA_KEY
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
+    from pymmcore_plus import CMMCorePlus
     from pymmcore_plus.mda._protocol import PImagePayload
 
 
@@ -123,7 +123,7 @@ def _z_positions(start_z: float, search_range_um: float, step_um: float) -> list
     if search_range_um <= 0:
         return [start_z]
     half_range = search_range_um / 2
-    n_steps = max(int(round(search_range_um / step_um)), 1)
+    n_steps = max(round(search_range_um / step_um), 1)
     positions = np.linspace(start_z - half_range, start_z + half_range, n_steps + 1)
     return [float(x) for x in positions]
 
@@ -144,9 +144,7 @@ def _software_af_failure_label(settings: dict[str, Any]) -> str:
     }.get(str(policy), str(policy))
 
 
-def run_software_autofocus(
-    core: CMMCorePlus, settings: Any
-) -> SoftwareAutofocusResult:
+def run_software_autofocus(core: CMMCorePlus, settings: Any) -> SoftwareAutofocusResult:
     options = normalize_software_af_settings(settings)
     params = options["params"]
     focus_device = core.getFocusDevice()
@@ -314,8 +312,7 @@ class SoftwareAutofocusDialog(QDialog):
         self._test_btn.clicked.connect(self._on_test_clicked)
 
         button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok
-            | QDialogButtonBox.StandardButton.Cancel
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
@@ -438,7 +435,9 @@ class SoftwareAutofocusMDAEngine(MDAEngine):
         af_meta = sequence.metadata.get(PYMMCW_METADATA_KEY, {}).get(
             PYMMCW_AUTOFOCUS_KEY, {}
         )
-        self._af_mode = AutofocusMode(str(af_meta.get("mode", AutofocusMode.NONE.value)))
+        self._af_mode = AutofocusMode(
+            str(af_meta.get("mode", AutofocusMode.NONE.value))
+        )
         self._software_af_settings = normalize_software_af_settings(
             af_meta.get(PYMMCW_SOFTWARE_AUTOFOCUS_KEY)
         )
@@ -449,9 +448,8 @@ class SoftwareAutofocusMDAEngine(MDAEngine):
 
     def exec_event(self, event: MDAEvent) -> Iterable[PImagePayload | None]:
         action = getattr(event, "action", None)
-        if (
-            self._af_mode is AutofocusMode.SOFTWARE
-            and isinstance(action, HardwareAutofocus)
+        if self._af_mode is AutofocusMode.SOFTWARE and isinstance(
+            action, HardwareAutofocus
         ):
             try:
                 result = run_software_autofocus(self.mmcore, self._software_af_settings)
@@ -472,8 +470,8 @@ class SoftwareAutofocusMDAEngine(MDAEngine):
             else:
                 self._af_succeeded = True
                 p_idx = event.index.get("p", None)
-                self._z_correction[p_idx] = result.correction_um + self._z_correction.get(
-                    p_idx, 0.0
+                self._z_correction[p_idx] = (
+                    result.correction_um + self._z_correction.get(p_idx, 0.0)
                 )
                 logger.info("Software autofocus succeeded: %s", result.summary())
             return ()

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -451,6 +451,7 @@ class MDAWidget(MDASequenceWidget):
 
         dialog = SoftwareAutofocusDialog(
             self.softwareAutofocusSettings(),
+            core=self._mmc,
             test_callback=self._run_software_autofocus_test,
             parent=self,
         )

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -33,6 +33,11 @@ from ._core_channels import CoreConnectedChannelTable
 from ._core_grid import CoreConnectedGridPlanWidget
 from ._core_positions import AF_UNAVAILABLE, CoreConnectedPositionTable
 from ._core_z import CoreConnectedZPlanWidget
+from ._autofocus import (
+    SoftwareAutofocusDialog,
+    SoftwareAutofocusMDAEngine,
+    run_software_autofocus,
+)
 from ._save_widget import SaveGroupBox
 
 if TYPE_CHECKING:
@@ -112,6 +117,8 @@ class MDAWidget(MDASequenceWidget):
     ) -> None:
         # create a couple core-connected variants of the tab widgets
         self._mmc = mmcore or CMMCorePlus.instance()
+        self._autofocus_engine = SoftwareAutofocusMDAEngine(self._mmc)
+        self._previous_mda_engine = self._mmc.mda.set_engine(self._autofocus_engine)
 
         super().__init__(parent=parent, tab_widget=CoreMDATabs(None, self._mmc))
 
@@ -138,6 +145,7 @@ class MDAWidget(MDASequenceWidget):
         self._mmc.mda.events.sequenceFinished.connect(self._on_mda_finished)
         self._mmc.events.systemConfigurationLoaded.connect(self._on_sys_config_loaded)
         self._mmc.events.propertyChanged.connect(self._on_property_changed)
+        self.autofocus.valueChanged.connect(self._update_autofocus_enablement)
 
         self.destroyed.connect(self._disconnect)
 
@@ -326,34 +334,39 @@ class MDAWidget(MDASequenceWidget):
         Enable af_axis and af_per_position only if there is an autofocus device and no
         absolute z plan is selected.
         """
+        z_plan_allows_af = not (
+            self.tab_wdg.isChecked(self.z_plan) and self.z_plan.mode() == Mode.TOP_BOTTOM
+        )
         af_device = self._get_autofocus_device()
         hardware_tooltip = self._get_tooltip(self.af_axis)
         self.af_axis.setHardwareAvailable(bool(af_device), hardware_tooltip)
         self.af_axis.setAxesAllowed(
-            bool(af_device) or self.af_axis.mode() is AutofocusMode.SOFTWARE,
+            z_plan_allows_af
+            and (bool(af_device) or self.af_axis.mode() is AutofocusMode.SOFTWARE),
             hardware_tooltip,
         )
 
         # update the autofocus per position widget
-        self.stage_positions.af_per_position.setEnabled(bool(af_device))
+        af_per_pos_enabled = bool(af_device) and self.af_axis.mode() is AutofocusMode.HARDWARE
+        self.stage_positions.af_per_position.setEnabled(af_per_pos_enabled)
         # set tooltip af_per_position
         self.stage_positions.af_per_position.setToolTip(
             self._get_tooltip(self.stage_positions.af_per_position)
+            if af_per_pos_enabled
+            else "Per-position autofocus offsets are only available in hardware mode."
         )
 
     def _get_tooltip(self, wdg: QWidget) -> str:
         """Return the tooltip for the autofocus widgets."""
-        # if there is no autofocus device, return the unavailable tooltip
-        if not self._mmc.getAutoFocusDevice():
-            return AF_UNAVAILABLE
-        # if autofocus device is available, but the z plan is in absolute mode, return
-        # the disabled tooltip
-        if (
-            self.tab_wdg.isChecked(self.z_plan)
-            and self.z_plan.mode() == Mode.TOP_BOTTOM
-            and self._mmc.getAutoFocusDevice()
-        ):
+        z_plan_blocks_af = (
+            self.tab_wdg.isChecked(self.z_plan) and self.z_plan.mode() == Mode.TOP_BOTTOM
+        )
+        if z_plan_blocks_af:
             return AF_DISABLED_TOOLTIP
+
+        # if there is no autofocus device, return the unavailable tooltip
+        if not self._mmc.getAutoFocusDevice() and self.af_axis.mode() is not AutofocusMode.SOFTWARE:
+            return AF_UNAVAILABLE
         # if the widget is the autofocus axis, return the autofocus axis tooltip
         if wdg is self.af_axis:
             return AF_AXIS_TOOLTIP
@@ -432,6 +445,22 @@ class MDAWidget(MDASequenceWidget):
         )
         return bool(response == QMessageBox.StandardButton.Ok)
 
+    def _on_af_configure_requested(self) -> None:
+        if self.autofocus.mode() is not AutofocusMode.SOFTWARE:
+            return
+
+        dialog = SoftwareAutofocusDialog(
+            self.softwareAutofocusSettings(),
+            test_callback=self._run_software_autofocus_test,
+            parent=self,
+        )
+        if dialog.exec():
+            self.setSoftwareAutofocusSettings(dialog.value())
+
+    def _run_software_autofocus_test(self, settings: dict[str, object]) -> str:
+        result = run_software_autofocus(self._mmc, settings)
+        return result.summary()
+
     def _enable_widgets(self, enable: bool) -> None:
         for child in self.children():
             if isinstance(child, CoreMDATabs):
@@ -462,10 +491,17 @@ class MDAWidget(MDASequenceWidget):
         with suppress(Exception):
             self._mmc.mda.events.sequenceStarted.disconnect(self._on_mda_started)
             self._mmc.mda.events.sequenceFinished.disconnect(self._on_mda_finished)
+            self.autofocus.valueChanged.disconnect(self._update_autofocus_enablement)
         self._mmc.events.systemConfigurationLoaded.disconnect(
             self._on_sys_config_loaded
         )
         self._mmc.events.propertyChanged.disconnect(self._on_property_changed)
+        if (
+            self._mmc.mda.engine is self._autofocus_engine
+            and self._previous_mda_engine is not None
+            and not self._mmc.mda.is_running()
+        ):
+            self._mmc.mda.set_engine(self._previous_mda_engine)
 
     def _enable_af(self, state: bool) -> None:
         """Override the autofocus enablement to account for the autofocus device."""

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -18,6 +18,7 @@ from useq import MDASequence, Position
 
 from pymmcore_widgets._util import get_next_available_path
 from pymmcore_widgets.useq_widgets import MDASequenceWidget
+from pymmcore_widgets.useq_widgets._autofocus import AutofocusMode
 from pymmcore_widgets.useq_widgets._mda_sequence import (
     AF_AXIS_TOOLTIP,
     AF_DISABLED_TOOLTIP,
@@ -258,7 +259,8 @@ class MDAWidget(MDASequenceWidget):
         # and position-specific offsets haven't been set, show a warning
         pos = self.stage_positions
         if (
-            self.af_axis.value()
+            self.af_axis.mode() is AutofocusMode.HARDWARE
+            and self.af_axis.axes()
             and not self._mmc.isContinuousFocusLocked()
             and (not self.tab_wdg.isChecked(pos) or not self._use_af_per_position())
             and not self._confirm_af_intentions()
@@ -324,12 +326,13 @@ class MDAWidget(MDASequenceWidget):
         Enable af_axis and af_per_position only if there is an autofocus device and no
         absolute z plan is selected.
         """
-        # get the autofocus device
         af_device = self._get_autofocus_device()
-
-        # update the autofocus axis widget
-        self.af_axis.setEnabled(bool(af_device))
-        self.af_axis.setToolTip(self._get_tooltip(self.af_axis))
+        hardware_tooltip = self._get_tooltip(self.af_axis)
+        self.af_axis.setHardwareAvailable(bool(af_device), hardware_tooltip)
+        self.af_axis.setAxesAllowed(
+            bool(af_device) or self.af_axis.mode() is AutofocusMode.SOFTWARE,
+            hardware_tooltip,
+        )
 
         # update the autofocus per position widget
         self.stage_positions.af_per_position.setEnabled(bool(af_device))

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -29,15 +29,15 @@ from pymmcore_widgets.useq_widgets._positions import AF_PER_POS_TOOLTIP
 from pymmcore_widgets.useq_widgets._time import TimePlanWidget
 from pymmcore_widgets.useq_widgets._z import Mode
 
-from ._core_channels import CoreConnectedChannelTable
-from ._core_grid import CoreConnectedGridPlanWidget
-from ._core_positions import AF_UNAVAILABLE, CoreConnectedPositionTable
-from ._core_z import CoreConnectedZPlanWidget
 from ._autofocus import (
     SoftwareAutofocusDialog,
     SoftwareAutofocusMDAEngine,
     run_software_autofocus,
 )
+from ._core_channels import CoreConnectedChannelTable
+from ._core_grid import CoreConnectedGridPlanWidget
+from ._core_positions import AF_UNAVAILABLE, CoreConnectedPositionTable
+from ._core_z import CoreConnectedZPlanWidget
 from ._save_widget import SaveGroupBox
 
 if TYPE_CHECKING:
@@ -335,7 +335,8 @@ class MDAWidget(MDASequenceWidget):
         absolute z plan is selected.
         """
         z_plan_allows_af = not (
-            self.tab_wdg.isChecked(self.z_plan) and self.z_plan.mode() == Mode.TOP_BOTTOM
+            self.tab_wdg.isChecked(self.z_plan)
+            and self.z_plan.mode() == Mode.TOP_BOTTOM
         )
         af_device = self._get_autofocus_device()
         hardware_tooltip = self._get_tooltip(self.af_axis)
@@ -347,7 +348,9 @@ class MDAWidget(MDASequenceWidget):
         )
 
         # update the autofocus per position widget
-        af_per_pos_enabled = bool(af_device) and self.af_axis.mode() is AutofocusMode.HARDWARE
+        af_per_pos_enabled = (
+            bool(af_device) and self.af_axis.mode() is AutofocusMode.HARDWARE
+        )
         self.stage_positions.af_per_position.setEnabled(af_per_pos_enabled)
         # set tooltip af_per_position
         self.stage_positions.af_per_position.setToolTip(
@@ -359,13 +362,17 @@ class MDAWidget(MDASequenceWidget):
     def _get_tooltip(self, wdg: QWidget) -> str:
         """Return the tooltip for the autofocus widgets."""
         z_plan_blocks_af = (
-            self.tab_wdg.isChecked(self.z_plan) and self.z_plan.mode() == Mode.TOP_BOTTOM
+            self.tab_wdg.isChecked(self.z_plan)
+            and self.z_plan.mode() == Mode.TOP_BOTTOM
         )
         if z_plan_blocks_af:
             return AF_DISABLED_TOOLTIP
 
         # if there is no autofocus device, return the unavailable tooltip
-        if not self._mmc.getAutoFocusDevice() and self.af_axis.mode() is not AutofocusMode.SOFTWARE:
+        if (
+            not self._mmc.getAutoFocusDevice()
+            and self.af_axis.mode() is not AutofocusMode.SOFTWARE
+        ):
             return AF_UNAVAILABLE
         # if the widget is the autofocus axis, return the autofocus axis tooltip
         if wdg is self.af_axis:

--- a/src/pymmcore_widgets/useq_widgets/_autofocus.py
+++ b/src/pymmcore_widgets/useq_widgets/_autofocus.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QWidget,
+)
+from superqt.utils import signals_blocked
+
+
+class AutofocusMode(str, Enum):
+    NONE = "none"
+    HARDWARE = "hardware"
+    SOFTWARE = "software"
+
+
+PYMMCW_AUTOFOCUS_KEY = "autofocus"
+SOFTWARE_AF_DISABLED_TOOLTIP = (
+    "Software autofocus cannot be used with absolute Z positions "
+    "(TOP_BOTTOM mode)."
+)
+SOFTWARE_AF_OPTIONS_TOOLTIP = (
+    "Open the software autofocus configuration widget."
+)
+SOFTWARE_AF_PENDING_TOOLTIP = (
+    "Software autofocus configuration widget is not implemented yet."
+)
+
+
+class AutofocusControls(QWidget):
+    valueChanged = Signal()
+    configureRequested = Signal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self._mode_label = QLabel("Autofocus:")
+        self._mode = QComboBox()
+        self._mode.addItem("None", AutofocusMode.NONE.value)
+        self._mode.addItem("Hardware", AutofocusMode.HARDWARE.value)
+        self._mode.addItem("Software", AutofocusMode.SOFTWARE.value)
+
+        self.use_af_p = QCheckBox("p")
+        self.use_af_t = QCheckBox("t")
+        self.use_af_g = QCheckBox("g")
+        self._configure = QPushButton("Configure...")
+        self._configure.setEnabled(False)
+        self._configure.setToolTip(SOFTWARE_AF_OPTIONS_TOOLTIP)
+
+        layout = QHBoxLayout(self)
+        layout.setSpacing(10)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._mode_label)
+        layout.addWidget(self._mode)
+        layout.addWidget(QLabel("Axis:"))
+        layout.addWidget(self.use_af_p)
+        layout.addWidget(self.use_af_t)
+        layout.addWidget(self.use_af_g)
+        layout.addWidget(self._configure)
+        layout.addStretch()
+
+        self._mode.currentIndexChanged.connect(self._on_mode_changed)
+        self.use_af_p.toggled.connect(self.valueChanged)
+        self.use_af_t.toggled.connect(self.valueChanged)
+        self.use_af_g.toggled.connect(self.valueChanged)
+        self._configure.clicked.connect(self.configureRequested)
+
+        self._axes_allowed = True
+        self._axes_disabled_tooltip = ""
+        self._hardware_available = True
+        self._hardware_unavailable_tooltip = ""
+        self._on_mode_changed()
+
+    def mode(self) -> AutofocusMode:
+        value = self._mode.currentData()
+        return AutofocusMode(str(value))
+
+    def setMode(self, mode: AutofocusMode | str) -> None:
+        mode_value = mode.value if isinstance(mode, AutofocusMode) else str(mode)
+        idx = self._mode.findData(mode_value)
+        if idx >= 0:
+            self._mode.setCurrentIndex(idx)
+
+    def axes(self) -> tuple[str, ...]:
+        if not self._axes_enabled():
+            return ()
+        axes: tuple[str, ...] = ()
+        if self.use_af_p.isChecked():
+            axes += ("p",)
+        if self.use_af_t.isChecked():
+            axes += ("t",)
+        if self.use_af_g.isChecked():
+            axes += ("g",)
+        return axes
+
+    def setAxes(self, value: tuple[str, ...]) -> None:
+        self.use_af_p.setChecked("p" in value)
+        self.use_af_t.setChecked("t" in value)
+        self.use_af_g.setChecked("g" in value)
+
+    def value(self) -> dict[str, Any]:
+        return {"mode": self.mode().value, "axes": self.axes()}
+
+    def setValue(self, value: dict[str, Any]) -> None:
+        if not value:
+            self.setMode(AutofocusMode.NONE)
+            self.setAxes(())
+            return
+        mode = value.get("mode", AutofocusMode.NONE.value)
+        axes = tuple(value.get("axes", ()))
+        with signals_blocked(self._mode):
+            self.setMode(mode)
+        self.setAxes(axes)
+        self._on_mode_changed()
+
+    def setAxesAllowed(self, allowed: bool, tooltip: str = "") -> None:
+        self._axes_allowed = allowed
+        self._axes_disabled_tooltip = tooltip
+        self._update_enabled_state()
+
+    def setHardwareAvailable(self, available: bool, tooltip: str = "") -> None:
+        self._hardware_available = available
+        self._hardware_unavailable_tooltip = tooltip
+        if not available and self.mode() == AutofocusMode.HARDWARE:
+            self.setMode(AutofocusMode.NONE)
+        self._update_enabled_state()
+
+    def _axes_enabled(self) -> bool:
+        return self._axes_allowed and self.mode() is not AutofocusMode.NONE
+
+    def _current_tooltip(self) -> str:
+        if not self._axes_allowed:
+            return self._axes_disabled_tooltip
+        if self.mode() is AutofocusMode.HARDWARE and not self._hardware_available:
+            return self._hardware_unavailable_tooltip
+        return ""
+
+    def _on_mode_changed(self) -> None:
+        self._update_enabled_state()
+        self.valueChanged.emit()
+
+    def _update_enabled_state(self) -> None:
+        mode = self.mode()
+        axes_enabled = self._axes_enabled()
+        tooltip = self._current_tooltip()
+        for widget in (self.use_af_p, self.use_af_t, self.use_af_g):
+            widget.setEnabled(axes_enabled)
+            widget.setToolTip(tooltip)
+        self._configure.setEnabled(mode is AutofocusMode.SOFTWARE and self._axes_allowed)
+        if mode is AutofocusMode.SOFTWARE:
+            self._configure.setToolTip(SOFTWARE_AF_OPTIONS_TOOLTIP)
+        elif mode is AutofocusMode.HARDWARE and not self._hardware_available:
+            self._configure.setToolTip(self._hardware_unavailable_tooltip)
+        else:
+            self._configure.setToolTip(SOFTWARE_AF_PENDING_TOOLTIP)

--- a/src/pymmcore_widgets/useq_widgets/_autofocus.py
+++ b/src/pymmcore_widgets/useq_widgets/_autofocus.py
@@ -25,12 +25,9 @@ class AutofocusMode(str, Enum):
 PYMMCW_AUTOFOCUS_KEY = "autofocus"
 PYMMCW_SOFTWARE_AUTOFOCUS_KEY = "software"
 SOFTWARE_AF_DISABLED_TOOLTIP = (
-    "Software autofocus cannot be used with absolute Z positions "
-    "(TOP_BOTTOM mode)."
+    "Software autofocus cannot be used with absolute Z positions (TOP_BOTTOM mode)."
 )
-SOFTWARE_AF_OPTIONS_TOOLTIP = (
-    "Open the software autofocus configuration widget."
-)
+SOFTWARE_AF_OPTIONS_TOOLTIP = "Open the software autofocus configuration widget."
 SOFTWARE_AF_PENDING_TOOLTIP = (
     "Software autofocus configuration widget is not implemented yet."
 )
@@ -206,7 +203,9 @@ class AutofocusControls(QWidget):
         for widget in (self.use_af_p, self.use_af_t, self.use_af_g):
             widget.setEnabled(axes_enabled)
             widget.setToolTip(tooltip)
-        self._configure.setEnabled(mode is AutofocusMode.SOFTWARE and self._axes_allowed)
+        self._configure.setEnabled(
+            mode is AutofocusMode.SOFTWARE and self._axes_allowed
+        )
         if mode is AutofocusMode.SOFTWARE:
             self._configure.setToolTip(SOFTWARE_AF_OPTIONS_TOOLTIP)
         elif mode is AutofocusMode.HARDWARE and not self._hardware_available:

--- a/src/pymmcore_widgets/useq_widgets/_autofocus.py
+++ b/src/pymmcore_widgets/useq_widgets/_autofocus.py
@@ -40,6 +40,7 @@ DEFAULT_SOFTWARE_AF_SETTINGS: dict[str, Any] = {
     "channel_mode": "current",
     "channel_group": None,
     "channel": None,
+    "failure_policy": "continue_keep_z",
     "params": {
         "search_range_um": 8.0,
         "step_um": 0.5,
@@ -71,6 +72,10 @@ def normalize_software_af_settings(value: Any) -> dict[str, Any]:
     for key in ("channel_group", "channel"):
         item = value.get(key)
         settings[key] = item if isinstance(item, str) and item else None
+
+    failure_policy = value.get("failure_policy")
+    if isinstance(failure_policy, str) and failure_policy:
+        settings["failure_policy"] = failure_policy
 
     params = value.get("params")
     if isinstance(params, dict):

--- a/src/pymmcore_widgets/useq_widgets/_autofocus.py
+++ b/src/pymmcore_widgets/useq_widgets/_autofocus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from enum import Enum
 from typing import Any
 
@@ -22,6 +23,7 @@ class AutofocusMode(str, Enum):
 
 
 PYMMCW_AUTOFOCUS_KEY = "autofocus"
+PYMMCW_SOFTWARE_AUTOFOCUS_KEY = "software"
 SOFTWARE_AF_DISABLED_TOOLTIP = (
     "Software autofocus cannot be used with absolute Z positions "
     "(TOP_BOTTOM mode)."
@@ -32,6 +34,41 @@ SOFTWARE_AF_OPTIONS_TOOLTIP = (
 SOFTWARE_AF_PENDING_TOOLTIP = (
     "Software autofocus configuration widget is not implemented yet."
 )
+
+DEFAULT_SOFTWARE_AF_SETTINGS: dict[str, Any] = {
+    "backend": "tenengrad",
+    "params": {
+        "search_range_um": 8.0,
+        "step_um": 0.5,
+        "crop_size_px": 512,
+        "exposure_ms": None,
+        "settle_ms": 50.0,
+        "max_retries": 1,
+    },
+}
+
+
+def default_software_af_settings() -> dict[str, Any]:
+    return deepcopy(DEFAULT_SOFTWARE_AF_SETTINGS)
+
+
+def normalize_software_af_settings(value: Any) -> dict[str, Any]:
+    settings = default_software_af_settings()
+    if not isinstance(value, dict):
+        return settings
+
+    backend = value.get("backend")
+    if isinstance(backend, str) and backend:
+        settings["backend"] = backend
+
+    params = value.get("params")
+    if isinstance(params, dict):
+        merged = {**settings["params"], **params}
+        exposure = merged.get("exposure_ms")
+        if exposure in (0, "", False):
+            merged["exposure_ms"] = None
+        settings["params"] = merged
+    return settings
 
 
 class AutofocusControls(QWidget):

--- a/src/pymmcore_widgets/useq_widgets/_autofocus.py
+++ b/src/pymmcore_widgets/useq_widgets/_autofocus.py
@@ -37,6 +37,9 @@ SOFTWARE_AF_PENDING_TOOLTIP = (
 
 DEFAULT_SOFTWARE_AF_SETTINGS: dict[str, Any] = {
     "backend": "tenengrad",
+    "channel_mode": "current",
+    "channel_group": None,
+    "channel": None,
     "params": {
         "search_range_um": 8.0,
         "step_um": 0.5,
@@ -60,6 +63,14 @@ def normalize_software_af_settings(value: Any) -> dict[str, Any]:
     backend = value.get("backend")
     if isinstance(backend, str) and backend:
         settings["backend"] = backend
+
+    channel_mode = value.get("channel_mode")
+    if isinstance(channel_mode, str) and channel_mode:
+        settings["channel_mode"] = channel_mode
+
+    for key in ("channel_group", "channel"):
+        item = value.get(key)
+        settings[key] = item if isinstance(item, str) and item else None
 
     params = value.get("params")
     if isinstance(params, dict):

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -25,8 +25,11 @@ import pymmcore_widgets
 from pymmcore_widgets._humanize import humanize_time
 from pymmcore_widgets.useq_widgets._autofocus import (
     PYMMCW_AUTOFOCUS_KEY,
+    PYMMCW_SOFTWARE_AUTOFOCUS_KEY,
     AutofocusControls,
     AutofocusMode,
+    default_software_af_settings,
+    normalize_software_af_settings,
 )
 from pymmcore_widgets.useq_widgets._channels import ChannelTable
 from pymmcore_widgets.useq_widgets._checkable_tabwidget_widget import CheckableTabWidget
@@ -281,6 +284,7 @@ class MDASequenceWidget(QWidget):
 
         self.keep_shutter_open = KeepShutterOpen()
         self.autofocus = AutofocusControls()
+        self._software_autofocus_settings = default_software_af_settings()
         cbox_row = QVBoxLayout()
         cbox_row.setContentsMargins(0, 0, 0, 0)
         cbox_row.setSpacing(5)
@@ -372,8 +376,9 @@ class MDASequenceWidget(QWidget):
             # check if the autofocus offsets are the same for all positions
             # and simplify to a single global autofocus plan if so.
             replace.update(self._simplify_af_offsets(val))
-        elif af_mode is AutofocusMode.HARDWARE and af_axes:
-            # otherwise use selected af axes as global autofocus plan
+        elif af_mode is not AutofocusMode.NONE and af_axes:
+            # Both hardware and software autofocus reuse the standard useq autofocus
+            # plan so the runner can inject the selected autofocus strategy.
             replace["autofocus_plan"] = useq.AxesBasedAF(axes=af_axes)
         else:
             replace["autofocus_plan"] = None
@@ -382,7 +387,11 @@ class MDASequenceWidget(QWidget):
             val = val.replace(**replace)
 
         meta = val.metadata.setdefault(PYMMCW_METADATA_KEY, {})
-        meta[PYMMCW_AUTOFOCUS_KEY] = {"mode": af_mode.value, "axes": af_axes}
+        meta[PYMMCW_AUTOFOCUS_KEY] = {
+            "mode": af_mode.value,
+            "axes": af_axes,
+            PYMMCW_SOFTWARE_AUTOFOCUS_KEY: self.softwareAutofocusSettings(),
+        }
 
         return val
 
@@ -404,6 +413,9 @@ class MDASequenceWidget(QWidget):
         )
         if autofocus_meta:
             self.autofocus.setValue(cast(dict[str, Any], autofocus_meta))
+            self.setSoftwareAutofocusSettings(
+                autofocus_meta.get(PYMMCW_SOFTWARE_AUTOFOCUS_KEY)
+            )
         else:
             axis: set[str] = set()
             if value.autofocus_plan:
@@ -420,8 +432,16 @@ class MDASequenceWidget(QWidget):
                     "axes": tuple(axis),
                 }
             )
+            self.setSoftwareAutofocusSettings(default_software_af_settings())
         axis_text = "".join(x for x in value.axis_order if x in self.tab_wdg.usedAxes())
         self.axis_order.setCurrentText(axis_text)
+
+    def softwareAutofocusSettings(self) -> dict[str, Any]:
+        return normalize_software_af_settings(self._software_autofocus_settings)
+
+    def setSoftwareAutofocusSettings(self, value: Any) -> None:
+        self._software_autofocus_settings = normalize_software_af_settings(value)
+        self.valueChanged.emit()
 
     def save(self, file: str | Path | None = None) -> None:
         """Save the current [`useq.MDASequence`][] to a file."""

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -412,7 +412,7 @@ class MDASequenceWidget(QWidget):
             PYMMCW_AUTOFOCUS_KEY, {}
         )
         if autofocus_meta:
-            self.autofocus.setValue(cast(dict[str, Any], autofocus_meta))
+            self.autofocus.setValue(cast("dict[str, Any]", autofocus_meta))
             self.setSoftwareAutofocusSettings(
                 autofocus_meta.get(PYMMCW_SOFTWARE_AUTOFOCUS_KEY)
             )
@@ -427,7 +427,9 @@ class MDASequenceWidget(QWidget):
             self.autofocus.setValue(
                 {
                     "mode": (
-                        AutofocusMode.HARDWARE.value if axis else AutofocusMode.NONE.value
+                        AutofocusMode.HARDWARE.value
+                        if axis
+                        else AutofocusMode.NONE.value
                     ),
                     "axes": tuple(axis),
                 }

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from importlib.util import find_spec
 from itertools import permutations
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import useq
 from qtpy.QtCore import Qt, Signal
@@ -23,6 +23,11 @@ from superqt.utils import signals_blocked
 
 import pymmcore_widgets
 from pymmcore_widgets._humanize import humanize_time
+from pymmcore_widgets.useq_widgets._autofocus import (
+    PYMMCW_AUTOFOCUS_KEY,
+    AutofocusControls,
+    AutofocusMode,
+)
 from pymmcore_widgets.useq_widgets._channels import ChannelTable
 from pymmcore_widgets.useq_widgets._checkable_tabwidget_widget import CheckableTabWidget
 from pymmcore_widgets.useq_widgets._grid import GridPlanWidget
@@ -50,9 +55,9 @@ for x in list(ALLOWED_ORDERS):
     ):
         if _check_order(x, first, second):
             ALLOWED_ORDERS.discard(x)
-AF_AXIS_TOOLTIP = "Use Hardware Autofocus on the selected axes."
+AF_AXIS_TOOLTIP = "Use autofocus on the selected axes."
 AF_DISABLED_TOOLTIP = (
-    "The hardware autofocus cannot be used with absolute Z positions (TOP_BOTTOM mode)."
+    "Autofocus cannot be used with absolute Z positions (TOP_BOTTOM mode)."
 )
 
 
@@ -179,52 +184,6 @@ class MDATabs(CheckableTabWidget):
             ch_table.setColumnHidden(ch_table.indexOf(_map[idx]), not checked)
 
 
-class AutofocusAxis(QWidget):
-    valueChanged = Signal()
-
-    def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
-
-        lbl = QLabel("Use Hardware Autofocus on Axis:")
-        self.use_af_p = QCheckBox("p")
-        self.use_af_t = QCheckBox("t")
-        self.use_af_g = QCheckBox("g")
-
-        layout = QHBoxLayout(self)
-        layout.setSpacing(10)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(lbl)
-        layout.addWidget(self.use_af_p)
-        layout.addWidget(self.use_af_t)
-        layout.addWidget(self.use_af_g)
-        layout.addStretch()
-
-        self.use_af_p.toggled.connect(self.valueChanged)
-        self.use_af_t.toggled.connect(self.valueChanged)
-        self.use_af_g.toggled.connect(self.valueChanged)
-
-        self.setToolTip(AF_AXIS_TOOLTIP)
-
-    def value(self) -> tuple[str, ...]:
-        """Return the autofocus axes."""
-        af_axis: tuple[str, ...] = ()
-        if not self.isEnabled():
-            return af_axis
-        if self.use_af_p.isChecked():
-            af_axis += ("p",)
-        if self.use_af_t.isChecked():
-            af_axis += ("t",)
-        if self.use_af_g.isChecked():
-            af_axis += ("g",)
-        return af_axis
-
-    def setValue(self, value: tuple[str, ...]) -> None:
-        """Set widget value from a tuple of autofocus axes."""
-        self.use_af_p.setChecked("p" in value)
-        self.use_af_t.setChecked("t" in value)
-        self.use_af_g.setChecked("g" in value)
-
-
 class KeepShutterOpen(QWidget):
     valueChanged = Signal()
 
@@ -321,12 +280,12 @@ class MDASequenceWidget(QWidget):
         top_row.addStretch()
 
         self.keep_shutter_open = KeepShutterOpen()
-        self.af_axis = AutofocusAxis()
+        self.autofocus = AutofocusControls()
         cbox_row = QVBoxLayout()
         cbox_row.setContentsMargins(0, 0, 0, 0)
         cbox_row.setSpacing(5)
         cbox_row.addWidget(self.keep_shutter_open)
-        cbox_row.addWidget(self.af_axis)
+        cbox_row.addWidget(self.autofocus)
         cbox_row.addStretch()
 
         bot_row = QHBoxLayout()
@@ -353,11 +312,16 @@ class MDASequenceWidget(QWidget):
         self.valueChanged.connect(self._update_time_estimate)
 
         self.keep_shutter_open.valueChanged.connect(self.valueChanged)
-        self.af_axis.valueChanged.connect(self.valueChanged)
+        self.autofocus.valueChanged.connect(self.valueChanged)
         self.stage_positions.af_per_position.toggled.connect(self._on_af_toggled)
+        self.autofocus.configureRequested.connect(self._on_af_configure_requested)
 
         with signals_blocked(self):
             self.tab_wdg.setChecked(self.channels, True)
+
+    @property
+    def af_axis(self) -> AutofocusControls:
+        return self.autofocus
 
     # ----------- Aliases for tab_wdg widgets -----------
 
@@ -401,16 +365,24 @@ class MDASequenceWidget(QWidget):
             "keep_shutter_open_across": self.keep_shutter_open.value(),
         }
 
-        if self._use_af_per_position():
+        af_mode = self.autofocus.mode()
+        af_axes = self.autofocus.axes()
+
+        if af_mode is AutofocusMode.HARDWARE and self._use_af_per_position():
             # check if the autofocus offsets are the same for all positions
             # and simplify to a single global autofocus plan if so.
             replace.update(self._simplify_af_offsets(val))
-        elif af_axes := self.af_axis.value():
+        elif af_mode is AutofocusMode.HARDWARE and af_axes:
             # otherwise use selected af axes as global autofocus plan
             replace["autofocus_plan"] = useq.AxesBasedAF(axes=af_axes)
+        else:
+            replace["autofocus_plan"] = None
 
         if replace:
             val = val.replace(**replace)
+
+        meta = val.metadata.setdefault(PYMMCW_METADATA_KEY, {})
+        meta[PYMMCW_AUTOFOCUS_KEY] = {"mode": af_mode.value, "axes": af_axes}
 
         return val
 
@@ -427,17 +399,27 @@ class MDASequenceWidget(QWidget):
         keep_shutter_open = value.keep_shutter_open_across
         self.keep_shutter_open.setValue(keep_shutter_open)
 
-        # update autofocus axes checkboxes
-        axis: set[str] = set()
-        # update from global autofocus plan
-        if value.autofocus_plan:
-            axis.update(value.autofocus_plan.axes)
-        # update from autofocus plans in each position sub-sequence
-        if value.stage_positions:
-            for pos in value.stage_positions:
-                if pos.sequence and pos.sequence.autofocus_plan:
-                    axis.update(pos.sequence.autofocus_plan.axes)
-        self.af_axis.setValue(tuple(axis))
+        autofocus_meta = value.metadata.get(PYMMCW_METADATA_KEY, {}).get(
+            PYMMCW_AUTOFOCUS_KEY, {}
+        )
+        if autofocus_meta:
+            self.autofocus.setValue(cast(dict[str, Any], autofocus_meta))
+        else:
+            axis: set[str] = set()
+            if value.autofocus_plan:
+                axis.update(value.autofocus_plan.axes)
+            if value.stage_positions:
+                for pos in value.stage_positions:
+                    if pos.sequence and pos.sequence.autofocus_plan:
+                        axis.update(pos.sequence.autofocus_plan.axes)
+            self.autofocus.setValue(
+                {
+                    "mode": (
+                        AutofocusMode.HARDWARE.value if axis else AutofocusMode.NONE.value
+                    ),
+                    "axes": tuple(axis),
+                }
+            )
         axis_text = "".join(x for x in value.axis_order if x in self.tab_wdg.usedAxes())
         self.axis_order.setCurrentText(axis_text)
 
@@ -506,9 +488,7 @@ class MDASequenceWidget(QWidget):
         """Enable or disable autofocus settings."""
         af_axis_tooltip = AF_AXIS_TOOLTIP if state else AF_DISABLED_TOOLTIP
         af_per_pos_tooltip = AF_PER_POS_TOOLTIP if state else AF_DISABLED_TOOLTIP
-        # enable autofocus axis widget
-        self.af_axis.setEnabled(state)
-        self.af_axis.setToolTip(af_axis_tooltip)
+        self.autofocus.setAxesAllowed(state, af_axis_tooltip if not state else "")
         # enable autofocus per position checkbox
         self.stage_positions.af_per_position.setEnabled(state)
         self.stage_positions.af_per_position.setToolTip(af_per_pos_tooltip)
@@ -528,11 +508,11 @@ class MDASequenceWidget(QWidget):
         """
         if self.z_plan.mode() == Mode.TOP_BOTTOM:
             # if any autofocus axis is selected, show a warning.
-            if self.af_axis.value() or self._use_af_per_position():
+            if self.autofocus.axes() or self._use_af_per_position():
                 QMessageBox.warning(
                     self,
                     "Autofocus Plan Disabled",
-                    "The Hardware Autofocus cannot be used with a Z Plan with Absolute "
+                    "Autofocus cannot be used with a Z Plan with Absolute "
                     "Z Positions (TOP_BOTTOM mode). It has been disabled.\n\n"
                     "To re-enable it, select a Z Plan with Relative Positions"
                     "(RANGE_AROUND or ABOVE_BELOW modes).",
@@ -580,7 +560,19 @@ class MDASequenceWidget(QWidget):
         # if the 'af_per_position' checkbox in the PositionTable is checked, set checked
         # also the autofocus p axis checkbox.
         if self._use_af_per_position() and self.tab_wdg.isChecked(self.stage_positions):
-            self.af_axis.use_af_p.setChecked(True)
+            self.autofocus.use_af_p.setChecked(True)
+
+    def _on_af_configure_requested(self) -> None:
+        if self.autofocus.mode() is not AutofocusMode.SOFTWARE:
+            return
+        QMessageBox.information(
+            self,
+            "Software Autofocus",
+            "Software autofocus configuration will be added in a follow-up step.\n\n"
+            "The current implementation stores the selected mode and axes in the "
+            "MDA settings so the execution backend can be connected next.",
+            QMessageBox.StandardButton.Ok,
+        )
 
     def _update_available_axis_orders(self) -> None:
         """Handle tabChecked signal.
@@ -646,7 +638,7 @@ class MDASequenceWidget(QWidget):
                     pos = pos.replace(sequence=None)
             stage_positions.append(pos)
         af_plan = useq.AxesBasedAF(
-            autofocus_motor_offset=af_offsets.pop(), axes=self.af_axis.value()
+            autofocus_motor_offset=af_offsets.pop(), axes=self.af_axis.axes()
         )
         return {"autofocus_plan": af_plan, "stage_positions": stage_positions}
 
@@ -657,7 +649,7 @@ class MDASequenceWidget(QWidget):
         new_pos = []
         for pos in positions:
             if (seq := pos.sequence) and (af_plan := seq.autofocus_plan):
-                af_plan = af_plan.replace(axes=self.af_axis.value())
+                af_plan = af_plan.replace(axes=self.af_axis.axes())
                 pos = pos.replace(sequence=seq.replace(autofocus_plan=af_plan))
             new_pos.append(pos)
 


### PR DESCRIPTION
## Summary

Draft feature PR for design feedback. This adds software autofocus support to the MDA widget path.

It includes:

- autofocus mode selection in the MDA widget
- software autofocus settings stored in MDA metadata
- a software autofocus dialog and MDA engine integration
- focus channel selection
- basic failure policy handling

## Background

This was developed and field-tested during TiEclipse timelapse work where hardware PFS-like behavior was needed from software autofocus inside MDA execution. I do not have a screenshot or formal bug report saved, so this PR is documented from commit history and the behavior implemented here.

## Notes for reviewers

This is intentionally a draft. I would like feedback on API shape, metadata schema, and whether the engine integration belongs here or should be refactored before merge. Hardware coverage is limited to the TiEclipse workflow so far.

## Validation

- python -m ruff check src/pymmcore_widgets/mda/_autofocus.py src/pymmcore_widgets/mda/_core_mda.py src/pymmcore_widgets/useq_widgets/_autofocus.py src/pymmcore_widgets/useq_widgets/_mda_sequence.py
- python -m compileall -q src/pymmcore_widgets/mda/_autofocus.py src/pymmcore_widgets/mda/_core_mda.py src/pymmcore_widgets/useq_widgets/_autofocus.py src/pymmcore_widgets/useq_widgets/_mda_sequence.py