### PR TITLE
fix: call onpropertyChanged with empy device label during mda events

### DIFF
--- a/src/pymmcore_widgets/control/_presets_widget.py
+++ b/src/pymmcore_widgets/control/_presets_widget.py
@@ -140,6 +140,8 @@ class PresetsWidget(QWidget):
 
     @Slot(str, str, object)
     def _on_property_changed(self, device: str, property: str, value: str) -> None:
+        if not device:
+            return
         if (device, property) not in self.dev_prop:
             if self._mmc.getDeviceType(device) != DeviceType.StateDevice:
                 return

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -76,3 +76,18 @@ def test_preset_widget(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
 
     global_mmcore.deleteConfigGroup("Camera")
     assert "Camera" not in global_mmcore.getAvailableConfigGroups()
+
+
+def test_preset_widget_ignores_empty_device(
+    qtbot: QtBot, global_mmcore: CMMCorePlus
+) -> None:
+    """propertyChanged with empty device label must not raise RuntimeError.
+
+    The C++ core can emit propertyChanged("", ...) for internal state changes
+    with no associated device (e.g. during MDA teardown).  The widget must
+    guard against calling getDeviceType("") in that case.
+    """
+    wdg = PresetsWidget("Channel")
+    qtbot.addWidget(wdg)
+    # Should not raise RuntimeError: No device with label ""
+    global_mmcore.events.propertyChanged.emit("", "State", "1")


### PR DESCRIPTION
Hi,
i was working with a virtual-microscope, and encountered an error message using an MDA event. After every frame, it was trying to call _on_property_changed with an empty device name after the shutter device was closed. If the device has no label, probably it should skip the call on this signal, since no device state was updated.