### PR TITLE
Prevent PresetsWidget internal refreshes from applying configs

### DIFF
--- a/src/pymmcore_widgets/control/_presets_widget.py
+++ b/src/pymmcore_widgets/control/_presets_widget.py
@@ -106,26 +106,29 @@ class PresetsWidget(QWidget):
     def _update_if_props_not_match_preset(self) -> None:
         if not self._mmc.getAvailableConfigs(self._group):
             return
-        for preset in self._presets:
-            _set_combo = True
-            for dev, prop, value in self._mmc.getConfigData(self._group, preset):
-                cache_value = self._mmc.getPropertyFromCache(dev, prop)
-                if cache_value != value:
-                    _set_combo = False
-                    break
-            if _set_combo:
-                # remove NO_MATCH if it exists
-                if (no_match_index := self._combo.findText(NO_MATCH)) >= 0:
-                    self._combo.removeItem(no_match_index)
-                with signals_blocked(self._combo):
+
+        with signals_blocked(self._combo):
+            for preset in self._presets:
+                _set_combo = True
+                for dev, prop, value in self._mmc.getConfigData(self._group, preset):
+                    cache_value = self._mmc.getPropertyFromCache(dev, prop)
+                    if cache_value != value:
+                        _set_combo = False
+                        break
+                if _set_combo:
+                    # remove NO_MATCH if it exists
+                    if (no_match_index := self._combo.findText(NO_MATCH)) >= 0:
+                        self._combo.removeItem(no_match_index)
                     self._combo.setCurrentText(preset)
                     return
-        # if None of the presets match the current system state
-        # add NO_MATCH to combo if not already there
-        current_items = [self._combo.itemText(i) for i in range(self._combo.count())]
-        if NO_MATCH not in current_items:
-            self._combo.addItem(NO_MATCH)
-        with signals_blocked(self._combo):
+
+            # if None of the presets match the current system state
+            # add NO_MATCH to combo if not already there
+            current_items = [
+                self._combo.itemText(i) for i in range(self._combo.count())
+            ]
+            if NO_MATCH not in current_items:
+                self._combo.addItem(NO_MATCH)
             self._combo.setCurrentText(NO_MATCH)
 
     @Slot(str, str)

--- a/tests/test_presets_widget.py
+++ b/tests/test_presets_widget.py
@@ -91,3 +91,26 @@ def test_preset_widget_ignores_empty_device(
     qtbot.addWidget(wdg)
     # Should not raise RuntimeError: No device with label ""
     global_mmcore.events.propertyChanged.emit("", "State", "1")
+
+
+def test_preset_widget_no_match_removal_does_not_apply_preset(
+    qtbot: QtBot, global_mmcore: CMMCorePlus
+) -> None:
+    """Internal combo refreshes must not call ``setConfig``."""
+    global_mmcore.setConfig("Camera", "HighRes")
+    wdg = PresetsWidget("Camera", mmcore=global_mmcore)
+    qtbot.addWidget(wdg)
+
+    global_mmcore.setProperty("Camera", "Binning", "8")
+    assert wdg.value() == "<no match>"
+
+    config_set_events: list[tuple[str, str]] = []
+    global_mmcore.events.configSet.connect(
+        lambda group, preset: config_set_events.append((group, preset))
+    )
+
+    global_mmcore.setProperty("Camera", "Binning", "1")
+
+    assert wdg.value() == "HighRes"
+    assert global_mmcore.getCurrentConfig("Camera") == "HighRes"
+    assert config_set_events == []


### PR DESCRIPTION
## Summary
- Block `PresetsWidget` combo signals during the full internal preset-state refresh.
- Prevent adding/removing `<no match>` from triggering `setConfig()`.
- Add a regression test for the `<no match>` -> preset transition.

## Motivation
When `PresetsWidget` refreshes after core property changes, removing the currently selected `<no match>` item can emit `currentTextChanged`. Since `_on_combo_changed()` calls `mmc.setConfig()`, an internal UI refresh may accidentally apply a hardware preset.

This was observed during MDA channel switching, where transient non-matching device states could cause an unintended channel preset to be selected. The issue is generic Qt signal reentrancy, not microscope-specific.

There is no screenshot attached because this is not a visual rendering change: the problematic behavior is an internal Qt signal emitted during combo-box synchronization. The regression test captures the behavior directly by asserting that the UI refresh does not emit `configSet`.

## Fix
Wrap the entire `_update_if_props_not_match_preset()` combo synchronization in `signals_blocked(self._combo)`, including `removeItem`, `addItem`, and `setCurrentText`.

This matches the existing pattern used by `ChannelGroupWidget`.

## Tests
- `ruff check src/pymmcore_widgets/control/_presets_widget.py tests/test_presets_widget.py`
- `ruff format --check src/pymmcore_widgets/control/_presets_widget.py tests/test_presets_widget.py`
- `pytest tests/test_presets_widget.py tests/test_channel_widget.py tests/test_group_preset_widget.py -q`