### PR TITLE
fix: state device widget init signal block

### DIFF
--- a/src/pymmcore_widgets/_deprecated/_device_widget.py
+++ b/src/pymmcore_widgets/_deprecated/_device_widget.py
@@ -145,7 +145,8 @@ class StateDeviceWidget(DeviceWidget):
         self._combo.currentIndexChanged.connect(self._on_combo_changed)
         self._changing = False
         self._refresh_choices()
-        self._combo.setCurrentText(self._mmc.getStateLabel(self._device_label))
+        with signals_blocked(self._combo):
+            self._combo.setCurrentText(self._mmc.getStateLabel(self._device_label))
 
         self.setLayout(QHBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)

--- a/src/pymmcore_widgets/control/_stage_widget.py
+++ b/src/pymmcore_widgets/control/_stage_widget.py
@@ -375,12 +375,13 @@ class StageWidget(QWidget):
         self._set_as_default()
 
     def _set_as_default(self) -> None:
-        if self._dtype is DeviceType.XYStage:
-            if self._mmc.getXYStageDevice() == self._device:
-                self._set_as_default_btn.setChecked(True)
-        elif self._dtype is DeviceType.Stage:
-            if self._mmc.getFocusDevice() == self._device:
-                self._set_as_default_btn.setChecked(True)
+        with signals_blocked(self._set_as_default_btn):
+            if self._dtype is DeviceType.XYStage:
+                if self._mmc.getXYStageDevice() == self._device:
+                    self._set_as_default_btn.setChecked(True)
+            elif self._dtype is DeviceType.Stage:
+                if self._mmc.getFocusDevice() == self._device:
+                    self._set_as_default_btn.setChecked(True)
 
     @Slot(bool)
     def _on_radiobutton_toggled(self, state: bool) -> None:


### PR DESCRIPTION
Issue: The initial `setCurrentText` fired `currentIndexChanged` -> `_on_combo_changed` -> `mmc.setState()` for the already-current state. On Nikon TI scopes that re-applies the objective turret preset on widget init, the turret "rotates" to its current position, and PFS gets disabled.

Fix: Block signals around the initial sync, matching the pattern already used in `_refresh_choices` and `_on_sys_cfg_loaded`.

Tested: With Nikon TI when opening napari-micromanager, the PFS stays enabled and turret doesn't "move".

Also added the same signal blocker to `_device_widget.py` for completeness. (No device settings changed there, but extra loop of setting default stage device)