### PR TITLE
fix: "p" at the front of axis order when auto-inserting current stage position

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -199,11 +199,8 @@ class MDAWidget(MDASequenceWidget):
             # not be in the event
             if "p" not in val.axis_order:
                 axis_order = list(val.axis_order)
-                # add the "p" axis at the beginning or after the "t" as the default
-                if "t" in axis_order:
-                    axis_order.insert(axis_order.index("t") + 1, "p")
-                else:
-                    axis_order.insert(0, "p")
+                # Always insert "p" at the front
+                axis_order.insert(0, "p")
                 replace["axis_order"] = tuple(axis_order)
 
         if replace:

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -570,7 +570,7 @@ def test_mda_no_pos_set(global_mmcore: CMMCorePlus, qtbot: QtBot):
     assert round(wdg.value().stage_positions[0].y) == 20
     assert round(wdg.value().stage_positions[0].z) == 30
 
-    assert "p" in wdg.value().axis_order
+    assert wdg.value().axis_order[0] == "p"
 
 
 @pytest.mark.parametrize("ext", ["json", "yaml"])


### PR DESCRIPTION
Ensure "p" axis is first when auto-inserting current position

When no stage positions are provided, the current position is added automatically and the "p" axis is placed at the front of axis_order.

Closes #550