### PR TITLE
fix: improve com table display

### DIFF
--- a/src/pymmcore_widgets/hcwizard/_dev_setup_dialog.py
+++ b/src/pymmcore_widgets/hcwizard/_dev_setup_dialog.py
@@ -232,11 +232,8 @@ class DeviceSetupDialog(QDialog):
             self.prop_table.hide()
 
         self.com_table = ComTable(core)
-        self.prop_table.portChanged.connect(self.com_table.rebuild_port)
-        if current_port is not None:
-            self.com_table.rebuild_port(current_port)
-        else:
-            self.com_table.hide()
+        self.prop_table.portChanged.connect(self._on_port_changed)
+        self._on_port_changed(current_port, "")
 
         # LAYOUT -------------
 
@@ -266,6 +263,15 @@ class DeviceSetupDialog(QDialog):
         # if device.initialized:
         #     with exceptions_as_dialog(use_error_message=True):
         #         device.load_in_core(reload=True)
+
+    def _on_port_changed(
+        self, port_dev_name: str | None, port_library_name: str = ""
+    ) -> None:
+        if port_dev_name is not None:
+            self.com_table.rebuild_port(port_dev_name, port_library_name)
+        valid_port = port_dev_name in [d for _, d in self._available_com_ports]
+        self.com_table.setVisible(valid_port)
+        self.adjustSize()
 
     def _on_name_changed(self) -> None:
         new_name = self.name_edit.text()


### PR DESCRIPTION
On Windows, I've found it a bit tricky to assign COM port properties to devices when using the Hardware Configuration Wizard:

<img width="995" height="870" alt="python_C50MiGbEkj" src="https://github.com/user-attachments/assets/08e4fb1a-95c2-4c2d-a426-53e60c2b843a" />

Now, this PR changes the behavior to this:

<img width="986" height="851" alt="python_dhEjMvyfPi" src="https://github.com/user-attachments/assets/47acc5ce-b320-4351-a8dc-2f85e4ada216" />

Note that [`Qt.WindowType.MSWindowsFixedSizeDialogHint`](https://github.com/pymmcore-plus/pymmcore-widgets/blob/ec9e89ad19bf5088fab3000242ad76020132af7b/src/pymmcore_widgets/hcwizard/_dev_setup_dialog.py#L113) prevents us from resizing that window. I elected to not mess with that here, in favor of just resizing the widget to always fit the whole table, because we're not talking about too many rows for COM/TCP ports. But it's a weak personal preference that I'd be open to changing.

Also, I didn't add a test because I didn't immediately see a way to get access to a COM port, if someone knows how let me know!